### PR TITLE
FIX - DESTROY ALL REMAINING TOAST

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ActivateActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ActivateActivity.java
@@ -23,6 +23,8 @@ import com.google.android.gms.vision.Detector;
 import com.google.android.gms.vision.barcode.Barcode;
 import com.google.android.gms.vision.barcode.BarcodeDetector;
 
+import net.wigle.wigleandroid.util.WiGLEToast;
+
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.KeyStoreException;
@@ -86,8 +88,8 @@ public class ActivateActivity extends Activity {
                         .setBarcodeFormats(Barcode.QR_CODE)
                         .build();
         if (!barcodeDetector.isOperational()) {
-            Toast.makeText(this.getApplicationContext(),
-                    "Barcode detection not available on this device", Toast.LENGTH_LONG);
+            //ALIBI: this *should* be unreachable, but the diversity of android devices and implementation can make this happen
+            WiGLEToast.showOverActivity(this, R.string.error_general, getString(R.string.no_barcode_support_text));
             Log.e(LOG_TAG, "Barcode detection not available on this device.");
             this.finish();
         } else {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
@@ -10,6 +10,7 @@ import net.wigle.wigleandroid.background.TransferListener;
 import net.wigle.wigleandroid.background.KmlWriter;
 import net.wigle.wigleandroid.model.Pair;
 import net.wigle.wigleandroid.model.QueryArgs;
+import net.wigle.wigleandroid.util.WiGLEToast;
 
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
@@ -146,7 +147,7 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
 
                 if (fail != null) {
                     // toast!
-                    Toast.makeText(getActivity(), fail, Toast.LENGTH_SHORT).show();
+                    WiGLEToast.showOverFragment(getActivity(), R.string.error_general, fail);
                 } else {
                     ListFragment.lameStatic.queryArgs = queryArgs;
                     // start db result activity

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -364,11 +364,7 @@ public final class MainActivity extends AppCompatActivity {
 
                 if (permissionsList.contains(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
                     message = mainActivity.getString(R.string.allow_storage);
-                }
-
-                // Show our own UI to explain to the user why we need to read the contacts
-                // before actually requesting the permission and showing the default UI
-                Toast.makeText(mainActivity, message, Toast.LENGTH_LONG).show();*/
+                } */
 
                 MainActivity.info("no permission for " + permissionsNeeded);
 
@@ -563,9 +559,6 @@ public final class MainActivity extends AppCompatActivity {
         } catch (final NullPointerException | IllegalStateException ex) {
             final String message = "exception in fragment switch: " + ex;
             error(message, ex);
-            if (!isFinishing()) {
-                Toast.makeText(this, message, Toast.LENGTH_LONG).show();
-            }
         }
 
         // Highlight the selected item, update the title, and close the drawer
@@ -784,8 +777,6 @@ public final class MainActivity extends AppCompatActivity {
         } catch (final IllegalStateException ex) {
             final String errorMessage = "Exception trying to show dialog: " + ex;
             MainActivity.error(errorMessage, ex);
-            //TODO: in this static context, we can't check isFinishing
-            Toast.makeText(activity, errorMessage, Toast.LENGTH_LONG).show();
         }
     }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
@@ -67,6 +67,7 @@ import net.wigle.wigleandroid.background.AbstractApiRequest;
 import net.wigle.wigleandroid.background.QueryThread;
 import net.wigle.wigleandroid.model.ConcurrentLinkedHashMap;
 import net.wigle.wigleandroid.model.Network;
+import net.wigle.wigleandroid.util.WiGLEToast;
 
 /**
  * show a map!
@@ -144,10 +145,9 @@ public final class MappingFragment extends Fragment {
             }
             catch (final SecurityException ex) {
                 MainActivity.error("security exception oncreateview map: " + ex, ex);
-                Toast.makeText(getActivity(), getString(R.string.status_fail), Toast.LENGTH_LONG).show();
             }
         } else {
-            Toast.makeText(getActivity(), getString(R.string.map_needs_playservice), Toast.LENGTH_LONG).show();
+            WiGLEToast.showOverFragment(this.getActivity(), R.string.fatal_pre_message, getString(R.string.map_needs_playservice));
         }
         MapsInitializer.initialize(getActivity());
         final View view = inflater.inflate(R.layout.map, container, false);
@@ -719,19 +719,19 @@ public final class MappingFragment extends Fragment {
                         switch (newMapType) {
                             case GoogleMap.MAP_TYPE_NORMAL:
                                 newMapType = GoogleMap.MAP_TYPE_SATELLITE;
-                                Toast.makeText(getActivity(), getString(R.string.map_toast_satellite), Toast.LENGTH_SHORT).show();
+                                WiGLEToast.showOverActivity(getActivity(), R.string.tab_map, getString(R.string.map_toast_satellite), Toast.LENGTH_SHORT);
                                 break;
                             case GoogleMap.MAP_TYPE_SATELLITE:
                                 newMapType = GoogleMap.MAP_TYPE_HYBRID;
-                                Toast.makeText(getActivity(), getString(R.string.map_toast_hybrid), Toast.LENGTH_SHORT).show();
+                                WiGLEToast.showOverActivity(getActivity(), R.string.tab_map, getString(R.string.map_toast_hybrid), Toast.LENGTH_SHORT);
                                 break;
                             case GoogleMap.MAP_TYPE_HYBRID:
                                 newMapType = GoogleMap.MAP_TYPE_TERRAIN;
-                                Toast.makeText(getActivity(), getString(R.string.map_toast_terrain), Toast.LENGTH_SHORT).show();
+                                WiGLEToast.showOverActivity(getActivity(), R.string.tab_map, getString(R.string.map_toast_terrain), Toast.LENGTH_SHORT);
                                 break;
                             case GoogleMap.MAP_TYPE_TERRAIN:
                                 newMapType = GoogleMap.MAP_TYPE_NORMAL;
-                                Toast.makeText(getActivity(), getString(R.string.map_toast_normal), Toast.LENGTH_SHORT).show();
+                                WiGLEToast.showOverActivity(getActivity(), R.string.tab_map, getString(R.string.map_toast_normal), Toast.LENGTH_SHORT);
                                 break;
                             default:
                                 MainActivity.error("unhandled mapType: " + newMapType);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/BackgroundGuiHandler.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/BackgroundGuiHandler.java
@@ -57,15 +57,13 @@ public class BackgroundGuiHandler extends Handler {
     public void handleMessage( final Message msg ) {
         synchronized ( lock ) {
             if (msg.what == AUTHENTICATION_ERROR) {
-                Toast.makeText(this.context, R.string.status_login_fail
-                        , Toast.LENGTH_LONG).show();
+                WiGLEToast.showOverActivity(this.context, R.string.error_general, context.getString(R.string.status_login_fail));
                 if (pp != null) {
                     pp.hide();
                 }
             }
             if (msg.what == CONNECTION_ERROR) {
-                Toast.makeText(this.context, R.string.no_wigle_conn
-                        , Toast.LENGTH_LONG).show();
+                WiGLEToast.showOverActivity(this.context, R.string.error_general, context.getString(R.string.no_wigle_conn));
                 if (pp != null) {
                     pp.hide();
                 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/GPSListener.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/GPSListener.java
@@ -235,7 +235,7 @@ public class GPSListener implements Listener, LocationListener {
                 final String announce = location == null ? mainActivity.getString(R.string.lost_location)
                         : mainActivity.getString(R.string.have_location) + " \"" + location.getProvider() + "\"";
                 if (null != mainActivity && ! mainActivity.isFinishing()) {
-                    WiGLEToast.showOverActivity(mainActivity, "", announce);
+                    WiGLEToast.showOverActivity(mainActivity, R.string.gps_status, announce);
                 }
             }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/GPSListener.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/GPSListener.java
@@ -5,6 +5,8 @@ import static android.location.LocationManager.NETWORK_PROVIDER;
 import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.R;
+import net.wigle.wigleandroid.util.WiGLEToast;
+
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
@@ -232,7 +234,9 @@ public class GPSListener implements Listener, LocationListener {
             if (!disableToast && null != mainActivity && !mainActivity.isFinishing()) {
                 final String announce = location == null ? mainActivity.getString(R.string.lost_location)
                         : mainActivity.getString(R.string.have_location) + " \"" + location.getProvider() + "\"";
-                Toast.makeText( mainActivity, announce, Toast.LENGTH_SHORT ).show();
+                if (null != mainActivity && ! mainActivity.isFinishing()) {
+                    WiGLEToast.showOverActivity(mainActivity, "", announce);
+                }
             }
 
             final boolean speechGPS = prefs.getBoolean( ListFragment.PREF_SPEECH_GPS, true );

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
@@ -23,6 +23,8 @@ import net.wigle.wigleandroid.NetworkListAdapter;
 import net.wigle.wigleandroid.model.NetworkType;
 import net.wigle.wigleandroid.FilterMatcher;
 import net.wigle.wigleandroid.R;
+import net.wigle.wigleandroid.util.WiGLEToast;
+
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -792,8 +794,9 @@ public class WifiReceiver extends BroadcastReceiver {
                     if ( now - lastWifiUnjamTime > resetWifiPeriod ) {
                         final boolean disableToast = prefs.getBoolean(ListFragment.PREF_DISABLE_TOAST, false);
                         if (!disableToast &&  null != mainActivity && !mainActivity.isFinishing()) {
-                            Toast.makeText( mainActivity,
-                                    mainActivity.getString(R.string.wifi_jammed), Toast.LENGTH_LONG ).show();
+                            if (null != mainActivity && !mainActivity.isFinishing()) {
+                                WiGLEToast.showOverActivity(mainActivity, R.string.error_general, mainActivity.getString(R.string.wifi_jammed));
+                            }
                         }
                         scanInFlight = false;
                         try {
@@ -837,15 +840,17 @@ public class WifiReceiver extends BroadcastReceiver {
                 if ( batteryKill > 0 && batteryLevel > 0 && batteryLevel <= batteryKill
                         && batteryStatus != BatteryManager.BATTERY_STATUS_CHARGING
                         && (System.currentTimeMillis() - constructionTime) > 30000L) {
-                    final String text = mainActivity.getString(R.string.battery_at) + " " + batteryLevel + " "
+                    if (null != mainActivity) {
+                        final String text = mainActivity.getString(R.string.battery_at) + " " + batteryLevel + " "
                             + mainActivity.getString(R.string.battery_postfix);
-                    if (null != mainActivity && !mainActivity.isFinishing()) {
-                        Toast.makeText(mainActivity, text, Toast.LENGTH_LONG).show();
+                        if (!mainActivity.isFinishing()) {
+                            WiGLEToast.showOverActivity(mainActivity, R.string.error_general, text);
+                        }
+                        MainActivity.warn("low battery, shutting down");
+                        mainActivity.speak(text);
+                        MainActivity.sleep(5000L);
+                        mainActivity.finish();
                     }
-                    MainActivity.warn("low battery, shutting down");
-                    mainActivity.speak( text );
-                    MainActivity.sleep(5000L);
-                    mainActivity.finish();
                 }
             }
         }

--- a/wiglewifiwardriving/src/main/res/values-ar/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ar/strings.xml
@@ -301,4 +301,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">تعذر الاتصال ب ويغل. الرجاء التحقق من الاتصال وإعادة المحاولة.</string>
     <string name="no_secure_wigle_conn">تعذر تأمين الاتصال ب ويغل. الرجاء التحقق وإعادة المحاولة</string>
+    <string name="error_general">خطأ</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">حالة غس</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-cs/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-cs/strings.xml
@@ -301,4 +301,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">Nelze se připojit k WiGLE. Zkontrolujte připojení a zkuste to znovu.</string>
     <string name="no_secure_wigle_conn">Nepodařilo se zajistit spojení s WiGLE. Zkontrolujte a zkuste to znovu.</string>
+    <string name="error_general">Chyba</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">Stav GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-da/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-da/strings.xml
@@ -301,4 +301,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">Kan ikke oprette forbindelse til WiGLE. Kontroller din forbindelse og prøv igen.</string>
     <string name="no_secure_wigle_conn">Kan ikke sikre forbindelse med WiGLE. Tjek venligst og prøv igen.</string>
+    <string name="error_general">Fejl</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">GPS Status</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-de/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-de/strings.xml
@@ -366,4 +366,7 @@
     <string name="delete_db_confirm">ACHTUNG! Sind Sie sicher, dass Sie Ihre lokalen Daten löschen möchten? Sie können Netzwerkdaten von WiGLE neu herunterladen, aber Positions- und Beobachtungsinformationen gehen verloren</string>
     <string name="no_wigle_conn">Kann nicht an WiGLE angeschlossen werden. Bitte überprüfen Sie Ihre Verbindung und versuchen Sie es erneut.</string>
     <string name="no_secure_wigle_conn">Portino kann nicht mit WiGLE gesichert werden. Bitte überprüfen und wiederholen.</string>
+    <string name="error_general">Fehler</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">GPS-Status</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-es/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-es/strings.xml
@@ -302,4 +302,7 @@
     <string name="delete_db_confirm">¿Está seguro de que desea borrar los datos locales? Puede volver a descargar los datos de la red desde WiGLE, pero la información de posición y observación se perderá.</string>
     <string name="no_wigle_conn">No se puede conectar a WiGLE. Compruebe su conexión y vuelva a intentarlo.</string>
     <string name="no_secure_wigle_conn">No se puede asegurar el connectino con WiGLE. Compruebe y vuelva a intentarlo.</string>
+    <string name="error_general">Error</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">Estado del GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fi/strings.xml
@@ -301,4 +301,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">Yhteys WiGLEiin ei onnistu. Tarkista yhteys ja yritä uudelleen.</string>
     <string name="no_secure_wigle_conn">Yhteyden muodostaminen WiGLE-yhteyteen ei onnistu. Tarkista ja yritä uudelleen.</string>
+    <string name="error_general">Virhe</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">GPS-tila</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fr/strings.xml
@@ -358,4 +358,7 @@
     <string name="delete_db_confirm">Êtes-vous sûr de vouloir effacer vos données locales? Vous pouvez ré-télécharger des données réseau de WiGLE, mais les informations de position et d\'observation seront perdues.</string>
     <string name="no_wigle_conn">Impossible de se connecter à WiGLE. Vérifiez votre connexion et réessayez.</string>
     <string name="no_secure_wigle_conn">Impossible de sécuriser la connexion avec WiGLE. Veuillez vérifier et réessayer.</string>
+    <string name="error_general">Erreur</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">État du GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fy/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fy/strings.xml
@@ -301,4 +301,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">Kin net ferbine mei WiFi. Kontrolearje jo ferbining en werhelje.</string>
     <string name="no_secure_wigle_conn">Koe de ferbining net feilichje mei WiFi. Kontrolearje asjebleaft en besykje.</string>
+    <string name="error_general">Fersin</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">GPS-stân</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-he/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-he/strings.xml
@@ -301,4 +301,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">לא ניתן להתחבר ל- WiGLE. בדוק את החיבור שלך ונסה שוב.</string>
     <string name="no_secure_wigle_conn">אין אפשרות לאבטח את החיבור ל- WiGLE. בדוק ונסה שוב.</string>
+    <string name="error_general">שְׁגִיאָה</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">מצב GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hi/strings.xml
@@ -301,4 +301,7 @@
     <string name="delete_db_confirm">क्या आप वाकई अपना स्थानीय डेटा साफ़ करना चाहते हैं? आप WiGLE से नेटवर्क डेटा को फिर से डाउनलोड कर सकते हैं, लेकिन स्थिति और अवलोकन जानकारी खो जाएंगे।</string>
     <string name="no_wigle_conn">वाईगल से कनेक्ट करने में असमर्थ कृपया अपना कनेक्शन जांचें और पुनः प्रयास करें।</string>
     <string name="no_secure_wigle_conn">वाईगल के साथ कनेक्शन सुरक्षित करने में असमर्थ कृपया चेक करें और पुनः प्रयास करें।</string>
+    <string name="error_general">त्रुटि</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">जीपीएस स्थिति</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hu/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hu/strings.xml
@@ -301,4 +301,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">Nem sikerült csatlakozni a WiGLE-hez. Ellenőrizze a kapcsolatot, és próbálkozzon újra.</string>
     <string name="no_secure_wigle_conn">Nem sikerült kapcsolódni a WiGLE kapcsolathoz. Kérjük, ellenőrizze és próbálja újra.</string>
+    <string name="error_general">Hiba</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">GPS állapot</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-it/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-it/strings.xml
@@ -363,4 +363,7 @@
     <string name="delete_db_confirm">Sei sicuro di voler cancellare i dati locali? È possibile scaricare nuovamente i dati di rete da WiGLE, ma le informazioni relative alla posizione e all\'osservazione verranno perse.</string>
     <string name="no_wigle_conn">Impossibile connettersi a WiGLE. Controllare la connessione e riprovare.</string>
     <string name="no_secure_wigle_conn">Impossibile garantire la connessione con WiGLE. Si prega di controllare e riprovare.</string>
+    <string name="error_general">Errore</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">Stato GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ja/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ja/strings.xml
@@ -299,4 +299,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">WiGLEに接続できません。接続を確認して再試行してください。</string>
     <string name="no_secure_wigle_conn">WiGLEとの接続を保護できません。確認して再試行してください。</string>
+    <string name="error_general">エラー</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">GPSステータス</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ko/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ko/strings.xml
@@ -299,4 +299,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">WiGle에 연결할 수 없습니다. 연결을 확인하고 다시 시도하십시오.</string>
     <string name="no_secure_wigle_conn">WiGLE과의 연결을 보호 할 수 없습니다. 확인하고 다시 시도하십시오.</string>
+    <string name="error_general">오류</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">GPS 상태</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-nl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nl/strings.xml
@@ -301,4 +301,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">Kan geen verbinding maken met WiGLE. Controleer uw verbinding en probeer het opnieuw.</string>
     <string name="no_secure_wigle_conn">Kan de verbinding met WiGLE niet beveiligen. Controleer en probeer het opnieuw.</string>
+    <string name="error_general">Fout</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">GPS-status</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-nn/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nn/strings.xml
@@ -342,4 +342,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">Unable to connect to WiGLE. Please check your connection and retry.</string>
     <string name="no_secure_wigle_conn">Unable to secure connection with WiGLE. Please check and retry.</string>
+    <string name="error_general">Feil</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">GPS-status</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-no/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-no/strings.xml
@@ -301,4 +301,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">Kan ikke koble til WiGLE. Vennligst sjekk forbindelsen og prøv igjen.</string>
     <string name="no_secure_wigle_conn">Kan ikke sikre forbindelse med WiGLE. Vennligst sjekk og prøv igjen.</string>
+    <string name="error_general">Feil</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">GPS-status</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pl/strings.xml
@@ -299,4 +299,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">Nie można połączyć się z WiGLE. Sprawdź połączenie i spróbuj ponownie.</string>
     <string name="no_secure_wigle_conn">Nie można zabezpieczyć połączenia z WiGLE. Sprawdź i spróbuj ponownie.</string>
+    <string name="error_general">Błąd</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">Stan GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
@@ -311,4 +311,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">Não foi possível conectar-se ao WiGLE. Verifique sua conexão e tente novamente.</string>
     <string name="no_secure_wigle_conn">Não é possível proteger a conexão com o WiGLE. Verifique e tente novamente.</string>
+    <string name="error_general">Erro</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">Status do GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt/strings.xml
@@ -299,4 +299,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">Não foi possível conectar-se ao WiGLE. Verifique sua conexão e tente novamente.</string>
     <string name="no_secure_wigle_conn">Não é possível proteger a conexão com o WiGLE. Verifique e tente novamente.</string>
+    <string name="error_general">Erro</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">Status do GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ru/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ru/strings.xml
@@ -311,4 +311,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">Не удалось подключиться к WiGLE. Проверьте подключение и повторите попытку.</string>
     <string name="no_secure_wigle_conn">Не удалось обеспечить соединение с WiGLE. Пожалуйста, проверьте и повторите попытку.</string>
+    <string name="error_general">ошибка</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">Состояние GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-sv/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-sv/strings.xml
@@ -299,4 +299,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">Det gick inte att ansluta till WiGLE. Kontrollera din anslutning och försök igen.</string>
     <string name="no_secure_wigle_conn">Det gick inte att säkra anslutningen med WiGLE. Kontrollera och försök igen.</string>
+    <string name="error_general">Fel</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">GPS-status</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-tr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-tr/strings.xml
@@ -301,4 +301,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">WiGLE\'ye bağlanılamıyor. Lütfen bağlantınızı kontrol edin ve tekrar deneyin.</string>
     <string name="no_secure_wigle_conn">WiGLE ile bağlantı kurulamıyor. Lütfen kontrol edin ve tekrar deneyin.</string>
+    <string name="error_general">Hata</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">GPS Durumu</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh/strings.xml
@@ -301,4 +301,7 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">无法连接到WiGLE。请检查您的连接并重试。</string>
     <string name="no_secure_wigle_conn">无法确保与WiGLE的连接。请检查并重试。</string>
+    <string name="error_general">错误</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">GPS状态</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values/strings.xml
@@ -366,4 +366,9 @@
     <string name="delete_db_confirm">Are you sure you want to clear your local data? You can re-download network data from WiGLE, but position and observation information will be lost.</string>
     <string name="no_wigle_conn">Unable to connect to WiGLE. Please check your connection and retry.</string>
     <string name="no_secure_wigle_conn">Unable to secure connection with WiGLE. Please check and retry.</string>
+    <string name="error_general">Error</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="error_general">Error</string>
+    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
+    <string name="gps_status">GPS Status</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values/strings.xml
@@ -368,7 +368,5 @@
     <string name="no_secure_wigle_conn">Unable to secure connection with WiGLE. Please check and retry.</string>
     <string name="error_general">Error</string>
     <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
-    <string name="error_general">Error</string>
-    <string name="no_barcode_support_text">Barcode detection not available on this device.</string>
     <string name="gps_status">GPS Status</string>
 </resources>


### PR DESCRIPTION
because android 7.1 just will not stop failing with BadTokenExceptions in odd places.
New strings entries are because of 1. new toast dialogs requiring titles 2. the fact that the odd camera lib-but-no-supported-cam error had not been i18n'd!