### PR TITLE
ENH- i18n template values and user-comprehensible strings for upload status

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UploadsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UploadsFragment.java
@@ -34,7 +34,10 @@ import org.json.JSONObject;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class UploadsFragment extends Fragment {
@@ -94,6 +97,17 @@ public class UploadsFragment extends Fragment {
     private UploadsListAdapter listAdapter;
     private RankDownloadHandler handler;
 
+    private static final Map<String, String> uploadStatusMap;
+    static {
+        Map<String, String> statusMap = new HashMap<String, String>();
+        statusMap.put("W", "upload_queued");
+        statusMap.put("I", "upload_parsing");
+        statusMap.put("T", "upload_trilaterating");
+        statusMap.put("S", "upload_stats");
+        statusMap.put("D", "upload_success");
+        statusMap.put("E", "upload_failed");
+        uploadStatusMap = Collections.unmodifiableMap(statusMap);
+    }
     /** Called when the activity is first created. */
     @Override
     public void onCreate( final Bundle savedInstanceState ) {
@@ -180,6 +194,16 @@ public class UploadsFragment extends Fragment {
 
     }
 
+    private String statusValue(String statusCode) {
+        String packageName = "net.wigle.wigleandroid";
+        int stringId =  getResources().getIdentifier("upload_unknown", "string", packageName);
+        if (uploadStatusMap.containsKey(statusCode)) {
+            stringId = getResources().getIdentifier(uploadStatusMap.get(statusCode), "string",
+                    packageName);
+        }
+        return getString(stringId);
+    }
+
     private final static class RankDownloadHandler extends DownloadHandler {
         private UploadsListAdapter uploadsListAdapter;
 
@@ -241,7 +265,7 @@ public class UploadsFragment extends Fragment {
                     rowBundle.putLong(key, row.getLong(key));
                 }
                 rowBundle.putString(KEY_TRANSID, row.getString(KEY_TRANSID));
-                rowBundle.putString(KEY_STATUS, row.getString(KEY_STATUS));
+                rowBundle.putString(KEY_STATUS, this.statusValue(row.getString(KEY_STATUS)));
                 resultList.add(rowBundle);
             }
             bundle.putParcelableArrayList(RESULT_LIST_KEY, resultList);

--- a/wiglewifiwardriving/src/main/res/values-ar/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ar/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">نشط الآن</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-ar/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ar/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Disable toast pop-ups</string>
     <string name="activate">نشط الآن</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-cs/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-cs/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">aktivujte nyní</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-cs/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-cs/strings.xml
@@ -256,5 +256,11 @@
     <string name="disable_toast">Disable toast pop-ups</string>
     <string name="activate">aktivujte nyní</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
-
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-da/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-da/strings.xml
@@ -256,5 +256,11 @@
     <string name="disable_toast">Disable toast pop-ups</string>
     <string name="activate">aktiver nu</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
-
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-da/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-da/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">aktiver nu</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-de/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-de/strings.xml
@@ -319,9 +319,9 @@
     <string name="activate">jetzt aktivieren</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-de/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-de/strings.xml
@@ -318,4 +318,11 @@
     <string name="prevmonthrank_title">Monatsrang letzter Monat</string>
     <string name="activate">jetzt aktivieren</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-es/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-es/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Desactiva toast pop-ups</string>
     <string name="activate">activa ahora</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-es/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-es/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">activa ahora</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-fi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fi/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Disable toast pop-ups</string>
     <string name="activate">Aktivoi nyt</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fi/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">Aktivoi nyt</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-fr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fr/strings.xml
@@ -313,4 +313,11 @@
     <string name="all_time_title">WiFi découverts depuis tous les temps</string>
     <string name="activate">Activer maintenant</string>
     <string name="setting_activate_prompt">visiter https://wigle.net/activate pour votre code utilisateur</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fy/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fy/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Toast pop-ups uitschakelen</string>
     <string name="activate">no aktivearje</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fy/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fy/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">no aktivearje</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-he/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-he/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">הפעל עכשיו</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-he/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-he/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Disable toast pop-ups</string>
     <string name="activate">הפעל עכשיו</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hi/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Disable toast pop-ups</string>
     <string name="activate">अब सक्रिय करें</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hi/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">अब सक्रिय करें</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-hu/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hu/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">aktiváld most</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-hu/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hu/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Felugró értesítések tiltása</string>
     <string name="activate">aktiváld most</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-it/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-it/strings.xml
@@ -298,9 +298,9 @@
     <string name="activate">attivate ora</string>
     <string name="setting_activate_prompt">vai a https://wigle.net/activate per il tuo codice</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-it/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-it/strings.xml
@@ -297,4 +297,11 @@
     <string name="allow_storage">Per impostazione predefinita, il database à posizionato sull\'unità esterna, si prega di consentire la scrittura sui supporti/file</string>
     <string name="activate">attivate ora</string>
     <string name="setting_activate_prompt">vai a https://wigle.net/activate per il tuo codice</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ja/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ja/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Disable toast pop-ups</string>
     <string name="activate">今すぐアクティブにする</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ja/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ja/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">今すぐアクティブにする</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-ko/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ko/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Disable toast pop-ups</string>
     <string name="activate">지금 실행 시켜라</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ko/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ko/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">지금 실행 시켜라</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-nl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nl/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Toast pop-ups uitschakelen</string>
     <string name="activate">activeer nu</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-nl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nl/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">activeer nu</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-nn/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nn/strings.xml
@@ -298,9 +298,9 @@
     <string name="activate">activate now</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-nn/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nn/strings.xml
@@ -297,4 +297,11 @@
     <string name="allow_storage">Database is put on external storage by default, please allow media/file storage</string>
     <string name="activate">activate now</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-no/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-no/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Disable toast pop-ups</string>
     <string name="activate">activate now</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-no/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-no/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">activate now</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-pl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pl/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Wtłącz dymki toast</string>
     <string name="activate">Zainstaluj teraz</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pl/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">Zainstaluj teraz</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
@@ -269,9 +269,9 @@
     <string name="activate">ative agora</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
@@ -268,4 +268,11 @@
     <string name="at">em</string>
     <string name="activate">ative agora</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Disable toast pop-ups</string>
     <string name="activate">ative agora</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">ative agora</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-ru/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ru/strings.xml
@@ -269,9 +269,9 @@
     <string name="activate">Активировать сейчас</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-ru/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ru/strings.xml
@@ -268,4 +268,11 @@
     <string name="at">на</string>
     <string name="activate">Активировать сейчас</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-sv/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-sv/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Disable toast pop-ups</string>
     <string name="activate">activate now</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-sv/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-sv/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">activate now</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-tr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-tr/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Disable toast pop-ups</string>
     <string name="activate">activate now</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-tr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-tr/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">activate now</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values-zh/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh/strings.xml
@@ -256,4 +256,11 @@
     <string name="disable_toast">Disable toast pop-ups</string>
     <string name="activate">激活</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh/strings.xml
@@ -257,9 +257,9 @@
     <string name="activate">激活</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>

--- a/wiglewifiwardriving/src/main/res/values/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values/strings.xml
@@ -319,5 +319,12 @@
     <string name="list_scanning_on">(Scanning turned on)</string>
     <string name="activate">activate now</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
+    <string name="upload_queued">Queued</string>
+    <string name="upload_parsing">Parsing...</string>
+    <string name="upload_trilaterating">Trilaterating...</string>
+    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_success">Completed</string>
+    <string name="upload_failed">Failed</string>
+    <string name="upload_unknown">Unknown</string>
     <string name="title_activity_activate">Scan to activate</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values/strings.xml
@@ -320,9 +320,9 @@
     <string name="activate">activate now</string>
     <string name="setting_activate_prompt">visit https://wigle.net/activate for your user code</string>
     <string name="upload_queued">Queued</string>
-    <string name="upload_parsing">Parsing...</string>
-    <string name="upload_trilaterating">Trilaterating...</string>
-    <string name="upload_stats">Final Stats...</string>
+    <string name="upload_parsing">Parsing…</string>
+    <string name="upload_trilaterating">Trilaterating…</string>
+    <string name="upload_stats">Final Stats…</string>
     <string name="upload_success">Completed</string>
     <string name="upload_failed">Failed</string>
     <string name="upload_unknown">Unknown</string>


### PR DESCRIPTION
Making the uploads screen display something people can read for status instead of single-letter codes.