### PR TITLE
ENH - adding a preference to prevent continually reconfirming user

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
@@ -248,10 +248,34 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
         importObservedButton.setOnClickListener( new OnClickListener() {
             @Override
             public void onClick( final View buttonView ) {
-                MainActivity.createConfirmation( getActivity(),
-                        DataFragment.this.getString(R.string.data_import_observed), MainActivity.DATA_TAB_POS, IMPORT_DIALOG);
+            MainActivity.createConfirmation(getActivity(),
+                    DataFragment.this.getString(R.string.data_import_observed),
+                    MainActivity.DATA_TAB_POS, IMPORT_DIALOG);
             }
         });
+    }
+
+    private void createAndStartImport() {
+        final MainActivity mainActivity = MainActivity.getMainActivity(DataFragment.this);
+        if (mainActivity != null) {
+            mainActivity.setTransferring();
+        }
+        // actually need this Activity context, for dialogs
+        final ObservationImporter task = new ObservationImporter(getActivity(),
+                ListFragment.lameStatic.dbHelper,
+                new ApiListener() {
+                    @Override
+                    public void requestComplete(JSONObject object, boolean cached) {
+                        if (mainActivity != null) {
+                            mainActivity.transferComplete();
+                        }
+                    }
+                });
+        try {
+            task.startDownload(this);
+        } catch (WiGLEAuthException waex) {
+            //moot due to bundle handling
+        }
     }
 
     @SuppressLint("SetTextI18n")
@@ -324,26 +348,7 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
                 break;
             }
             case IMPORT_DIALOG: {
-                final MainActivity mainActivity = MainActivity.getMainActivity(DataFragment.this);
-                if (mainActivity != null) {
-                    mainActivity.setTransferring();
-                }
-                // actually need this Activity context, for dialogs
-                final ObservationImporter task = new ObservationImporter(getActivity(),
-                        ListFragment.lameStatic.dbHelper,
-                        new ApiListener() {
-                            @Override
-                            public void requestComplete(JSONObject object, boolean cached) {
-                                if (mainActivity != null) {
-                                    mainActivity.transferComplete();
-                                }
-                            }
-                        });
-                try {
-                    task.startDownload(this);
-                } catch (WiGLEAuthException waex) {
-                    //moot due to bundle handling
-                }
+                this.createAndStartImport();
                 break;
             }
             case ZERO_OUT_DIALOG: {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
@@ -137,6 +137,8 @@ public final class SettingsFragment extends Fragment implements DialogListener {
             case DEAUTHORIZE_DIALOG: {
                 editor.remove(ListFragment.PREF_AUTHNAME);
                 editor.remove(ListFragment.PREF_TOKEN);
+                editor.remove(ListFragment.PREF_CONFIRM_UPLOAD_USER);
+
                 String mapTileMode = prefs.getString(ListFragment.PREF_SHOW_DISCOVERED,
                         ListFragment.PREF_MAP_NO_TILE);
                 if (ListFragment.PREF_MAP_NOTMINE_TILE.equals(mapTileMode) ||
@@ -530,6 +532,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
         // ALIBI: if the u|p changes, force refetch token
         editor.remove(ListFragment.PREF_AUTHNAME);
         editor.remove(ListFragment.PREF_TOKEN);
+        editor.remove(ListFragment.PREF_CONFIRM_UPLOAD_USER);
         editor.apply();
         this.clearCachefiles();
     }


### PR DESCRIPTION
on upload, once you've agreed to use the current user (and you aren't anonymous), we stop hassling you each time. If you deauthorize or change credentials, the dialog appears once more.

next step in background uploading project.