### PR TITLE
ENH - Adds Option to Require GPS Accuracy to Record Data

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
@@ -82,6 +82,7 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
     public static final String PREF_LANGUAGE = "speechLanguage";
     public static final String PREF_RESET_WIFI_PERIOD = "resetWifiPeriod";
     public static final String PREF_BATTERY_KILL_PERCENT = "batteryKillPercent";
+    public static final String PREF_GPS_ACCURACY = "gpsAccuracyThreshold";
     public static final String PREF_MUTED = "muted";
     public static final String PREF_WIFI_WAS_OFF = "wifiWasOff";
     public static final String PREF_DISTANCE_RUN = "distRun";

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -151,6 +151,7 @@ public final class MainActivity extends AppCompatActivity {
     public static final long SCAN_DEFAULT = 2000L;
     public static final long SCAN_FAST_DEFAULT = 1000L;
     public static final long DEFAULT_BATTERY_KILL_PERCENT = 2L;
+    public static final long DEFAULT_GPS_ACCURACY_THRESHOLD = 0L;
 
     private static MainActivity mainActivity;
     private static ListFragment listActivity;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
@@ -353,6 +353,12 @@ public final class SettingsFragment extends Fragment implements DialogListener {
         doSpinner( R.id.battery_kill_spinner, view, ListFragment.PREF_BATTERY_KILL_PERCENT,
                 MainActivity.DEFAULT_BATTERY_KILL_PERCENT, batteryPeriods, batteryName );
 
+        // GPS ACCURACY THRESHOLD spinner
+        final Long[] accuracyThreshold = new Long[]{ 4L,10L,20L,0L };
+        final String[] accuracyName = new String[]{ "High","Medium","Low",off };
+        doSpinner( R.id.gps_accuracy_spinner, view, ListFragment.PREF_GPS_ACCURACY,
+                MainActivity.DEFAULT_GPS_ACCURACY_THRESHOLD, accuracyThreshold, accuracyName );
+
         // reset wifi spinner
         final Long[] resetPeriods = new Long[]{ 15000L,30000L,60000L,90000L,120000L,300000L,600000L,0L };
         final String[] resetName = new String[]{ "15" + sec, "30" + sec,"1" + min,"1.5" + min,

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
@@ -284,7 +284,13 @@ public class WifiReceiver extends BroadcastReceiver {
                     else {
                         // loop for stress-testing
                         // for ( int i = 0; i < 10; i++ ) {
-                        dbHelper.addObservation( network, location, added );
+                        long gpsAccuracyThreshold = prefs.getLong(
+                                ListFragment.PREF_GPS_ACCURACY, MainActivity.DEFAULT_GPS_ACCURACY_THRESHOLD);
+                        final boolean gpsAccurate = (gpsAccuracyThreshold == 0L) || gpsAccuracyThreshold >= location.getAccuracy();
+
+                        if ( gpsAccurate ) {
+                            dbHelper.addObservation(network, location, added);
+                        }
                         // }
                     }
                 } else {
@@ -491,6 +497,7 @@ public class WifiReceiver extends BroadcastReceiver {
 
     private Network recordCellInfo(final Location location) {
         TelephonyManager tele = (TelephonyManager) mainActivity.getSystemService( Context.TELEPHONY_SERVICE );
+        final SharedPreferences prefs = mainActivity.getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
         Network network = null;
         if ( tele != null ) {
       /*
@@ -588,7 +595,13 @@ public class WifiReceiver extends BroadcastReceiver {
                 }
 
                 if ( location != null ) {
-                    dbHelper.addObservation(network, location, newForRun);
+                    long gpsAccuracyThreshold = prefs.getLong(
+                            ListFragment.PREF_GPS_ACCURACY, MainActivity.DEFAULT_GPS_ACCURACY_THRESHOLD);
+                    final boolean gpsAccurate = (gpsAccuracyThreshold == 0L) || gpsAccuracyThreshold >= location.getAccuracy();
+
+                    if ( gpsAccurate ) {
+                        dbHelper.addObservation(network, location, newForRun);
+                    }
                 }
             }
         }

--- a/wiglewifiwardriving/src/main/res/layout/settings.xml
+++ b/wiglewifiwardriving/src/main/res/layout/settings.xml
@@ -198,6 +198,33 @@
         />
 </LinearLayout>
 
+
+
+    <LinearLayout
+		android:orientation="horizontal"
+		android:layout_width="fill_parent"
+		android:layout_height="wrap_content"
+		android:layout_marginTop="2dip"
+		android:layout_marginBottom="2dip"
+		>
+		<Spinner android:id="@+id/gps_accuracy_spinner"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:drawSelectorOnTop="true"
+			android:layout_weight="0"
+			android:prompt="@string/gps_accuracy_text"
+			/>
+		<TextView
+			android:id="@+id/gps_accuracy_text"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:text="@string/gps_accuracy_text"
+			android:layout_weight="1"
+			android:layout_marginRight="6dip"
+			tools:ignore="RtlHardcoded"
+			/>
+	</LinearLayout>
+
 <LinearLayout
     android:orientation="horizontal"
     android:layout_width="fill_parent"

--- a/wiglewifiwardriving/src/main/res/layout/settings.xml
+++ b/wiglewifiwardriving/src/main/res/layout/settings.xml
@@ -200,30 +200,30 @@
 
 
 
-    <LinearLayout
-		android:orientation="horizontal"
-		android:layout_width="fill_parent"
+<LinearLayout
+    android:orientation="horizontal"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="2dip"
+    android:layout_marginBottom="2dip"
+    >
+	<Spinner android:id="@+id/gps_accuracy_spinner"
+		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"
-		android:layout_marginTop="2dip"
-		android:layout_marginBottom="2dip"
-		>
-		<Spinner android:id="@+id/gps_accuracy_spinner"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:drawSelectorOnTop="true"
-			android:layout_weight="0"
-			android:prompt="@string/gps_accuracy_text"
+		android:drawSelectorOnTop="true"
+		android:layout_weight="0"
+		android:prompt="@string/gps_accuracy_text"
+		/>
+	<TextView
+		android:id="@+id/gps_accuracy_text"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:text="@string/gps_accuracy_text"
+		android:layout_weight="1"
+		android:layout_marginRight="6dip"
+		tools:ignore="RtlHardcoded"
 			/>
-		<TextView
-			android:id="@+id/gps_accuracy_text"
-			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:text="@string/gps_accuracy_text"
-			android:layout_weight="1"
-			android:layout_marginRight="6dip"
-			tools:ignore="RtlHardcoded"
-			/>
-	</LinearLayout>
+</LinearLayout>
 
 <LinearLayout
     android:orientation="horizontal"

--- a/wiglewifiwardriving/src/main/res/values/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="period_text">Time between WiFi scans when slower than 8 km/h or 5 mph</string>
     <string name="periodfast_text">Time between WiFi scans when faster than 8 km/h or 5 mph</string>
     <string name="gps_text">Time between GPS updates</string>
+    <string name="gps_accuracy_text">GPS accuracy level required to record</string>
     <string name="speak_text">Time between audio speech</string>
     <string name="battery_kill_text">Exit at this battery level</string>
     <string name="reset_wifi_text">Decide WiFi is jammed</string>


### PR DESCRIPTION
This adds an option to the "Settings" screen to limit the collection of data points gathered with inaccurate GPS readings.

The Options
High (4m accuracy or Lower)
Medium (10m accuracy or Lower)
Low (20m accuracy or Lower)
Off (All data will be collected) - Default

This is done to both improve quality of data, and reduce export/upload filesize/bandwidth.