### PR TITLE
simplify service notification setup. create one even if shutting down

### DIFF
--- a/wiglewifiwardriving/wiglewifiwardriving.iml
+++ b/wiglewifiwardriving/wiglewifiwardriving.iml
@@ -87,6 +87,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/build-info" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/check-manifest" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes-jar" />


### PR DESCRIPTION
our minimum sdk level means we don't have to jump through reflection hoops to set up the notification anymore.