### PR TITLE
FIX - Notification now deseapear when swipe-killing the application

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -990,6 +990,8 @@ public final class MainActivity extends AppCompatActivity {
         } catch (final IllegalArgumentException ex) {
             info("wifiReceiver not registered: " + ex);
         }
+
+        stopService(new Intent(MainActivity.this,WigleService.class));
     }
 
     @Override


### PR DESCRIPTION
Before this commit, when you swipe out the application from the list, the notification of the service saying how many Wifi network was staying. Now, it disappear, as the service is stopped.
