### PR TITLE
now that BT defaults to on, bug report from forums

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
@@ -438,7 +438,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
         MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.use_network_location, ListFragment.PREF_USE_NETWORK_LOC, false);
         MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.disable_toast, ListFragment.PREF_DISABLE_TOAST, false);
         MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.boot_start, ListFragment.PREF_START_AT_BOOT ,false);
-        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.bluetooth_ena, ListFragment.PREF_SCAN_BT, false, new PrefCheckboxListener() {
+        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.bluetooth_ena, ListFragment.PREF_SCAN_BT, true, new PrefCheckboxListener() {
             @Override
             public void preferenceSet(boolean value) {
                 MainActivity.info("Signaling bluetooth change: "+value);


### PR DESCRIPTION
default checkbox state will now match default of BT scanning on.