### PR TITLE
FIX - bug report on scanning change

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
@@ -275,7 +275,6 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
         if (null != ma) {
             final boolean scanning = !ma.isScanning();
             ma.handleScanChange(scanning);
-            String name = ma.getString(R.string.scan) + " " + (scanning ? ma.getString(R.string.off) : ma.getString(R.string.on));
             handleScanChange(ma, getView());
         }
     }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
@@ -276,7 +276,6 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
             final boolean scanning = !ma.isScanning();
             ma.handleScanChange(scanning);
             String name = ma.getString(R.string.scan) + " " + (scanning ? ma.getString(R.string.off) : ma.getString(R.string.on));
-            ma.setTitle(name);
             handleScanChange(ma, getView());
         }
     }


### PR DESCRIPTION
from user bug:

> When using the indicator/button to turn scanning on and off, the title changes to "Scan Off" and "Scan On". Using the menu doesn't do that. Also, the text indication is backwards. I've attached a couple of screenshots to demonstrate.
