### PR TITLE
FIX - wrapping the obvious makeText / dead context with isFinishing() tests

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -405,7 +405,9 @@ public final class MainActivity extends AppCompatActivity {
 
                 if (restart) {
                     // restart the app now that we can talk to the database
-                    Toast.makeText(mainActivity, R.string.restart, Toast.LENGTH_LONG).show();
+                    if (!isFinishing()) {
+                        Toast.makeText(mainActivity, R.string.restart, Toast.LENGTH_LONG).show();
+                    }
 
                     Intent i = getBaseContext().getPackageManager()
                             .getLaunchIntentForPackage(getBaseContext().getPackageName());
@@ -548,7 +550,9 @@ public final class MainActivity extends AppCompatActivity {
         } catch (final NullPointerException | IllegalStateException ex) {
             final String message = "exception in fragment switch: " + ex;
             error(message, ex);
-            Toast.makeText(this, message, Toast.LENGTH_LONG).show();
+            if (!isFinishing()) {
+                Toast.makeText(this, message, Toast.LENGTH_LONG).show();
+            }
         }
 
         // Highlight the selected item, update the title, and close the drawer
@@ -767,6 +771,7 @@ public final class MainActivity extends AppCompatActivity {
         } catch (final IllegalStateException ex) {
             final String errorMessage = "Exception trying to show dialog: " + ex;
             MainActivity.error(errorMessage, ex);
+            //TODO: in this static context, we can't check isFinishing
             Toast.makeText(activity, errorMessage, Toast.LENGTH_LONG).show();
         }
     }
@@ -1468,7 +1473,7 @@ public final class MainActivity extends AppCompatActivity {
         @SuppressWarnings("deprecation")
         final String notifOn = Settings.Secure.getString(getContentResolver(),
                 Settings.Secure.WIFI_NETWORKS_AVAILABLE_NOTIFICATION_ON);
-        if (notifOn != null && "1".equals(notifOn) && state.wifiReceiver == null) {
+        if (notifOn != null && "1".equals(notifOn) && state.wifiReceiver == null && !isFinishing()) {
             Toast.makeText(this, getString(R.string.best_results),
                     Toast.LENGTH_LONG).show();
         }
@@ -1482,7 +1487,9 @@ public final class MainActivity extends AppCompatActivity {
         boolean turnedWifiOn = false;
         if (!wifiManager.isWifiEnabled()) {
             // tell user, cuz this takes a little while
-            Toast.makeText(this, getString(R.string.turn_on_wifi), Toast.LENGTH_LONG).show();
+            if (!isFinishing()) {
+                Toast.makeText(this, getString(R.string.turn_on_wifi), Toast.LENGTH_LONG).show();
+            }
 
             // save so we can turn it back off when we exit
             edit.putBoolean(ListFragment.PREF_WIFI_WAS_OFF, true);
@@ -1605,9 +1612,9 @@ public final class MainActivity extends AppCompatActivity {
             // check if there is a gps
             final LocationProvider locProvider = locationManager.getProvider(GPS_PROVIDER);
 
-            if (locProvider == null) {
+            if (locProvider == null && !isFinishing()) {
                 Toast.makeText(this, getString(R.string.no_gps_device), Toast.LENGTH_LONG).show();
-            } else if (!locationManager.isProviderEnabled(GPS_PROVIDER)) {
+            } else if (!locationManager.isProviderEnabled(GPS_PROVIDER) && !isFinishing()) {
                 // gps exists, but isn't on
                 Toast.makeText(this, getString(R.string.turn_on_gps), Toast.LENGTH_LONG).show();
                 final Intent myIntent = new Intent(Settings.ACTION_LOCATION_SOURCE_SETTINGS);
@@ -1867,7 +1874,9 @@ public final class MainActivity extends AppCompatActivity {
         // don't call on emulator, it crashes it
         if (wifiWasOff && !state.inEmulator) {
             // tell user, cuz this takes a little while
-            Toast.makeText(this, getString(R.string.turning_wifi_off), Toast.LENGTH_SHORT).show();
+            if (!isFinishing()) {
+                Toast.makeText(this, getString(R.string.turning_wifi_off), Toast.LENGTH_SHORT).show();
+            }
 
             // well turn it of now that we're done
             final WifiManager wifiManager = (WifiManager) getApplicationContext()

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/GPSListener.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/GPSListener.java
@@ -229,7 +229,7 @@ public class GPSListener implements Listener, LocationListener {
 
             final SharedPreferences prefs = mainActivity.getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
             final boolean disableToast = prefs.getBoolean( ListFragment.PREF_DISABLE_TOAST, false );
-            if (!disableToast) {
+            if (!disableToast && null != mainActivity && !mainActivity.isFinishing()) {
                 final String announce = location == null ? mainActivity.getString(R.string.lost_location)
                         : mainActivity.getString(R.string.have_location) + " \"" + location.getProvider() + "\"";
                 Toast.makeText( mainActivity, announce, Toast.LENGTH_SHORT ).show();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
@@ -774,7 +774,7 @@ public class WifiReceiver extends BroadcastReceiver {
                     MainActivity.warn("Time since last scan: " + sinceLastScan + " milliseconds");
                     if ( now - lastWifiUnjamTime > resetWifiPeriod ) {
                         final boolean disableToast = prefs.getBoolean(ListFragment.PREF_DISABLE_TOAST, false);
-                        if (!disableToast) {
+                        if (!disableToast &&  null != mainActivity && !mainActivity.isFinishing()) {
                             Toast.makeText( mainActivity,
                                     mainActivity.getString(R.string.wifi_jammed), Toast.LENGTH_LONG ).show();
                         }
@@ -822,7 +822,9 @@ public class WifiReceiver extends BroadcastReceiver {
                         && (System.currentTimeMillis() - constructionTime) > 30000L) {
                     final String text = mainActivity.getString(R.string.battery_at) + " " + batteryLevel + " "
                             + mainActivity.getString(R.string.battery_postfix);
-                    Toast.makeText( mainActivity, text, Toast.LENGTH_LONG ).show();
+                    if (null != mainActivity && !mainActivity.isFinishing()) {
+                        Toast.makeText(mainActivity, text, Toast.LENGTH_LONG).show();
+                    }
                     MainActivity.warn("low battery, shutting down");
                     mainActivity.speak( text );
                     MainActivity.sleep(5000L);


### PR DESCRIPTION
Note: there are still toast pop-ups in static contexts, and in:

- BackgroundGuiHandlers
- MappingFragment
- DataFragment
- ActivateActivity

but these are unlikely to overlap on app-exit