### PR TITLE
FIX - just trap this error, since restoring map state isn't really that big a deal

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/NetworkActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/NetworkActivity.java
@@ -183,7 +183,12 @@ public class NetworkActivity extends ActionBarActivity implements DialogListener
         MainActivity.info("NET: onSaveInstanceState");
         super.onSaveInstanceState(outState);
         if (mapView != null) {
-            mapView.onSaveInstanceState(outState);
+            try {
+                mapView.onSaveInstanceState(outState);
+            } catch (android.os.BadParcelableException bpe) {
+                MainActivity.error("Exception saving NetworkActivity instance state: ",bpe);
+                //this is really low-severity, since we can restore all state anyway
+            }
         }
     }
 


### PR DESCRIPTION
Common bug report on android versions 4.0 -> 7.0, unable to repro in debugging.
Some notes online indicate that this happens with specific GMS versions, is not fault of use.

Since this shouldn't crash the app, we're trapping and logging, although we'll continue to look for more info