### PR TITLE
ENH - upload using the new API

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import net.wigle.wigleandroid.background.ApiListener;
 import net.wigle.wigleandroid.background.ObservationImporter;
+import net.wigle.wigleandroid.background.ObservationUploader;
 import net.wigle.wigleandroid.background.TransferListener;
 import net.wigle.wigleandroid.background.FileUploaderTask;
 import net.wigle.wigleandroid.background.KmlWriter;
@@ -292,17 +293,15 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
         switch (dialogId) {
             case CSV_RUN_DIALOG: {
                 // actually need this Activity context, for dialogs
-                FileUploaderTask fileUploaderTask = new FileUploaderTask( getActivity(),
-                        ListFragment.lameStatic.dbHelper, DataFragment.this, true );
-                fileUploaderTask.setWriteRunOnly();
-                fileUploaderTask.start();
+                ObservationUploader observationUploader = new ObservationUploader(getActivity(),
+                        ListFragment.lameStatic.dbHelper, DataFragment.this, true, false, true);
+                observationUploader.start();
                 break;
             }
             case CSV_DB_DIALOG: {
-                FileUploaderTask fileUploaderTask = new FileUploaderTask( getActivity(),
-                        ListFragment.lameStatic.dbHelper, DataFragment.this, true );
-                fileUploaderTask.setWriteWholeDb();
-                fileUploaderTask.start();
+                ObservationUploader observationUploader = new ObservationUploader(getActivity(),
+                        ListFragment.lameStatic.dbHelper, DataFragment.this, true, true, false);
+                observationUploader.start();
                 break;
             }
             case KML_RUN_DIALOG: {
@@ -340,7 +339,7 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
                 try {
                     task.startDownload(this);
                 } catch (WiGLEAuthException waex) {
-                    //moot due to budle handling
+                    //moot due to bundle handling
                 }
                 break;
             }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -65,6 +65,7 @@ import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GooglePlayServicesUtil;
 
 import net.wigle.wigleandroid.background.FileUploaderTask;
+import net.wigle.wigleandroid.background.ObservationUploader;
 import net.wigle.wigleandroid.listener.BatteryLevelReceiver;
 import net.wigle.wigleandroid.listener.GPSListener;
 import net.wigle.wigleandroid.listener.PhoneState;
@@ -110,7 +111,7 @@ public final class MainActivity extends AppCompatActivity {
         TTS tts;
         boolean inEmulator;
         PhoneState phoneState;
-        FileUploaderTask fileUploaderTask;
+        ObservationUploader observationUploader;
         NetworkListAdapter listAdapter;
         String previousStatus;
         int currentTab;
@@ -124,7 +125,6 @@ public final class MainActivity extends AppCompatActivity {
 
     static final Locale ORIG_LOCALE = Locale.getDefault();
     // form auth
-    public static final String FILE_POST_URL = "https://wigle.net/gps/gps/main/confirmfile/";
     public static final String TOKEN_URL = "https://api.wigle.net/api/v2/activate";
     // no auth
     public static final String SITE_STATS_URL = "https://api.wigle.net/api/v2/stats/site";
@@ -134,6 +134,7 @@ public final class MainActivity extends AppCompatActivity {
     public static final String UPLOADS_STATS_URL = "https://api.wigle.net/api/v2/file/transactions";
     public static final String USER_STATS_URL = "https://api.wigle.net/api/v2/stats/user";
     public static final String OBSERVED_URL = "https://api.wigle.net/api/v2/network/mine";
+    public static final String FILE_POST_URL = "https://api.wigle.net/api/v2/file/upload";
 
     private static final String LOG_TAG = "wigle";
     public static final String ENCODING = "ISO-8859-1";
@@ -216,8 +217,8 @@ public final class MainActivity extends AppCompatActivity {
             // tell those that need it that we have a new context
             state.gpsListener.setMainActivity(this);
             state.wifiReceiver.setMainActivity(this);
-            if (state.fileUploaderTask != null) {
-                state.fileUploaderTask.setContext(this);
+            if (state.observationUploader != null) {
+                state.observationUploader.setContext(this);
             }
         } else {
             info("MAIN: creating new state");
@@ -1683,7 +1684,7 @@ public final class MainActivity extends AppCompatActivity {
         MainActivity.info("transfer complete");
         // start a scan to get the ball rolling again if this is non-stop mode
         scheduleScan();
-        state.fileUploaderTask = null;
+        state.observationUploader = null;
     }
 
     public void setLocationUI() {
@@ -1738,9 +1739,9 @@ public final class MainActivity extends AppCompatActivity {
         }
 
         // interrupt this just in case
-        final FileUploaderTask fileUploaderTask = state.fileUploaderTask;
-        if (fileUploaderTask != null) {
-            fileUploaderTask.setInterrupted();
+        final ObservationUploader observationUploader = state.observationUploader;
+        if (observationUploader != null) {
+            observationUploader.setInterrupted();
         }
 
         if (state.gpsListener != null) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
@@ -166,7 +166,6 @@ public final class SettingsFragment extends Fragment implements DialogListener {
                 "</a> " + atString + " <a href='https://wigle.net/register'>WiGLE.net</a>";
         try {
             if (Build.VERSION.SDK_INT >= 24) {
-                //Html.fromHtml(String, int) // for 24 api and more
                 register.setText(Html.fromHtml(registerBlurb,
                         Html.FROM_HTML_MODE_LEGACY));
             } else {
@@ -364,7 +363,12 @@ public final class SettingsFragment extends Fragment implements DialogListener {
         if (currentValue.equals(newValue.trim())) {
             return;
         }
-        editor.putString( key, newValue.trim() );
+        if (newValue.trim().isEmpty()) {
+            //ALIBI: empty values should unset
+            editor.remove(key);
+        } else {
+            editor.putString(key, newValue.trim());
+        }
         // ALIBI: if the u|p changes, force refetch token
         editor.remove(ListFragment.PREF_AUTHNAME);
         editor.remove(ListFragment.PREF_TOKEN);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractApiRequest.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractApiRequest.java
@@ -10,6 +10,7 @@ import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.WiGLEAuthException;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.BufferedReader;
@@ -219,5 +220,44 @@ public abstract class AbstractApiRequest extends AbstractBackgroundTask {
         }
     }
 
-    abstract void downloadTokenAndStart(final Fragment fragment);
+    /**
+     * need to DRY this up vs. the bundle-notification in ObservationImporter
+     */
+    protected void downloadTokenAndStart(final Fragment fragment) {
+        final ApiDownloader task = new ApiDownloader(fragment.getActivity(), ListFragment.lameStatic.dbHelper,
+                null, MainActivity.TOKEN_URL, true, false, true, AbstractApiRequest.REQUEST_POST,
+                new ApiListener() {
+                    @Override
+                    public void requestComplete(final JSONObject json, final boolean isCache)
+                            throws WiGLEAuthException {
+                        try {
+                            // {"success": true, "authname": "AID...", "token": "..."}
+                            if (json.getBoolean("success")) {
+                                final String authname = json.getString("authname");
+                                final String token = json.getString("token");
+                                final SharedPreferences prefs = fragment.getContext()
+                                        .getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+                                final SharedPreferences.Editor edit = prefs.edit();
+                                edit.putString(ListFragment.PREF_AUTHNAME, authname);
+                                edit.putString(ListFragment.PREF_TOKEN, token);
+                                edit.apply();
+                                // execute ourselves, the pending task
+                                start();
+                            } else if (json.has("credential_0")) {
+                                String message = "login failed for " +
+                                        json.getString("credential_0");
+                                MainActivity.warn(message);
+                                throw new WiGLEAuthException(message);
+                            } else {
+                                throw new WiGLEAuthException("Unable to log in.");
+                            }
+                        }
+                        catch (final JSONException ex) {
+                            MainActivity.warn("json exception: " + ex + " json: " + json, ex);
+                            throw new WiGLEAuthException("Unable to log in.");
+                        }
+                    }
+                });
+        task.start();
+    }
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ApiDownloader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ApiDownloader.java
@@ -1,15 +1,11 @@
 package net.wigle.wigleandroid.background;
 
-import android.content.SharedPreferences;
-import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 
 import net.wigle.wigleandroid.DatabaseHelper;
-import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.WiGLEAuthException;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.IOException;
@@ -46,47 +42,4 @@ public class ApiDownloader extends AbstractApiRequest {
             MainActivity.error("ex: " + ex + " result: " + result, ex);
         }
     }
-
-    @Override
-    /**
-     * need to DRY this up vs. the bundle-notification in ObservationImporter
-     */
-    protected void downloadTokenAndStart(final Fragment fragment) {
-        final ApiDownloader task = new ApiDownloader(fragment.getActivity(), ListFragment.lameStatic.dbHelper,
-                null, MainActivity.TOKEN_URL, true, false, true, AbstractApiRequest.REQUEST_POST,
-                new ApiListener() {
-                    @Override
-                    public void requestComplete(final JSONObject json, final boolean isCache)
-                            throws WiGLEAuthException {
-                        try {
-                            // {"success": true, "authname": "AID...", "token": "..."}
-                            if (json.getBoolean("success")) {
-                                final String authname = json.getString("authname");
-                                final String token = json.getString("token");
-                                final SharedPreferences prefs = fragment.getContext()
-                                        .getSharedPreferences(ListFragment.SHARED_PREFS, 0);
-                                final SharedPreferences.Editor edit = prefs.edit();
-                                edit.putString(ListFragment.PREF_AUTHNAME, authname);
-                                edit.putString(ListFragment.PREF_TOKEN, token);
-                                edit.apply();
-                                // execute ourselves, the pending task
-                                start();
-                            } else if (json.has("credential_0")) {
-                                String message = "login failed for " +
-                                        json.getString("credential_0");
-                                MainActivity.warn(message);
-                                throw new WiGLEAuthException(message);
-                            } else {
-                                throw new WiGLEAuthException("Unable to log in.");
-                            }
-                        }
-                        catch (final JSONException ex) {
-                            MainActivity.warn("json exception: " + ex + " json: " + json, ex);
-                            throw new WiGLEAuthException("Unable to log in.");
-                        }
-                    }
-                });
-        task.start();
-    }
-
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/HttpFileUploader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/HttpFileUploader.java
@@ -135,6 +135,7 @@ final class HttpFileUploader {
      */
     public static String upload( final String urlString, final String filename, final String fileParamName,
                                  final FileInputStream fileInputStream, final Map<String,String> params,
+                                 final PreConnectConfigurator preConnectConfigurator,
                                  final Handler handler, final long filesize)
                                 throws IOException {
 
@@ -143,7 +144,8 @@ final class HttpFileUploader {
 
         try {
             final boolean setBoundary = true;
-            conn = connect(urlString, setBoundary, ApiDownloader.REQUEST_POST);
+            conn = connect(urlString, setBoundary, preConnectConfigurator,
+                    ApiDownloader.REQUEST_POST);
             if (conn == null) {
                 throw new IOException("No connection for: " + urlString);
             }
@@ -204,7 +206,7 @@ final class HttpFileUploader {
             while ( byteswritten < filesize ) {
                 final long bytes = fc.transferTo( byteswritten, chunk, wbc );
                 if ( bytes <= 0 ) {
-                    MainActivity.info( "giving up transfering file. bytes: " + bytes );
+                    MainActivity.info( "giving up transferring file. bytes: " + bytes );
                     break;
                 }
                 byteswritten += bytes;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationImporter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationImporter.java
@@ -145,5 +145,4 @@ public class ObservationImporter extends AbstractApiRequest {
                 });
         task.start();
     }
-
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
@@ -1,5 +1,29 @@
 package net.wigle.wigleandroid.background;
 
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.database.Cursor;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.os.Bundle;
+import android.os.Environment;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.util.Base64;
+
+import net.wigle.wigleandroid.DBException;
+import net.wigle.wigleandroid.DatabaseHelper;
+import net.wigle.wigleandroid.ListFragment;
+import net.wigle.wigleandroid.MainActivity;
+import net.wigle.wigleandroid.R;
+import net.wigle.wigleandroid.WiGLEAuthException;
+import net.wigle.wigleandroid.model.Network;
+
+import org.json.JSONObject;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -7,6 +31,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.ConnectException;
+import java.net.HttpURLConnection;
 import java.net.UnknownHostException;
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
@@ -25,135 +50,111 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
-import net.wigle.wigleandroid.DBException;
-import net.wigle.wigleandroid.DatabaseHelper;
-import net.wigle.wigleandroid.ListFragment;
-import net.wigle.wigleandroid.MainActivity;
-import net.wigle.wigleandroid.model.Network;
-import net.wigle.wigleandroid.R;
+/**
+ * replacement file upload task
+ * Created by arkasha on 2/6/17.
+ */
 
-import android.annotation.SuppressLint;
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.content.SharedPreferences.Editor;
-import android.content.pm.PackageInfo;
-import android.content.pm.PackageManager;
-import android.content.pm.PackageManager.NameNotFoundException;
-import android.database.Cursor;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
-import android.os.Bundle;
-import android.os.Environment;
-import android.support.v4.app.FragmentActivity;
-
-public final class FileUploaderTask extends AbstractBackgroundTask {
-    private final TransferListener listener;
-    private final boolean justWriteFile;
-    private boolean writeWholeDb;
-    private boolean writeRunOnly;
+public class ObservationUploader extends AbstractApiRequest {
 
     private static final String COMMA = ",";
     private static final String NEWLINE = "\n";
+
+    private final boolean justWriteFile;
+    private final boolean writeEntireDb;
+    private final boolean writeRun;
 
     private static class CountStats {
         int byteCount;
         int lineCount;
     }
 
-    public FileUploaderTask( final FragmentActivity context, final DatabaseHelper dbHelper, final TransferListener listener,
-                             final boolean justWriteFile ) {
-
-        super( context, dbHelper, "HttpUL", true );
-        if ( listener == null ) {
-            throw new IllegalArgumentException( "listener is null" );
-        }
-
-        this.listener = listener;
+    public ObservationUploader(final FragmentActivity context,
+                               final DatabaseHelper dbHelper, final ApiListener listener,
+                               boolean justWriteFile, boolean writeEntireDb, boolean writeRun) {
+        super(context, dbHelper, "ApiUL", null, MainActivity.FILE_POST_URL, false,
+                true, false, false,
+                AbstractApiRequest.REQUEST_POST, listener, true);
         this.justWriteFile = justWriteFile;
+
+        if (writeRun && writeEntireDb) {
+            throw new IllegalArgumentException("Cannot specify both individual run and entire db");
+        } else if (!writeRun && !writeEntireDb) {
+            throw new IllegalArgumentException("Must specify either individual run and entire db");
+        }
+        this.writeEntireDb = writeEntireDb;
+        this.writeRun = writeRun;
     }
 
-    public void setWriteWholeDb() {
-        this.writeWholeDb = true;
-    }
-
-    public void setWriteRunOnly() {
-        this.writeRunOnly = true;
-    }
 
     @Override
-    public void subRun() {
+    protected void subRun() throws IOException, InterruptedException, WiGLEAuthException {
         try {
             if ( justWriteFile ) {
                 justWriteFile();
-            }
-            else {
+            } else {
                 doRun();
             }
-        }
-        catch ( final InterruptedException ex ) {
+        } catch ( final InterruptedException ex ) {
             MainActivity.info( "file upload interrupted" );
-        }
-        catch ( final Throwable throwable ) {
+        } catch (final WiGLEAuthException waex) {
+            // ALIBI: allow auth exception through
+            throw waex;
+        } catch ( final Throwable throwable ) {
             MainActivity.writeError( Thread.currentThread(), throwable, context );
-            throw new RuntimeException( "FileUploaderTask throwable: " + throwable, throwable );
+            throw new RuntimeException( "ObservationUploader throwable: " + throwable, throwable );
         }
         finally {
             // tell the listener
-            listener.transferComplete();
+            listener.requestComplete(null, false);
         }
+
     }
 
-    private void doRun() throws InterruptedException {
+    private void doRun() throws InterruptedException, WiGLEAuthException {
         final String username = getUsername();
         final String password = getPassword();
         Status status = validateUserPass(username, password);
         final Bundle bundle = new Bundle();
         if ( status == null ) {
-            status = doUpload( username, password, bundle );
+            status = doUpload(bundle);
         }
-
         // tell the gui thread
         sendBundledMessage( status.ordinal(), bundle );
     }
 
-    @SuppressLint("SimpleDateFormat")
-    public static OutputStream getOutputStream(final Context context, final Bundle bundle, final Object[] fileFilename)
-            throws IOException {
-        final SimpleDateFormat fileDateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
-        final String filename = "WigleWifi_" + fileDateFormat.format(new Date()) + ".csv.gz";
-
-
-        final boolean hasSD = MainActivity.hasSD();
-        File file = null;
-        bundle.putString( BackgroundGuiHandler.FILENAME, filename );
-        if ( hasSD ) {
-            final String filepath = MainActivity.safeFilePath( Environment.getExternalStorageDirectory() ) + "/wiglewifi/";
-            final File path = new File( filepath );
-            //noinspection ResultOfMethodCallIgnored
-            path.mkdirs();
-            String openString = filepath + filename;
-            MainActivity.info("Opening file: " + openString);
-            file = new File( openString );
-            if ( ! file.exists() ) {
-                if (!file.createNewFile()) {
-                    throw new IOException("Could not create file: " + openString);
-                }
-            }
-            bundle.putString( BackgroundGuiHandler.FILEPATH, filepath );
-            bundle.putString( BackgroundGuiHandler.FILENAME, filename );
+    /**
+     * override base startDownload
+     * TODO: a misnomer, really
+     * @param fragment
+     * @throws WiGLEAuthException
+     */
+    @Override
+    public void startDownload(final Fragment fragment) throws WiGLEAuthException {
+        // download token if needed
+        final SharedPreferences prefs = fragment.getActivity().getSharedPreferences(
+                ListFragment.SHARED_PREFS, 0);
+        final boolean beAnonymous = prefs.getBoolean(ListFragment.PREF_BE_ANONYMOUS, false);
+        final String authname = prefs.getString(ListFragment.PREF_AUTHNAME, null);
+        final String userName = prefs.getString(ListFragment.PREF_USERNAME, null);
+        final String userPass = prefs.getString(ListFragment.PREF_PASSWORD, null);
+        MainActivity.info("authname: " + authname);
+        Status valid = validateUserPass(userName, userPass);
+        if ((authname == null) && (null != valid) && valid.equals(Status.SUCCESS)) {
+            MainActivity.info("No authname, going to request token");
+            downloadTokenAndStart(fragment);
+        } else {
+            start();
         }
-
-        @SuppressWarnings({ "deprecation", "resource" })
-        final FileOutputStream rawFos = hasSD ? new FileOutputStream( file )
-                : context.openFileOutput( filename, Context.MODE_WORLD_READABLE );
-
-        final GZIPOutputStream fos = new GZIPOutputStream( rawFos );
-        fileFilename[0] = file;
-        fileFilename[1] = filename;
-        return fos;
     }
 
-    private Status doUpload( final String username, final String password, final Bundle bundle )
+    /**
+     * upload guts. lifted from FileUploaderTask
+     * @param bundle
+     * @return
+     * @throws InterruptedException
+     */
+    private Status doUpload( final Bundle bundle )
             throws InterruptedException {
 
         Status status;
@@ -165,13 +166,31 @@ public final class FileUploaderTask extends AbstractBackgroundTask {
             final String filename = (String) fileFilename[1];
 
             // write file
-            CountStats countStats = new CountStats();
+            ObservationUploader.CountStats countStats = new ObservationUploader.CountStats();
             long maxId = writeFile( fos, bundle, countStats );
 
+            final Map<String,String> params = new HashMap<>();
+
+            final SharedPreferences prefs = context.getSharedPreferences( ListFragment.SHARED_PREFS, 0);
+            if ( prefs.getBoolean(ListFragment.PREF_DONATE, false) ) {
+                params.put("donate","on");
+            }
+            final boolean beAnonymous = prefs.getBoolean(ListFragment.PREF_BE_ANONYMOUS, false);
+            final String authname = prefs.getString(ListFragment.PREF_AUTHNAME, null);
+            if (!beAnonymous && null == authname) {
+                return Status.BAD_LOGIN;
+            }
+            final String userName = prefs.getString(ListFragment.PREF_USERNAME, null);
+            final String token = prefs.getString(ListFragment.PREF_TOKEN, null);
+            final String encoded = (null != token && null != authname) ?
+                    Base64.encodeToString((authname + ":" + token).getBytes("UTF-8"),
+                        Base64.NO_WRAP) : null;
+
             // don't upload empty files
-            if ( countStats.lineCount == 0 && ! "bobzilla".equals(username) ) {
+            if ( countStats.lineCount == 0 && ! "bobzilla".equals(userName) ) {
                 return Status.EMPTY_FILE;
             }
+            MainActivity.info("preparing upload...");
 
             // show on the UI
             sendBundledMessage( Status.UPLOADING.ordinal(), bundle );
@@ -182,7 +201,7 @@ public final class FileUploaderTask extends AbstractBackgroundTask {
                 final FileInputStream fin = context.openFileInput(filename);
                 filesize = fin.available();
                 fin.close();
-                // MainActivity.info("filesize: " + filesize);
+                MainActivity.info("filesize: " + filesize);
             }
             if ( filesize <= 0 ) {
                 filesize = countStats.byteCount; // as an upper bound
@@ -193,92 +212,93 @@ public final class FileUploaderTask extends AbstractBackgroundTask {
             @SuppressWarnings("ConstantConditions")
             final FileInputStream fis = hasSD ? new FileInputStream( file )
                     : context.openFileInput( filename );
-            final Map<String,String> params = new HashMap<>();
+            MainActivity.info("authname: " + authname);
 
-            params.put("observer", username);
-            params.put("password", password);
-            final SharedPreferences prefs = context.getSharedPreferences( ListFragment.SHARED_PREFS, 0);
-            if ( prefs.getBoolean(ListFragment.PREF_DONATE, false) ) {
-                params.put("donate","on");
+            if (beAnonymous) {
+                MainActivity.info("anonymous upload");
             }
+
+            // Cannot set request property after connection is made
+            PreConnectConfigurator preConnectConfigurator = new PreConnectConfigurator() {
+                @Override
+                public void configure(HttpURLConnection connection) {
+                    if (null != encoded && !encoded.isEmpty()) {
+                        connection.setRequestProperty("Authorization", "Basic " + encoded);
+                    }
+                }
+            };
+
             final String response = HttpFileUploader.upload(
-                    MainActivity.FILE_POST_URL, filename, "stumblefile", fis,
-                    params, null, getHandler(), filesize );
+                    MainActivity.FILE_POST_URL, filename, "file", fis,
+                    params, preConnectConfigurator, getHandler(), filesize );
 
             // as upload() is currently written: response can never be null. leave checks inplace anyhow. -uhtu
 
             if ( ! prefs.getBoolean(ListFragment.PREF_DONATE, false) ) {
                 if ( response != null && response.indexOf("donate=Y") > 0 ) {
-                    final Editor editor = prefs.edit();
+                    final SharedPreferences.Editor editor = prefs.edit();
                     editor.putBoolean( ListFragment.PREF_DONATE, true );
                     editor.apply();
                 }
             }
 
-            if ( response != null && response.indexOf("uploaded successfully") > 0 ) {
+            //TODO: any reason to parse this JSON object? all we care about are two strings.
+            MainActivity.info(response);
+            if ( response != null && response.indexOf("\"success\":true") > 0 ) {
                 status = Status.SUCCESS;
 
                 // save in the prefs
-                final Editor editor = prefs.edit();
+                final SharedPreferences.Editor editor = prefs.edit();
                 editor.putLong( ListFragment.PREF_DB_MARKER, maxId );
                 editor.putLong( ListFragment.PREF_MAX_DB, maxId );
                 editor.putLong( ListFragment.PREF_NETS_UPLOADED, dbHelper.getNetworkCount() );
                 editor.apply();
-            }
-            else if ( response != null && response.indexOf("does not match login") > 0 ) {
-                status = Status.BAD_LOGIN;
-            }
-            else {
+            } else if ( response != null && response.indexOf("File upload failed.") > 0 ) {
+                status = Status.FAIL;
+            } else {
                 String error;
                 if ( response != null && response.trim().equals( "" ) ) {
                     error = "no response from server";
-                }
-                else {
+                } else {
                     error = "response: " + response;
                 }
                 MainActivity.error( error );
                 bundle.putString( BackgroundGuiHandler.ERROR, error );
                 status = Status.FAIL;
             }
-        }
-        catch ( final InterruptedException ex ) {
+        } catch ( final InterruptedException ex ) {
             throw ex;
-        }
-        catch ( final FileNotFoundException ex ) {
+        } catch ( final FileNotFoundException ex ) {
             ex.printStackTrace();
             MainActivity.error( "file problem: " + ex, ex );
             MainActivity.writeError( this, ex, context, "Has data connection: " + hasDataConnection(context) );
             status = Status.EXCEPTION;
             bundle.putString( BackgroundGuiHandler.ERROR, "file problem: " + ex );
-        }
-        catch (ConnectException ex) {
+        } catch (ConnectException ex) {
             ex.printStackTrace();
-            MainActivity.error( "connect problem: " + ex, ex );
+            MainActivity.error( "connection problem: " + ex, ex );
             MainActivity.writeError( this, ex, context, "Has data connection: " + hasDataConnection(context) );
             status = Status.EXCEPTION;
             bundle.putString( BackgroundGuiHandler.ERROR, "connect problem: " + ex );
             if (! hasDataConnection(context)) {
                 bundle.putString( BackgroundGuiHandler.ERROR, context.getString(R.string.no_data_conn) + ex);
             }
-        }
-        catch (UnknownHostException ex) {
+        } catch (UnknownHostException ex) {
             ex.printStackTrace();
-            MainActivity.error( "dns problem: " + ex, ex );
+            MainActivity.error( "DNS problem: " + ex, ex );
             MainActivity.writeError( this, ex, context, "Has data connection: " + hasDataConnection(context) );
             status = Status.EXCEPTION;
             bundle.putString( BackgroundGuiHandler.ERROR, "dns problem: " + ex );
             if (! hasDataConnection(context)) {
                 bundle.putString( BackgroundGuiHandler.ERROR, context.getString(R.string.no_data_conn) + ex);
             }
-        }
-        catch ( final IOException ex ) {
+        } catch ( final IOException ex ) {
             ex.printStackTrace();
             MainActivity.error( "io problem: " + ex, ex );
             MainActivity.writeError( this, ex, context, "Has data connection: " + hasDataConnection(context) );
             status = Status.EXCEPTION;
             bundle.putString( BackgroundGuiHandler.ERROR, "io problem: " + ex );
-        }
-        catch ( final Exception ex ) {
+        } catch ( final Exception ex ) {
             ex.printStackTrace();
             MainActivity.error( "ex problem: " + ex, ex );
             MainActivity.writeError( this, ex, context, "Has data connection: " + hasDataConnection(context) );
@@ -301,9 +321,13 @@ public final class FileUploaderTask extends AbstractBackgroundTask {
         return mobile != null && mobile.isAvailable();
     }
 
+    /**
+     * (directly lifted from FileUploaderTask)
+     * @return
+     */
     public Status justWriteFile() {
         Status status = null;
-        final CountStats countStats = new CountStats();
+        final ObservationUploader.CountStats countStats = new ObservationUploader.CountStats();
         final Bundle bundle = new Bundle();
 
         try {
@@ -342,15 +366,27 @@ public final class FileUploaderTask extends AbstractBackgroundTask {
         return status;
     }
 
-    private long writeFile( final OutputStream fos, final Bundle bundle, final CountStats countStats )
-            throws IOException, NameNotFoundException, InterruptedException, DBException {
+    /**
+     * (directly lifted from FileUploadTask)
+     * @param fos
+     * @param bundle
+     * @param countStats
+     * @return
+     * @throws IOException
+     * @throws PackageManager.NameNotFoundException
+     * @throws InterruptedException
+     * @throws DBException
+     */
+    private long writeFile( final OutputStream fos, final Bundle bundle,
+                            final ObservationUploader.CountStats countStats ) throws IOException,
+            PackageManager.NameNotFoundException, InterruptedException, DBException {
 
         final SharedPreferences prefs = context.getSharedPreferences( ListFragment.SHARED_PREFS, 0);
         long maxId = prefs.getLong( ListFragment.PREF_DB_MARKER, 0L );
-        if ( writeWholeDb ) {
+        if ( writeEntireDb ) {
             maxId = 0;
         }
-        else if ( writeRunOnly ) {
+        else if ( writeRun ) {
             // max id at startup
             maxId = prefs.getLong( ListFragment.PREF_MAX_DB, 0L );
         }
@@ -367,9 +403,22 @@ public final class FileUploaderTask extends AbstractBackgroundTask {
         }
     }
 
+    /**
+     * (lifted directly from FileUploaderTask)
+     * @param fos
+     * @param bundle
+     * @param countStats
+     * @param cursor
+     * @return
+     * @throws IOException
+     * @throws PackageManager.NameNotFoundException
+     * @throws InterruptedException
+     */
     @SuppressLint("SimpleDateFormat")
-    private long writeFileWithCursor( final OutputStream fos, final Bundle bundle, final CountStats countStats,
-                                      final Cursor cursor ) throws IOException, NameNotFoundException, InterruptedException {
+    private long writeFileWithCursor( final OutputStream fos, final Bundle bundle,
+                                      final ObservationUploader.CountStats countStats,
+                                      final Cursor cursor ) throws IOException,
+            PackageManager.NameNotFoundException, InterruptedException {
 
         final SharedPreferences prefs = context.getSharedPreferences( ListFragment.SHARED_PREFS, 0);
         long maxId = prefs.getLong( ListFragment.PREF_DB_MARKER, 0L );
@@ -411,7 +460,7 @@ public final class FileUploaderTask extends AbstractBackgroundTask {
             final NumberFormat numberFormat = NumberFormat.getNumberInstance( Locale.US );
             // no commas in the comma-separated file
             numberFormat.setGroupingUsed( false );
-            if ( numberFormat instanceof DecimalFormat ) {
+            if ( numberFormat instanceof DecimalFormat) {
                 final DecimalFormat dc = (DecimalFormat) numberFormat;
                 dc.setMaximumFractionDigits( 16 );
             }
@@ -514,8 +563,10 @@ public final class FileUploaderTask extends AbstractBackgroundTask {
                 //  end = byteBuffer.limit();
                 //}
 
-                // MainActivity.info("buffer: arrayOffset: " + byteBuffer.arrayOffset() + " limit: " + byteBuffer.limit()
-                //     + " capacity: " + byteBuffer.capacity() + " pos: " + byteBuffer.position() + " end: " + end
+                // MainActivity.info("buffer: arrayOffset: " + byteBuffer.arrayOffset() + " limit: "
+                // + byteBuffer.limit()
+                //     + " capacity: " + byteBuffer.capacity() + " pos: " + byteBuffer.position() +
+                // " end: " + end
                 //     + " result: " + result );
                 final long writeStart = System.currentTimeMillis();
                 fos.write(byteBuffer.array(), offset, end+offset );
@@ -529,40 +580,115 @@ public final class FileUploaderTask extends AbstractBackgroundTask {
             }
         }
 
-        MainActivity.info("wrote file in: " + (System.currentTimeMillis() - start) + "ms. fileWriteMillis: "
-                + fileWriteMillis + " netmillis: " + netMillis );
+        MainActivity.info("wrote file in: " + (System.currentTimeMillis() - start) +
+                "ms. fileWriteMillis: " + fileWriteMillis + " netmillis: " + netMillis );
 
         return maxId;
     }
 
+    /**
+     * (lifted directly from FileUploaderTask)
+     * @param fos
+     * @param data
+     * @throws IOException
+     */
     public static void writeFos( final OutputStream fos, final String data ) throws IOException {
         if ( data != null ) {
             fos.write( data.getBytes( MainActivity.ENCODING ) );
         }
     }
 
-    private void singleCopyNumberFormat( final NumberFormat numberFormat, final StringBuffer stringBuffer,
-                                         final CharBuffer charBuffer, final FieldPosition fp, final int number ) {
+
+    /**
+     * (lifted directly from FileUploaderTask)
+     * @param numberFormat
+     * @param stringBuffer
+     * @param charBuffer
+     * @param fp
+     * @param number
+     */
+    private void singleCopyNumberFormat( final NumberFormat numberFormat,
+                                         final StringBuffer stringBuffer,
+                                         final CharBuffer charBuffer, final FieldPosition fp,
+                                         final int number ) {
         stringBuffer.setLength( 0 );
         numberFormat.format( number, stringBuffer, fp );
         stringBuffer.getChars(0, stringBuffer.length(), charBuffer.array(), charBuffer.position() );
         charBuffer.position( charBuffer.position() + stringBuffer.length() );
     }
 
-    private void singleCopyNumberFormat( final NumberFormat numberFormat, final StringBuffer stringBuffer,
-                                         final CharBuffer charBuffer, final FieldPosition fp, final double number ) {
+    /**
+     * (lifted directly from FileUploaderTask)
+     * @param numberFormat
+     * @param stringBuffer
+     * @param charBuffer
+     * @param fp
+     * @param number
+     */
+    private void singleCopyNumberFormat( final NumberFormat numberFormat,
+                                         final StringBuffer stringBuffer,
+                                         final CharBuffer charBuffer, final FieldPosition fp,
+                                         final double number ) {
         stringBuffer.setLength( 0 );
         numberFormat.format( number, stringBuffer, fp );
         stringBuffer.getChars(0, stringBuffer.length(), charBuffer.array(), charBuffer.position() );
         charBuffer.position( charBuffer.position() + stringBuffer.length() );
     }
 
-    private void singleCopyDateFormat( final DateFormat dateFormat, final StringBuffer stringBuffer,
-                                       final CharBuffer charBuffer, final FieldPosition fp, final Date date ) {
+    /**
+     * (lifted directly from FileUploaderTask)
+     * @param dateFormat
+     * @param stringBuffer
+     * @param charBuffer
+     * @param fp
+     * @param date
+     */
+    private void singleCopyDateFormat(final DateFormat dateFormat, final StringBuffer stringBuffer,
+                                      final CharBuffer charBuffer, final FieldPosition fp,
+                                      final Date date ) {
         stringBuffer.setLength( 0 );
         dateFormat.format( date, stringBuffer, fp );
         stringBuffer.getChars(0, stringBuffer.length(), charBuffer.array(), charBuffer.position() );
         charBuffer.position( charBuffer.position() + stringBuffer.length() );
+    }
+
+    @SuppressLint("SimpleDateFormat")
+    public static OutputStream getOutputStream(final Context context, final Bundle bundle,
+                                               final Object[] fileFilename)
+            throws IOException {
+        final SimpleDateFormat fileDateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+        final String filename = "WigleWifi_" + fileDateFormat.format(new Date()) + ".csv.gz";
+
+
+        final boolean hasSD = MainActivity.hasSD();
+        File file = null;
+        bundle.putString( BackgroundGuiHandler.FILENAME, filename );
+        if ( hasSD ) {
+            final String filepath = MainActivity.safeFilePath(
+                    Environment.getExternalStorageDirectory() ) + "/wiglewifi/";
+            final File path = new File( filepath );
+            //noinspection ResultOfMethodCallIgnored
+            path.mkdirs();
+            String openString = filepath + filename;
+            MainActivity.info("Opening file: " + openString);
+            file = new File( openString );
+            if ( ! file.exists() ) {
+                if (!file.createNewFile()) {
+                    throw new IOException("Could not create file: " + openString);
+                }
+            }
+            bundle.putString( BackgroundGuiHandler.FILEPATH, filepath );
+            bundle.putString( BackgroundGuiHandler.FILENAME, filename );
+        }
+
+        @SuppressWarnings({ "deprecation", "resource" })
+        final FileOutputStream rawFos = hasSD ? new FileOutputStream( file )
+                : context.openFileOutput( filename, Context.MODE_WORLD_READABLE );
+
+        final GZIPOutputStream fos = new GZIPOutputStream( rawFos );
+        fileFilename[0] = file;
+        fileFilename[1] = filename;
+        return fos;
     }
 
 }


### PR DESCRIPTION
in order to switch over to QR-based activation, we need everything to use the same API pathway. This is a "light-weight" cutover to the v2 API for uploads without undertaking a deeper rewrite to limit scope and complexity of the change. It's clear that we'll need to further refactor AbstractApiRequest children to bring the observation upload/download functionality into line with the ApiDownload functionality, and DRY everything up. This still requires further edge-case testing, and review. Steps to be taken after this change (not included in this PR):
- move static methods out of HttpFileUploader (and either into their own utility class or into AbstractApiRequest)
- Eliminate vestigial HttpFileUploader and FileUploaderTask