### PR TITLE
FIX - some native implementations barf on Matcher.reset(charseq).

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/FilterMatcher.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/FilterMatcher.java
@@ -41,14 +41,23 @@ public final class FilterMatcher {
         }
 
         if ( matcher != null ) {
-            matcher.reset(network.getSsid());
-            final boolean invert = prefs.getBoolean( prefix + ListFragment.PREF_MAPF_INVERT, false );
-            final boolean matches = matcher.find();
-            if ( ! matches && ! invert) {
-                return false;
-            }
-            else if ( matches && invert ) {
-                return false;
+            try {
+                final String ssid = network.getSsid();
+                if (null == ssid) {
+
+                }
+                matcher.reset(ssid);
+                final boolean invert = prefs.getBoolean(prefix + ListFragment.PREF_MAPF_INVERT, false);
+                final boolean matches = matcher.find();
+                if (!matches && !invert) {
+                    return false;
+                } else if (matches && invert) {
+                    return false;
+                }
+            } catch (IllegalArgumentException iaex) {
+                MainActivity.warn("Matcher: IllegalArgument: " + network.getSsid() + "pattern: " + matcher.pattern());
+                final boolean invert = prefs.getBoolean(prefix + ListFragment.PREF_MAPF_INVERT, false);
+                return !invert;
             }
         }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/FilterMatcher.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/FilterMatcher.java
@@ -43,9 +43,6 @@ public final class FilterMatcher {
         if ( matcher != null ) {
             try {
                 final String ssid = network.getSsid();
-                if (null == ssid) {
-
-                }
                 matcher.reset(ssid);
                 final boolean invert = prefs.getBoolean(prefix + ListFragment.PREF_MAPF_INVERT, false);
                 final boolean matches = matcher.find();


### PR DESCRIPTION
one of our most common bugs (between map and list filter regexes) - IllegalArgumentException: utext_close failed: U_ILLEGAL_ARGUMENT_ERROR on  net.wigle.wigleandroid.FilterMatcher.isOk(FilterMatcher.java:46)

**Observed on:**
- LGE w3c (LGL34C) rel. 4.4
- Lenovo  A3300-H (LenovoA3300-H) rel 4.4.2
- Samsung j7ltespr (SM-J700P) rel 6.0.1 

not bubbling this issue to top since filtering is real-time with WiFiReceiver.onReceive (not just on new MapRender() )