### PR TITLE
FIX - creating a gingerbread-friendly Legacy observation import.

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
@@ -3,6 +3,7 @@ package net.wigle.wigleandroid;
 import java.util.List;
 
 import net.wigle.wigleandroid.background.ApiListener;
+import net.wigle.wigleandroid.background.LegacyObservationImporter;
 import net.wigle.wigleandroid.background.ObservationImporter;
 import net.wigle.wigleandroid.background.ObservationUploader;
 import net.wigle.wigleandroid.background.TransferListener;
@@ -20,6 +21,7 @@ import android.location.Address;
 import android.location.Geocoder;
 import android.media.AudioManager;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.DialogFragment;
@@ -262,21 +264,41 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
         if (mainActivity != null) {
             mainActivity.setTransferring();
         }
+
         // actually need this Activity context, for dialogs
-        final ObservationImporter task = new ObservationImporter(getActivity(),
-                ListFragment.lameStatic.dbHelper,
-                new ApiListener() {
-                    @Override
-                    public void requestComplete(JSONObject object, boolean cached) {
-                        if (mainActivity != null) {
-                            mainActivity.transferComplete();
+        if (Build.VERSION.SDK_INT >= 11) {
+
+            final ObservationImporter task = new ObservationImporter(getActivity(),
+                    ListFragment.lameStatic.dbHelper,
+                    new ApiListener() {
+                        @Override
+                        public void requestComplete(JSONObject object, boolean cached) {
+                            if (mainActivity != null) {
+                                mainActivity.transferComplete();
+                            }
                         }
-                    }
-                });
-        try {
-            task.startDownload(this);
-        } catch (WiGLEAuthException waex) {
-            //moot due to bundle handling
+                    });
+            try {
+                task.startDownload(this);
+            } catch (WiGLEAuthException waex) {
+                //moot due to bundle handling
+            }
+        } else {
+            final LegacyObservationImporter task = new LegacyObservationImporter(getActivity(),
+                    ListFragment.lameStatic.dbHelper,
+                    new ApiListener() {
+                        @Override
+                        public void requestComplete(JSONObject object, boolean cached) {
+                            if (mainActivity != null) {
+                                mainActivity.transferComplete();
+                            }
+                        }
+                    });
+            try {
+                task.startDownload(this);
+            } catch (WiGLEAuthException waex) {
+                //moot due to bundle handling
+            }
         }
     }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/LegacyObservationImporter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/LegacyObservationImporter.java
@@ -1,0 +1,110 @@
+package net.wigle.wigleandroid.background;
+
+import android.location.Location;
+import android.os.Bundle;
+import android.support.v4.app.FragmentActivity;
+
+import net.wigle.wigleandroid.DatabaseHelper;
+import net.wigle.wigleandroid.ListFragment;
+import net.wigle.wigleandroid.MainActivity;
+import net.wigle.wigleandroid.model.Network;
+import net.wigle.wigleandroid.model.NetworkType;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+
+/**
+ * ALIBI: A blast from the past for Gingerbread compat
+ * NOTE: this is extremely inefficient compared to the streaming parser,
+ *   and cannot handle large datasets; it will OOM
+ * REMOVE THIS CLASS ONCE WE DROP SDKv9/10 support!
+ * Created by arkasha on 8/07/2017
+ */
+@Deprecated
+public class LegacyObservationImporter extends AbstractProgressApiRequest {
+
+    public LegacyObservationImporter(final FragmentActivity context,
+                               final DatabaseHelper dbHelper, final ApiListener listener) {
+        super(context, dbHelper, "HttpDL", "observed-cache.json", MainActivity.OBSERVED_URL, false,
+                true, true, false,
+                AbstractApiRequest.REQUEST_GET, listener, true);
+    }
+
+    @Override
+    protected void subRun() throws IOException, InterruptedException {
+        Status status = Status.UNKNOWN;
+        final Bundle bundle = new Bundle();
+
+        String result = null;
+        try {
+            result = doDownload(this.connectionMethod);
+            if (cacheFilename != null) {
+                cacheResult(result);
+            }
+            final JSONObject json = new JSONObject(result);
+            try {
+                if (json.getBoolean("success")) {
+                    Integer total = json.getInt("count");
+                    JSONArray results = json.getJSONArray("results");
+                    if ((null != total) && (total > 0L) && (null != results) &&
+                            (results.length() > 0)) {
+                        status = Status.WRITE_SUCCESS;
+                        for (int i = 0; i < results.length(); i++) {
+                            String netId = results.getString(i);
+                            //DEBUG: MainActivity.info(netId);
+                            final String ssid = "";
+                            final int frequency = 0;
+                            final String capabilities = "";
+                            final int level = 0;
+                            final Network network = new Network(netId, ssid, frequency,
+                                    capabilities, level, NetworkType.WIFI);
+                            final Location location = new Location("wigle");
+                            final boolean newForRun = true;
+                            ListFragment.lameStatic.dbHelper.blockingAddObservation(
+                                    network, location, newForRun);
+
+                            if ((i % 1000) == 0) {
+                                MainActivity.info("lineCount: " + i + " of " + total);
+                            }
+                            if (total == 0) {
+                                total = 1;
+                            }
+                            final int percentDone = (i * 1000) / total;
+                            sendPercentTimesTen(percentDone, bundle);
+                        }
+                    }
+                } else {
+                    MainActivity.error("MyObserved success: false");
+                }
+            } catch (JSONException jex) {
+                MainActivity.error("MyObserved json parse error:", jex);
+                status = Status.EXCEPTION;
+                bundle.putString(BackgroundGuiHandler.ERROR, "JSON problem: " + jex);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+                status = Status.EXCEPTION;
+                bundle.putString(BackgroundGuiHandler.ERROR, "Connection problem: " + e);
+            } catch (Exception e) {
+                e.printStackTrace();
+                status = Status.EXCEPTION;
+                bundle.putString(BackgroundGuiHandler.ERROR, "ERROR: " + e + " (from " +
+                        e.getCause()+")");
+            } finally {
+                listener.requestComplete(null, false);
+            }
+
+            if (status == null) {
+                status = Status.FAIL;
+            }
+        } catch (final Exception ex) {
+            MainActivity.error("ex: " + ex + " result: " + result, ex);
+            status = Status.EXCEPTION;
+            bundle.putString(BackgroundGuiHandler.ERROR, "ex problem: " + ex);
+        } finally {
+            sendBundledMessage(status.ordinal(), bundle);
+        }
+    }
+}

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationImporter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationImporter.java
@@ -16,12 +16,8 @@ import net.wigle.wigleandroid.WiGLEAuthException;
 import net.wigle.wigleandroid.model.Network;
 import net.wigle.wigleandroid.model.NetworkType;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.IOException;
 
 /**


### PR DESCRIPTION
inefficient, but will work for small sets - returns big JSON string, then parses it all in memory (like the bad old days).
This could should be removed as soon as we drop Gingerbread support.