### PR TITLE
ENH- don't let the OS optimize battery usage

### DIFF
--- a/wiglewifiwardriving/src/main/AndroidManifest.xml
+++ b/wiglewifiwardriving/src/main/AndroidManifest.xml
@@ -35,6 +35,8 @@
     <!-- confine camera activation to Marshmallow and up. -->
     <!-- NB: this functionality exists as early as JellyBean (4.2.2), but not worth the thrash -->
     <uses-permission-sdk-23 android:name="android.permission.CAMERA" />
+    <!-- scan lag due to Marshmallow-and-upBattery Optimization -->
+    <uses-permission-sdk-23 android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <permission
         android:name="net.wigle.wigleandroid.permission.MAPS_RECEIVE"

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -333,6 +333,18 @@ public final class MainActivity extends AppCompatActivity {
             }
             addPermission(permissionsList, Manifest.permission.WRITE_EXTERNAL_STORAGE);
 
+            PowerManager pm = (PowerManager) this.getSystemService(Context.POWER_SERVICE);
+            if (pm.isIgnoringBatteryOptimizations(this.getPackageName())) {
+                //intent.setAction(Settings.ACTION_IGNORE_BATTERY_OPTIMIZATION_SETTINGS);
+                MainActivity.info("ignoring battery optimization");
+            } else {
+                MainActivity.info("requesting to ignore battery optimization");
+                Intent intent = new Intent();
+                intent.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
+                intent.setData(Uri.parse("package:" + this.getPackageName()));
+                startActivity(intent);
+            }
+
             if (!permissionsList.isEmpty()) {
                 // The permission is NOT already granted.
                 // Check if the user has been asked about this permission already and denied


### PR DESCRIPTION
Believe the frequent "wifi resets" and scan lag in android Marshmallow and higher are a symptom of battery optimization - will be testing extensively before merging this fix.

There's some inconclusive documentation that suggests that requesting and using this permission can result in app suspension from the Play Store.