### PR TITLE
switch to finishSoon to try and defeat RemoteServiceException

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
@@ -215,15 +215,6 @@ public class DashboardFragment extends Fragment {
     return retval;
   }
 
-  // XXX
-//  @Override
-//  public void finish() {
-//    ListActivity.info( "finish dash." );
-//    finishing.set( true );
-//
-//    super.finish();
-//  }
-
   @Override
   public void onDestroy() {
     MainActivity.info( "DASH: onDestroy" );

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
@@ -47,7 +47,6 @@ import org.json.JSONObject;
  */
 public final class DataFragment extends Fragment implements ApiListener, TransferListener, DialogListener {
 
-    private static final int MENU_EXIT = 11;
     private static final int MENU_ERROR_REPORT = 13;
 
     private static final int CSV_RUN_DIALOG = 120;
@@ -543,10 +542,6 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
     @Override
     public boolean onOptionsItemSelected( final MenuItem item ) {
         switch ( item.getItemId() ) {
-            case MENU_EXIT:
-                final MainActivity main = MainActivity.getMainActivity();
-                main.finish();
-                return true;
             case MENU_ERROR_REPORT:
                 final Intent errorReportIntent = new Intent( getActivity(), ErrorReportActivity.class );
                 startActivity( errorReportIntent );

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ErrorReportActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ErrorReportActivity.java
@@ -103,7 +103,7 @@ public class ErrorReportActivity extends AppCompatActivity {
         // shut down anything we can get a handle to
         final MainActivity mainActivity = MainActivity.getMainActivity();
         if ( mainActivity != null ) {
-            mainActivity.finish();
+            mainActivity.finishSoon();
         }
         if ( NetworkActivity.networkActivity != null ) {
             NetworkActivity.networkActivity.finish();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
@@ -98,7 +98,6 @@ public final class MappingFragment extends Fragment {
 
     private static final int DEFAULT_ZOOM = 17;
     public static final LatLng DEFAULT_POINT = new LatLng(41.95d, -87.65d);
-    private static final int MENU_EXIT = 12;
     private static final int MENU_ZOOM_IN = 13;
     private static final int MENU_ZOOM_OUT = 14;
     private static final int MENU_TOGGLE_LOCK = 15;
@@ -657,11 +656,6 @@ public final class MappingFragment extends Fragment {
     public boolean onOptionsItemSelected( final MenuItem item ) {
         final SharedPreferences prefs = getActivity().getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
         switch ( item.getItemId() ) {
-            case MENU_EXIT: {
-                final MainActivity main = MainActivity.getMainActivity();
-                main.finish();
-                return true;
-            }
             case MENU_ZOOM_IN: {
                 mapView.getMapAsync(new OnMapReadyCallback() {
                     @Override

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/NetworkActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/NetworkActivity.java
@@ -55,7 +55,7 @@ import net.wigle.wigleandroid.model.OUI;
 
 @SuppressWarnings("deprecation")
 public class NetworkActivity extends AppCompatActivity implements DialogListener {
-    private static final int MENU_EXIT = 11;
+    private static final int MENU_RETURN = 11;
     private static final int MENU_COPY = 12;
     private static final int NON_CRYPTO_DIALOG = 130;
 
@@ -553,7 +553,7 @@ public class NetworkActivity extends AppCompatActivity implements DialogListener
         MenuItem item = menu.add(0, MENU_COPY, 0, getString(R.string.menu_copy_network));
         item.setIcon( android.R.drawable.ic_menu_save );
 
-        item = menu.add(0, MENU_EXIT, 0, getString(R.string.menu_return));
+        item = menu.add(0, MENU_RETURN, 0, getString(R.string.menu_return));
         item.setIcon( android.R.drawable.ic_menu_revert );
 
         return true;
@@ -563,7 +563,7 @@ public class NetworkActivity extends AppCompatActivity implements DialogListener
     @Override
     public boolean onOptionsItemSelected( final MenuItem item ) {
         switch ( item.getItemId() ) {
-            case MENU_EXIT:
+            case MENU_RETURN:
                 // call over to finish
                 finish();
                 return true;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/TerminationReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/TerminationReceiver.java
@@ -21,7 +21,7 @@ public class TerminationReceiver extends BroadcastReceiver {
                 MainActivity ma = MainActivity.getMainActivity();
                 if (null != ma) {
                     //ALIBI: multiple terminations in rapid succession can cause NPE
-                    ma.finish();
+                    ma.finishSoon();
                 }
                 return;
             default:

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
@@ -850,8 +850,7 @@ public class WifiReceiver extends BroadcastReceiver {
                         }
                         MainActivity.warn("low battery, shutting down");
                         mainActivity.speak(text);
-                        MainActivity.sleep(5000L);
-                        mainActivity.finish();
+                        mainActivity.finishSoon(4000L);
                     }
                 }
             }


### PR DESCRIPTION
Was able to dupe when starting and low-battery path is engaged. This takes care of that path, and changes all cases of MainActivity to finish after a callback, since it's not enough to just call Service.startForeground you actually have to allow time/execution for the notification to be displayed.

Also clean up some MENU_EXIT's that aren't used anymore because they are fragments, and call the notification code in more places in the service just in case that is also a path of RemoteServiceException possibilities.

Android bug: https://issuetracker.google.com/issues/76112072