### PR TITLE
[ENH] Turn Bluetooth scanning on by default

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -1711,7 +1711,7 @@ public final class MainActivity extends AppCompatActivity {
         final boolean willActivateBt = canBtBeActivated();
         final boolean willActivateWifi = canWifiBeActivated();
         final SharedPreferences prefs = getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
-        final boolean useBt = (prefs.getBoolean(ListFragment.PREF_SCAN_BT, false));
+        final boolean useBt = (prefs.getBoolean(ListFragment.PREF_SCAN_BT, true));
 
         if ((willActivateBt && useBt) || willActivateWifi) {
 
@@ -1825,7 +1825,7 @@ public final class MainActivity extends AppCompatActivity {
         }
         final SharedPreferences prefs = getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
         final Editor edit = prefs.edit();
-        if (prefs.getBoolean(ListFragment.PREF_SCAN_BT, false)) {
+        if (prefs.getBoolean(ListFragment.PREF_SCAN_BT, true)) {
             if (!bt.isEnabled()) {
                 info("Enable bluetooth");
                 edit.putBoolean(ListFragment.PREF_BT_WAS_OFF, true);


### PR DESCRIPTION
Bluetooth mostly doesn't explode in testing now; turning on by default.