### PR TITLE
BUG - Fixes and cleanup

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
@@ -594,7 +594,10 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
 
     public void makeUploadDialog(final MainActivity main) {
         final SharedPreferences prefs = main.getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
-        final String username = prefs.getString( ListFragment.PREF_USERNAME, "anonymous" );
+        final boolean beAnonymous = prefs.getBoolean(ListFragment.PREF_BE_ANONYMOUS, false);
+        final String username = beAnonymous? "anonymous":
+                prefs.getString( ListFragment.PREF_USERNAME, "anonymous" );
+
         final String text = getString(R.string.list_upload) + "\n" + getString(R.string.username) + ": " + username;
         MainActivity.createConfirmation( ListFragment.this.getActivity(), text, MainActivity.LIST_TAB_POS, UPLOAD_DIALOG);
     }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -308,19 +308,16 @@ public final class MainActivity extends AppCompatActivity {
     private void checkInitKeystore() {
         final SharedPreferences prefs = getApplicationContext().
                 getSharedPreferences(ListFragment.SHARED_PREFS, 0);
-        if (!prefs.getString(ListFragment.PREF_AUTHNAME,"").isEmpty() &&
-                TokenAccess.isApiTokenSet(prefs)) {
-            if (TokenAccess.checkMigrateKeystoreVersion(prefs, this)) {
-                // successful migration should remove the password value
-                if (!prefs.getString(ListFragment.PREF_PASSWORD,
-                        "").isEmpty()) {
-                    final Editor editor = prefs.edit();
-                    editor.remove(ListFragment.PREF_PASSWORD);
-                    editor.apply();
-                }
-            } else {
-                MainActivity.info("Not able to upgrade key storage.");
+        if (TokenAccess.checkMigrateKeystoreVersion(prefs, this)) {
+            // successful migration should remove the password value
+            if (!prefs.getString(ListFragment.PREF_PASSWORD,
+                    "").isEmpty()) {
+                final Editor editor = prefs.edit();
+                editor.remove(ListFragment.PREF_PASSWORD);
+                editor.apply();
             }
+        } else {
+            MainActivity.info("Not able to upgrade key storage.");
         }
     }
 
@@ -1816,7 +1813,8 @@ public final class MainActivity extends AppCompatActivity {
             Toast.makeText(this, getString(R.string.turning_wifi_off), Toast.LENGTH_SHORT).show();
 
             // well turn it of now that we're done
-            final WifiManager wifiManager = (WifiManager) getSystemService(Context.WIFI_SERVICE);
+            final WifiManager wifiManager = (WifiManager) getApplicationContext()
+                    .getSystemService(Context.WIFI_SERVICE);
             MainActivity.info("turning back off wifi");
             try {
                 wifiManager.setWifiEnabled(false);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
@@ -119,30 +119,24 @@ public final class SettingsFragment extends Fragment implements DialogListener {
             }
             case ANONYMOUS_DIALOG: {
                 // turn anonymous
-                if (view != null) {
-                    final EditText user = (EditText) view.findViewById(R.id.edit_username);
-                    final EditText pass = (EditText) view.findViewById(R.id.edit_password);
-                    user.setEnabled(false);
-                    pass.setEnabled(false);
-                }
                 editor.putBoolean( ListFragment.PREF_BE_ANONYMOUS, true );
                 editor.apply();
 
                 if (view != null) {
+                    this.updateView(view);
+                    //TODO: will updateView handle this?
                     final CheckBox be_anonymous = (CheckBox) view.findViewById(R.id.be_anonymous);
                     be_anonymous.setChecked(true);
-
-                    // might have to remove or show register link
-                    updateRegister(view);
                 }
-
                 break;
             }
             case DEAUTHORIZE_DIALOG: {
                 editor.remove(ListFragment.PREF_AUTHNAME);
                 editor.remove(ListFragment.PREF_TOKEN);
                 editor.apply();
-                this.updateView(view);
+                if (view != null) {
+                    this.updateView(view);
+                }
                 break;
             }
             default:
@@ -284,11 +278,10 @@ public final class SettingsFragment extends Fragment implements DialogListener {
 
         // anonymous
         final CheckBox beAnonymous = (CheckBox) view.findViewById(R.id.be_anonymous);
-        final EditText pass = (EditText) view.findViewById(R.id.edit_password);
         final boolean isAnonymous = prefs.getBoolean( ListFragment.PREF_BE_ANONYMOUS, false);
         if ( isAnonymous ) {
             user.setEnabled( false );
-            pass.setEnabled( false );
+            passEdit.setEnabled( false );
         }
 
         beAnonymous.setChecked( isAnonymous );
@@ -306,12 +299,12 @@ public final class SettingsFragment extends Fragment implements DialogListener {
                     // confirm
                     MainActivity.createConfirmation( getActivity(), "Upload anonymously?",
                             MainActivity.SETTINGS_TAB_POS, ANONYMOUS_DIALOG );
-                }
-                else {
+                } else {
                     // unset anonymous
-                    user.setEnabled( true );
-                    pass.setEnabled( true );
-
+                    if (!authUser.isEmpty() && !authToken.isEmpty()) {
+                        user.setEnabled(true);
+                        passEdit.setEnabled(true);
+                    }
                     editor.putBoolean( ListFragment.PREF_BE_ANONYMOUS, false );
                     editor.apply();
 
@@ -363,16 +356,16 @@ public final class SettingsFragment extends Fragment implements DialogListener {
             @Override
             public void onCheckedChanged( final CompoundButton buttonView, final boolean isChecked ) {
                 if ( isChecked ) {
-                    pass.setTransformationMethod(SingleLineTransformationMethod.getInstance());
+                    passEdit.setTransformationMethod(SingleLineTransformationMethod.getInstance());
                 }
                 else {
-                    pass.setTransformationMethod(PasswordTransformationMethod.getInstance());
+                    passEdit.setTransformationMethod(PasswordTransformationMethod.getInstance());
                 }
             }
         });
 
-        pass.setText( prefs.getString( ListFragment.PREF_PASSWORD, "" ) );
-        pass.addTextChangedListener( new SetWatcher() {
+        passEdit.setText( prefs.getString( ListFragment.PREF_PASSWORD, "" ) );
+        passEdit.addTextChangedListener( new SetWatcher() {
             @Override
             public void onTextChanged( final String s ) {
                 credentialsUpdate(ListFragment.PREF_PASSWORD, editor, prefs, s);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractApiRequest.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractApiRequest.java
@@ -268,6 +268,7 @@ public abstract class AbstractApiRequest extends AbstractBackgroundTask {
             preConnectConfigurator = new PreConnectConfigurator() {
                 @Override
                 public void configure(HttpURLConnection connection) {
+                    //TODO: for non-upload tasks, how to handle anonymity
                     connection.setRequestProperty("Authorization", "Basic " + encoded);
                 }
             };

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/FileUploaderTask.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/FileUploaderTask.java
@@ -156,6 +156,7 @@ public final class FileUploaderTask extends AbstractBackgroundTask {
         return fos;
     }
 
+    @Deprecated
     private Status doUpload( final String username, final String password, final Bundle bundle )
             throws InterruptedException {
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
@@ -226,13 +226,15 @@ public class ObservationUploader extends AbstractProgressApiRequest {
 
             // Cannot set request property after connection is made
             PreConnectConfigurator preConnectConfigurator = new PreConnectConfigurator() {
-                @Override
-                public void configure(HttpURLConnection connection) {
-                    if (null != encoded && !encoded.isEmpty()) {
-                        connection.setRequestProperty("Authorization", "Basic " + encoded);
+                    @Override
+                    public void configure(HttpURLConnection connection) {
+                    if (!beAnonymous) {
+                        if (null != encoded && !encoded.isEmpty()) {
+                            connection.setRequestProperty("Authorization", "Basic " + encoded);
+                        }
                     }
                 }
-            };
+                          };
 
             final String response = HttpFileUploader.upload(
                     MainActivity.FILE_POST_URL, filename, "file", fis,


### PR DESCRIPTION
the combination of the last two PRs results in some odd behavior for anonymous uploads. these edits will provide beAnonymous after auth the ability to temporarily anonymize uploads without deauthorizing. This may or may not be a direction we want to go. (the alternative is to clear creds upon setting anonymous, removing all access to profile / stats data, and prevent reversion to authenticated uploads without creds-re-entry, reconfirmation)