### PR TITLE
[FIX] Fix for old sqlite w/ no instr() function

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
@@ -31,6 +31,7 @@ public class DashboardFragment extends Fragment {
   private final Handler timer = new Handler();
   private AtomicBoolean finishing;
   private NumberFormat numberFormat;
+  private NumberFormat  wholeNumberFormat;
   private ScrollView scrollView;
   private View landscape;
   private View portrait;
@@ -51,7 +52,16 @@ public class DashboardFragment extends Fragment {
     getActivity().setVolumeControlStream( AudioManager.STREAM_MUSIC );
 
     finishing = new AtomicBoolean( false );
-    numberFormat = NumberFormat.getNumberInstance( Locale.US );
+    Configuration sysConfig = getResources().getConfiguration();
+    Locale locale = null;
+    if (null != sysConfig) {
+        locale = sysConfig.locale;
+    }
+    if (null == locale) {
+        locale = Locale.US;
+    }
+    numberFormat = NumberFormat.getNumberInstance(locale);
+    wholeNumberFormat = NumberFormat.getIntegerInstance(locale);
     if ( numberFormat instanceof DecimalFormat ) {
       numberFormat.setMinimumFractionDigits(2);
       numberFormat.setMaximumFractionDigits(2);
@@ -148,13 +158,13 @@ public class DashboardFragment extends Fragment {
         updateDist( view, R.id.prevrundist, ListFragment.PREF_DISTANCE_PREV_RUN, getString(R.string.dash_dist_prev) );
 
         tv = (TextView) view.findViewById( R.id.queuesize );
-        tv.setText( getString(R.string.dash_db_queue) + " " + ListFragment.lameStatic.preQueueSize );
+        tv.setText( getString(R.string.dash_db_queue) + " " + wholeNumberFormat.format(ListFragment.lameStatic.preQueueSize) );
 
         tv = (TextView) view.findViewById( R.id.dbNets );
-        tv.setText( getString(R.string.dash_db_nets) + " " + ListFragment.lameStatic.dbNets );
+        tv.setText( getString(R.string.dash_db_nets) + " " + wholeNumberFormat.format(ListFragment.lameStatic.dbNets) );
 
         tv = (TextView) view.findViewById( R.id.dbLocs );
-        tv.setText( getString(R.string.dash_db_locs) + " " + ListFragment.lameStatic.dbLocs );
+        tv.setText( getString(R.string.dash_db_locs) + " " + wholeNumberFormat.format(ListFragment.lameStatic.dbLocs) );
 
         tv = (TextView) view.findViewById( R.id.gpsstatus );
         Location location = ListFragment.lameStatic.location;
@@ -233,7 +243,7 @@ public class DashboardFragment extends Fragment {
 
   }
 
-  private long newNetsSinceUpload() {
+  private String newNetsSinceUpload() {
     final SharedPreferences prefs = getActivity().getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
     final long marker = prefs.getLong( ListFragment.PREF_DB_MARKER, 0L );
     final long uploaded = prefs.getLong( ListFragment.PREF_NETS_UPLOADED, 0L );
@@ -245,7 +255,7 @@ public class DashboardFragment extends Fragment {
         newSinceUpload = 0;
       }
     }
-    return newSinceUpload;
+    return wholeNumberFormat.format(newSinceUpload);
   }
 
   private void updateDist( final View view, final int id, final String pref, final String title ) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
@@ -41,6 +41,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteStatement;
 import android.location.Location;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
@@ -107,8 +108,12 @@ public final class DatabaseHelper extends Thread {
     private static final String LOCATION_DELETE = "drop table " + LOCATION_TABLE;
     private static final String NETWORK_DELETE = "drop table " + NETWORK_TABLE;
 
-    private static final String LOCATED_NETS_QUERY_STEM = " FROM " + DatabaseHelper.NETWORK_TABLE
-            + " WHERE bestlat != 0.0 AND bestlon != 0.0 AND instr(bssid, '_') <= 0";
+    private static final String LOCATED_NETS_QUERY_STEM = (Build.VERSION.SDK_INT > 19)?
+                " FROM " + DatabaseHelper.NETWORK_TABLE
+            + " WHERE bestlat != 0.0 AND bestlon != 0.0 AND instr(bssid, '_') <= 0":
+                " FROM " + DatabaseHelper.NETWORK_TABLE
+            + " WHERE bestlat != 0.0 AND bestlon != 0.0 AND bssid NOT LIKE '%_%' ESCAPE '_'";
+
     //ALIBI: Sqlite types are dynamic, so usual warnings about doubles and zero == should be moot
 
     private static final String LOCATED_NETS_COUNT_QUERY = "SELECT count(*)" +LOCATED_NETS_QUERY_STEM;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/GsmOperator.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/GsmOperator.java
@@ -8,6 +8,7 @@ import android.telephony.CellIdentityLte;
 import android.telephony.CellIdentityWcdma;
 
 import net.wigle.wigleandroid.MainActivity;
+import net.wigle.wigleandroid.util.InsufficientSpaceException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -267,6 +268,8 @@ public class GsmOperator {
                         //recopy the MccMnc DB file to see whether we can recover.
                         s.mxcDbHelper.implantMxcDatabase();
                         //TODO: too aggressive? operator = s.mxcDbHelper.networkNameForMccMnc(mcc, mnc);
+                    } catch (InsufficientSpaceException sex) {
+                        MainActivity.error("GSMOp implant failed: ",sex);
                     } catch (Exception ex) {
                         MainActivity.warn("Mxc DB recopy failed", ex);
                     }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/FileUtility.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/FileUtility.java
@@ -1,0 +1,47 @@
+package net.wigle.wigleandroid.util;
+
+import android.os.Build;
+import android.os.Environment;
+import android.os.StatFs;
+
+import java.io.File;
+
+/**
+ * Simple filespace check calls
+ */
+public class FileUtility {
+
+    //ALIBI: can't actually read the size of compressed assets via the asset manager - has to be hardcoded
+    //  this can be updated by checking the size of wiglewifiwardriving/src/main/assets/mmcmnc.sqlite on build
+    public final static long EST_MXC_DB_SIZE = 331776;
+
+    // Start warning if there isn't this much space left on the primary storage location for networks
+    public final static long WARNING_THRESHOLD_BYTES = 131072;
+
+    //based on the smart answer in https://stackoverflow.com/questions/7115016/how-to-find-the-amount-of-free-storage-disk-space-left-on-android
+    public static long getFreeBytes(File path) {
+        StatFs stats = new StatFs(path.getAbsolutePath());
+        if (Build.VERSION.SDK_INT >= 18) {
+            return stats.getAvailableBlocksLong() * stats.getBlockSizeLong();
+        } else {
+            return (long) (stats.getAvailableBlocks() * stats.getBlockSize());
+        }
+    }
+
+    public static boolean checkInternalStorageDangerZone() {
+        return getFreeInternalBytes() > WARNING_THRESHOLD_BYTES;
+    }
+
+    public static boolean checkExternalStorageDangerZone() {
+        return getFreeExternalBytes() > WARNING_THRESHOLD_BYTES;
+    }
+
+    public static long getFreeExternalBytes() {
+        return FileUtility.getFreeBytes(Environment.getExternalStorageDirectory());
+    }
+
+    public static long getFreeInternalBytes() {
+        return FileUtility.getFreeBytes(Environment.getDataDirectory());
+    }
+
+}

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/InsufficientSpaceException.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/InsufficientSpaceException.java
@@ -1,0 +1,15 @@
+package net.wigle.wigleandroid.util;
+
+public class InsufficientSpaceException extends Exception {
+    public InsufficientSpaceException() {
+        super();
+    }
+
+    public InsufficientSpaceException(String message) {
+        super(message);
+    }
+
+    public InsufficientSpaceException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/wiglewifiwardriving/src/main/res/values-ar/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ar/strings.xml
@@ -402,8 +402,13 @@
     <string name="search_empty">النتائج فارغة</string>
     <string name="search_query_limit">لقد وصلت إلى الحد الأقصى من عمليات البحث اليوم. ستتم إعادة تعيين الحد الخاص بك غدًا.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">يقوم نظام أندرويد باي (9.0) بإبطال شبكة WiFi إلى 2 في الدقيقة. ترقية Android إذا كان ذلك ممكنًا.</string>
+    <string name="q_bad">يمسح نظام Android 10 throttles WiFi ما لم يتم تعطيله في إعدادات المطور.</string>
+    <string name="enable_developer">لتمكين خيارات المطور: الإعدادات -> حول الهاتف -> اضغط على Build Number 7 مرات.</string>
+    <string name="disable_throttle">لتعطيل التحكم في تفحص WiFi: النظام -> خيارات متقدمة -> خيارات المطور -> تفحص اختناق WiFi إلى وضع الإيقاف.</string>
+    <string name="no_internal_space_title">لا المساحة المتاحة</string>
+    <string name="no_internal_space_message">لا توجد مساحة تخزين داخلية كافية على جهازك.</string>
+    <string name="no_external_space_title">لا المساحة المتاحة</string>
+    <string name="no_external_space_message">لا يوجد مساحة تخزين كافية للتطبيق الخارجي على جهازك.</string>
+    <string name="no_mxc_space_message">لا توجد مساحة تخزين داخلية كافية على جهازك لتثبيت قاعدة بيانات بحث مشغل الخلية. سيتم استخدام معرفات الجهاز الموردة.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-cs/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-cs/strings.xml
@@ -402,8 +402,13 @@
     <string name="search_empty">Výsledky prázdné</string>
     <string name="search_query_limit">Do dnešního dne jste dosáhli maximálního počtu vyhledávání. Váš limit se zítra vynuluje.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0) snižuje WiFi skenování na 2 za minutu. Pokud je to možné, upgradujte Android.</string>
+    <string name="q_bad">Android 10 škrtá skenování WiFi, pokud to není zakázáno v Nastavení vývojáře.</string>
+    <string name="enable_developer">Chcete-li povolit možnosti vývojáře: Nastavení -> O telefonu -> Poklepejte 7krát na Sestavit číslo.</string>
+    <string name="disable_throttle">Chcete-li zakázat omezení skenování WiFi: Systém -> Upřesnit -> Možnosti vývojáře -> Šetření WiFi skenování vypnuto.</string>
+    <string name="no_internal_space_title">Není k dispozici žádný prostor</string>
+    <string name="no_internal_space_message">Ve vašem zařízení není dostatek interního úložiště aplikací.</string>
+    <string name="no_external_space_title">Není k dispozici žádný prostor</string>
+    <string name="no_external_space_message">Ve vašem zařízení není dostatek úložiště externí aplikace.</string>
+    <string name="no_mxc_space_message">Chcete-li zakázat omezení skenování WiFi: Systém -> Upřesnit -> Možnosti vývojáře -> Šetření WiFi skenování vypnuto.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-da/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-da/strings.xml
@@ -402,8 +402,13 @@
     <string name="search_empty">Resultater tom</string>
     <string name="search_query_limit">Du har nået det maksimale antal søgninger i dag. Din grænse vil blive nulstillet i morgen.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0) throttles WiFi-scanninger til 2 pr. Minut. Opgrader Android hvis muligt.</string>
+    <string name="q_bad">Android 10 throttles WiFi-scanninger, medmindre det er deaktiveret i Developer Settings.</string>
+    <string name="enable_developer">Sådan aktiveres udviklerindstillinger: Indstillinger -> Om telefon -> Tryk på Build Number 7 gange.</string>
+    <string name="disable_throttle">Sådan deaktiveres WiFi-scanning-throttling: System -> Avanceret -> Udviklerindstillinger -> WiFi-scanning-throttling til slukket.</string>
+    <string name="no_internal_space_title">Ingen plads tilgængelig</string>
+    <string name="no_internal_space_message">Der er ikke nok intern applikationslagring på din enhed.</string>
+    <string name="no_external_space_title">Ingen plads tilgængelig</string>
+    <string name="no_external_space_message">Der er ikke nok ekstern applikationslagring på din enhed.</string>
+    <string name="no_mxc_space_message">Der er ikke nok intern applikationslagring på din enhed til at installere opslagningsdatabasen for celleoperatøren. Enheds-leverede ID\'er bruges.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-de/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-de/strings.xml
@@ -402,8 +402,13 @@
     <string name="search_empty">Ergebnisse leer</string>
     <string name="search_query_limit">Sie haben heute die maximale Anzahl an Suchen erreicht. Ihr Limit wird morgen zurückgesetzt.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0) drosselt WiFi-Scans auf 2 pro Minute. Wenn möglich, aktualisieren Sie Android.</string>
+    <string name="q_bad">Android 10 drosselt WLAN-Scans, sofern dies nicht in den Entwicklereinstellungen deaktiviert ist.</string>
+    <string name="enable_developer">So aktivieren Sie die Entwickleroptionen: Einstellungen -> Informationen zum Telefon -> Tippen Sie siebenmal auf Build-Nummer.</string>
+    <string name="disable_throttle">So deaktivieren Sie die WLAN-Scan-Drosselung: System -> Erweitert -> Entwickleroptionen -> WLAN-Scan-Drosselung auf Aus.</string>
+    <string name="no_internal_space_title">Kein Platz verfügbar</string>
+    <string name="no_internal_space_message">Auf Ihrem Gerät ist nicht genügend interner Anwendungsspeicher vorhanden.</string>
+    <string name="no_external_space_title">Kein Platz verfügbar</string>
+    <string name="no_external_space_message">Auf Ihrem Gerät ist nicht genügend externer Anwendungsspeicher vorhanden.</string>
+    <string name="no_mxc_space_message">Auf Ihrem Gerät ist nicht genügend interner Anwendungsspeicher vorhanden, um die Suchdatenbank für Mobilfunkbetreiber zu installieren. Vom Gerät bereitgestellte IDs werden verwendet.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-es/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-es/strings.xml
@@ -348,8 +348,13 @@
     <string name="search_empty">Resultados vacíos</string>
     <string name="search_query_limit">Has alcanzado el número máximo de búsquedas en la actualidad. Tu límite se restablecerá mañana.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0) acelera los escaneos WiFi a 2 por minuto. Actualice Android si es posible.</string>
+    <string name="q_bad">Android 10 acelera los escaneos WiFi a menos que esté deshabilitado en la Configuración del desarrollador.</string>
+    <string name="enable_developer">Para habilitar las opciones de desarrollador: Configuración -> Acerca del teléfono -> Toque Número de compilación 7 veces.</string>
+    <string name="disable_throttle">Para deshabilitar la aceleración de escaneo WiFi: Sistema -> Avanzado -> Opciones de desarrollador -> Aceleración de escaneo WiFi a apagado.</string>
+    <string name="no_internal_space_title">No hay espacio disponible</string>
+    <string name="no_internal_space_message">No hay suficiente almacenamiento interno de aplicaciones en su dispositivo.</string>
+    <string name="no_external_space_title">No hay espacio disponible</string>
+    <string name="no_external_space_message">No hay suficiente almacenamiento de aplicaciones externas en su dispositivo.</string>
+    <string name="no_mxc_space_message">No hay suficiente almacenamiento interno de aplicaciones en su dispositivo para instalar la base de datos de búsqueda del operador de celda. Se utilizarán las ID suministradas por el dispositivo.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fi/strings.xml
@@ -259,6 +259,7 @@
     <string name="use_wigle_tiles">Use WiGLE OSM tiles</string>
     <string name="wigle_service">WiGLE Wifi Service</string>
     <string name="disable_toast">Disable toast pop-ups</string>
+    <string name="at">at</string>
     <string name="drawer_open">Laatikko auki</string>
     <string name="drawer_close">Laatikko suljettu</string>
     <string name="netwpa3_title">WPA3</string>
@@ -347,8 +348,13 @@
     <string name="search_empty">Tulokset tyhjä</string>
     <string name="search_query_limit">Olet saavuttanut suurimman määrän hakuja tänään. Rajasi palautetaan huomenna.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0) kuristaa WiFi-skannauksen nopeuteen 2 minuutissa. Päivitä Android, jos mahdollista.</string>
+    <string name="q_bad">Android 10 ohjaa WiFi-skannauksia, ellei niitä ole otettu käyttöön kehittäjäasetuksissa.</string>
+    <string name="enable_developer">Kehittäjävaihtoehtojen ottaminen käyttöön: Asetukset -> Tietoja puhelimesta -> Napauta Rakennusnumero 7 kertaa.</string>
+    <string name="disable_throttle">WiFi-skannauksen kuristustoiminnon poistaminen käytöstä: Järjestelmä -> Lisäasetukset -> Kehittäjäasetukset -> WiFi-skannauksen kuristus pois päältä.</string>
+    <string name="no_internal_space_title">Ei tilaa käytettävissä</string>
+    <string name="no_internal_space_message">Laitteellasi ei ole tarpeeksi sisäistä sovellusmuistia.</string>
+    <string name="no_external_space_title">Ei tilaa käytettävissä</string>
+    <string name="no_external_space_message">Laitteellasi ei ole tarpeeksi ulkoista sovellusmuistia.</string>
+    <string name="no_mxc_space_message">Laitteellasi ei ole tarpeeksi sisäistä sovellusmuistia solu-operaattorin hakutietokannan asentamiseen. Laitteen toimittamia tunnuksia käytetään.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fr/strings.xml
@@ -402,8 +402,13 @@
     <string name="search_empty">Résultats vides</string>
     <string name="search_query_limit">Vous avez atteint le nombre maximal de recherches aujourd\'hui. Votre limite sera réinitialisée demain.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0) accélère les analyses WiFi à 2 par minute. Mettez à niveau Android si possible.</string>
+    <string name="q_bad">Android 10 accélère les analyses Wi-Fi, à moins que celles-ci ne soient désactivées dans les paramètres du développeur.</string>
+    <string name="enable_developer">Pour activer les options de développement: Paramètres -> À propos du téléphone -> Tapez Numéro de construction 7 fois.</string>
+    <string name="disable_throttle">Pour désactiver la limitation de l\'analyse WiFi: Système -> Avancé -> Options développeurs -> Limitation de l\'analyse WiFi désactivée.</string>
+    <string name="no_internal_space_title">Pas d\'espace disponible</string>
+    <string name="no_internal_space_message">Il n\'y a pas assez de stockage d\'application interne sur votre appareil.</string>
+    <string name="no_external_space_title">Pas d\'espace disponible</string>
+    <string name="no_external_space_message">Il n\'y a pas assez de stockage d\'application externe sur votre appareil.</string>
+    <string name="no_mxc_space_message">Le stockage interne des applications sur votre appareil est insuffisant pour installer la base de données de recherche des opérateurs de cellules. Les identifiants fournis par l\'appareil seront utilisés.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fy/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fy/strings.xml
@@ -347,8 +347,13 @@
     <string name="search_empty">Results Empty</string>
     <string name="search_query_limit">You\'ve reached the maximum number of searches today. Your limit will reset tomorrow.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0) beperkt wifi-scans tot 2 per minuut. Upgrade Android indien mogelijk.</string>
+    <string name="q_bad">Android 10 beperkt wifi-scans tenzij uitgeschakeld in de instellingen voor ontwikkelaars.</string>
+    <string name="enable_developer">Om ontwikkelaaropties in te schakelen: Instellingen -> Over telefoon -> Tik 7 keer op Build-nummer.</string>
+    <string name="disable_throttle">Beperking van WiFi-scan uitschakelen: Systeem -> Geavanceerd -> Ontwikkelaarsopties -> Beperking van WiFi-scan uit.</string>
+    <string name="no_internal_space_title">Geen ruimte beschikbaar</string>
+    <string name="no_internal_space_message">Er is onvoldoende interne toepassingsopslag op uw apparaat.</string>
+    <string name="no_external_space_title">Geen ruimte beschikbaar</string>
+    <string name="no_external_space_message">Er is onvoldoende externe toepassingsopslag op uw apparaat.</string>
+    <string name="no_mxc_space_message">Er is onvoldoende interne toepassingsopslag op uw apparaat om de opzoekdatabase van de mobiele operator te installeren. Door het apparaat geleverde ID\'s worden gebruikt.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-he/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-he/strings.xml
@@ -402,8 +402,13 @@
     <string name="search_empty">תוצאות ריקות</string>
     <string name="search_query_limit">הגעת למספר המרבי של חיפושים היום. המגבלה שלך תאופס מחר.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">פאי אנדרואיד (9.0) מצמצם סריקות WiFi ל -2 לדקה. שדרג אנדרואיד במידת האפשר.</string>
+    <string name="q_bad">אנדרואיד 10 מצמצם סריקות WiFi אלא אם כן הוא מושבת בהגדרות המפתח.</string>
+    <string name="enable_developer">כדי לאפשר אפשרויות מפתח: הגדרות -> אודות טלפון -> הקש Build Build 7 פעמים.</string>
+    <string name="disable_throttle">כדי להשבית את מצערת סריקת WiFi: מערכת -> מתקדם -> אפשרויות מפתחים -> מצערת סריקת WiFi למצב כבוי.</string>
+    <string name="no_internal_space_title">אין מקום פנוי</string>
+    <string name="no_internal_space_message">אין מספיק אחסון יישומי פנימי במכשיר שלך.</string>
+    <string name="no_external_space_title">אין מקום פנוי</string>
+    <string name="no_external_space_message">אין מספיק שטח אחסון ליישומים חיצוניים במכשיר שלך.</string>
+    <string name="no_mxc_space_message">אין מספיק אחסון יישומי פנימי במכשיר שלך בכדי להתקין את מסד הנתונים לחיפוש מפעיל סלולרי. יש להשתמש במזהים המסופקים במכשירים.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hi/strings.xml
@@ -345,8 +345,13 @@
     <string name="search_empty">परिणाम खाली</string>
     <string name="search_query_limit">आप आज अधिकतम खोज पर पहुँच गए हैं। आपकी सीमा कल रीसेट हो जाएगी।</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">एंड्रॉइड पाई (9.0) थ्रॉटल वाईफाई स्कैन 2 प्रति मिनट। यदि संभव हो तो Android अपग्रेड करें।</string>
+    <string name="q_bad">डेवलपर सेटिंग में अक्षम होने तक एंड्रॉइड 10 थ्रोटल्स वाईफाई स्कैन करता है।</string>
+    <string name="enable_developer">डेवलपर विकल्पों को सक्षम करने के लिए: सेटिंग्स -> फ़ोन के बारे में -> बिल्ड नंबर 7 बार टैप करें।</string>
+    <string name="disable_throttle">वाईफाई स्कैन थ्रॉटलिंग को निष्क्रिय करने के लिए: सिस्टम -> उन्नत -> डेवलपर विकल्प -> वाईफाई स्कैन थ्रॉटलिंग को बंद करना।</string>
+    <string name="no_internal_space_title">कोई स्थान उपलब्ध नहीं है</string>
+    <string name="no_internal_space_message">आपके डिवाइस पर पर्याप्त आंतरिक अनुप्रयोग संग्रहण नहीं है।</string>
+    <string name="no_external_space_title">कोई स्थान उपलब्ध नहीं है</string>
+    <string name="no_external_space_message">आपके डिवाइस पर पर्याप्त बाहरी अनुप्रयोग संग्रहण नहीं है।</string>
+    <string name="no_mxc_space_message">सेल ऑपरेटर लुकअप डेटाबेस को स्थापित करने के लिए आपके डिवाइस पर पर्याप्त आंतरिक अनुप्रयोग संग्रहण नहीं है। डिवाइस-आपूर्ति की गई आईडी का उपयोग किया जाएगा।</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hu/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hu/strings.xml
@@ -347,8 +347,13 @@
     <string name="search_empty">Eredmények üresek</string>
     <string name="search_query_limit">Ma elérte a maximális számú keresést. A határidőt holnap visszaállítja.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Az Android Pie (9.0) fojtja a WiFi sebességét percenként 2-re. Frissítse az Android rendszert, ha lehetséges.</string>
+    <string name="q_bad">Az Android 10 gátolja a WiFi-szkennelést, kivéve, ha le van tiltva a fejlesztői beállításokban.</string>
+    <string name="enable_developer">A fejlesztői lehetőségek engedélyezése: Beállítások -> A telefonról -> 7-szer érintse meg az Összeállítás számot.</string>
+    <string name="disable_throttle">A WiFi szkennelés gátlásának letiltása: Rendszer -> Speciális -> Fejlesztői beállítások -> A WiFi szkennelés gázszabályozása kikapcsolva.</string>
+    <string name="no_internal_space_title">Nincs hely</string>
+    <string name="no_internal_space_message">Nincs elég belső alkalmazástároló eszközén.</string>
+    <string name="no_external_space_title">Nincs hely</string>
+    <string name="no_external_space_message">Nincs elég külső alkalmazás tárolóeszköz a készüléken.</string>
+    <string name="no_mxc_space_message">A készüléken nincs elegendő belső tárhely a cellaüzemeltető keresési adatbázisának telepítéséhez. Az eszköz által szállított azonosítókat fogjuk használni.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-it/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-it/strings.xml
@@ -402,8 +402,13 @@
     <string name="search_empty">Risultati vuoti</string>
     <string name="search_query_limit">Hai raggiunto il numero massimo di ricerche oggi. Il tuo limite verrà ripristinato domani.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0) riduce le scansioni WiFi a 2 al minuto. Aggiorna Android se possibile.</string>
+    <string name="q_bad">Android 10 limita le scansioni WiFi a meno che non sia disabilitato nelle Impostazioni sviluppatore.</string>
+    <string name="enable_developer">Per abilitare le opzioni sviluppatore: Impostazioni -> Informazioni sul telefono -> Tocca Numero build 7 volte.</string>
+    <string name="disable_throttle">Per disabilitare la limitazione della scansione WiFi: Sistema -> Avanzate -> Opzioni sviluppatore -> Limitazione della scansione WiFi disattivata.</string>
+    <string name="no_internal_space_title">Nessuno spazio disponibile</string>
+    <string name="no_internal_space_message">Non c\'è abbastanza memoria interna per l\'applicazione sul tuo dispositivo.</string>
+    <string name="no_external_space_title">Nessuno spazio disponibile</string>
+    <string name="no_external_space_message">Non è disponibile memoria sufficiente per l\'applicazione esterna sul dispositivo.</string>
+    <string name="no_mxc_space_message">La memoria interna dell\'applicazione non è sufficiente sul dispositivo per installare il database di ricerca dell\'operatore di cella. Verranno utilizzati gli ID forniti dal dispositivo.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ja/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ja/strings.xml
@@ -402,8 +402,13 @@
     <string name="search_empty">空の結果</string>
     <string name="search_query_limit">あなたは今日最大検索数に達しました。あなたの制限は明日リセットされます。</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie（9.0）は、WiFiスキャンを1分あたり2に絞ります。可能であればAndroidをアップグレードします。</string>
+    <string name="q_bad">Android 10 は、開発者設定で無効にされていない限り、WiFiスキャンを抑制します。</string>
+    <string name="enable_developer">開発者向けオプションを有効にするには：[設定]-> [電話について]-> [ビルド番号]を7回タップします。</string>
+    <string name="disable_throttle">WiFiスキャンスロットリングを無効にするには：[システム]-> [詳細]-> [開発者オプション]-> [WiFiスキャンスロットリングをオフにします。</string>
+    <string name="no_internal_space_title">利用可能なスペースがありません</string>
+    <string name="no_internal_space_message">デバイスに十分な内部アプリケーションストレージがありません。</string>
+    <string name="no_external_space_title">利用可能なスペースがありません</string>
+    <string name="no_external_space_message">デバイスに十分な外部アプリケーションストレージがありません。</string>
+    <string name="no_mxc_space_message">セルオペレータルックアップデータベースをインストールするための十分な内部アプリケーションストレージがデバイスにありません。デバイス提供のIDが使用されます。</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ko/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ko/strings.xml
@@ -345,8 +345,13 @@
     <string name="search_empty">빈 결과</string>
     <string name="search_query_limit">오늘 최대 검색 수에 도달했습니다. 한도가 내일 다시 설정됩니다.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0)는 WiFi 스캔을 분당 2로 제한합니다. 가능하면 Android를 업그레이드하십시오.</string>
+    <string name="q_bad">Android 10 는 개발자 설정에서 비활성화하지 않으면 WiFi 스캔을 조절합니다.</string>
+    <string name="enable_developer">개발자 옵션을 활성화하려면 : 설정-> 전화 정보-> 빌드 번호를 7 번 누릅니다.</string>
+    <string name="disable_throttle">WiFi 스캔 조절을 비활성화하려면 : 시스템-> 고급-> 개발자 옵션-> WiFi 스캔 조절을 끕니다.</string>
+    <string name="no_internal_space_title">사용 가능한 공간이 없습니다</string>
+    <string name="no_internal_space_message">기기에 내부 애플리케이션 저장소가 충분하지 않습니다.</string>
+    <string name="no_external_space_title">사용 가능한 공간이 없습니다</string>
+    <string name="no_external_space_message">기기에 외부 애플리케이션 저장소가 충분하지 않습니다.</string>
+    <string name="no_mxc_space_message">셀 운영자 조회 데이터베이스를 설치하기에 디바이스에 내부 애플리케이션 스토리지가 충분하지 않습니다. 장치 제공 ID가 사용됩니다.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-nl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nl/strings.xml
@@ -116,6 +116,7 @@
     <string name="tab_dash">Overzicht</string>
     <string name="tab_data">Gegevens</string>
     <string name="tab_stats">Statistieken</string>
+    <string name="tab_search">Zoeken</string>
     <string name="ok">OK</string>
     <string name="cancel">Annuleren</string>
     <string name="dash_scan_off">Scan is uit</string>
@@ -259,6 +260,18 @@
     <string name="use_wigle_tiles">Gebruik WiGLE OSM-tegels</string>
     <string name="wigle_service">WiGLE Wifi Service</string>
     <string name="disable_toast">Toast pop-ups uitschakelen</string>
+    <string name="menu_cluster_off">Clustering uit</string>
+    <string name="menu_cluster_on">Clustering aan</string>
+    <string name="menu_traffic_off">Verkeer uitgeschakeld</string>
+    <string name="menu_traffic_on">Verkeer aan</string>
+    <string name="menu_map_type">Wissel kaarttype</string>
+    <string name="map_toast_normal">Kaarttype: Normaal</string>
+    <string name="map_toast_satellite">Kaarttype: Satelliet</string>
+    <string name="map_toast_hybrid">Kaarttype: hybride</string>
+    <string name="map_toast_terrain">Kaarttype: Terrein</string>
+    <string name="map_needs_playservice">Map vereist Google Play Service</string>
+    <string name="register">Registreren</string>
+    <string name="at">op</string>
     <string name="netwpa3_title">WPA3</string>
     <string name="netwpa2_title">WPA2</string>
     <string name="netwpa_title">WPA</string>
@@ -345,8 +358,13 @@
     <string name="search_empty">Resultaten leeg</string>
     <string name="search_query_limit">U heeft vandaag het maximale aantal zoekopdrachten bereikt. Je limiet wordt morgen opnieuw ingesteld.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0) beperkt wifi-scans tot 2 per minuut. Upgrade Android indien mogelijk.</string>
+    <string name="q_bad">Android 10 beperkt wifi-scans tenzij uitgeschakeld in de instellingen voor ontwikkelaars.</string>
+    <string name="enable_developer">Om ontwikkelaaropties in te schakelen: Instellingen -> Over telefoon -> Tik 7 keer op Build-nummer.</string>
+    <string name="disable_throttle">Beperking van WiFi-scan uitschakelen: Systeem -> Geavanceerd -> Ontwikkelaarsopties -> Beperking van WiFi-scan uit.</string>
+    <string name="no_internal_space_title">Geen ruimte beschikbaar</string>
+    <string name="no_internal_space_message">Er is onvoldoende interne toepassingsopslag op uw apparaat.</string>
+    <string name="no_external_space_title">Geen ruimte beschikbaar</string>
+    <string name="no_external_space_message">Er is onvoldoende externe toepassingsopslag op uw apparaat.</string>
+    <string name="no_mxc_space_message">Er is onvoldoende interne toepassingsopslag op uw apparaat om de opzoekdatabase van de mobiele operator te installeren. Door het apparaat geleverde ID\'s worden gebruikt.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-nn/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nn/strings.xml
@@ -380,8 +380,13 @@
     <string name="search_empty">Resultater Tom</string>
     <string name="search_query_limit">Du har nådd det maksimale antallet søk i dag. Grensen din vil nullstille i morgen.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0) struper WiFi-skanninger til 2 per minutt. Oppgrader Android hvis mulig.</string>
+    <string name="q_bad">Android 10 struper WiFi-skanninger med mindre den er deaktivert i utviklerinnstillinger.</string>
+    <string name="enable_developer">Slik aktiverer du utvikleralternativer: Innstillinger -> Om telefon -> Trykk på Byggenummer 7 ganger.</string>
+    <string name="disable_throttle">Det er ikke nok intern applikasjonslagring på enheten din til å installere oppslagdatabasen for celleoperatøren. Enhetsleverte ID-er vil bli brukt.</string>
+    <string name="no_internal_space_title">Ingen plass tilgjengelig</string>
+    <string name="no_internal_space_message">Det er ikke nok intern applikasjonslagring på enheten din.</string>
+    <string name="no_external_space_title">Ingen plass tilgjengelig</string>
+    <string name="no_external_space_message">Det er ikke nok ekstern applikasjonslagring på enheten din.</string>
+    <string name="no_mxc_space_message">Det er ikke nok intern applikasjonslagring på enheten din til å installere oppslagdatabasen for celleoperatøren. Enhetsleverte ID-er vil bli brukt.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-no/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-no/strings.xml
@@ -345,8 +345,13 @@
     <string name="search_empty">Resultater Tom</string>
     <string name="search_query_limit">Du har nådd det maksimale antallet søk i dag. Grensen din vil nullstille i morgen.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0) struper WiFi-skanninger til 2 per minutt. Oppgrader Android hvis mulig.</string>
+    <string name="q_bad">Android 10 struper WiFi-skanninger med mindre den er deaktivert i utviklerinnstillinger.</string>
+    <string name="enable_developer">Slik aktiverer du utvikleralternativer: Innstillinger -> Om telefon -> Trykk på Byggenummer 7 ganger.</string>
+    <string name="disable_throttle">Det er ikke nok intern applikasjonslagring på enheten din til å installere oppslagdatabasen for celleoperatøren. Enhetsleverte ID-er vil bli brukt.</string>
+    <string name="no_internal_space_title">Ingen plass tilgjengelig</string>
+    <string name="no_internal_space_message">Det er ikke nok intern applikasjonslagring på enheten din.</string>
+    <string name="no_external_space_title">Ingen plass tilgjengelig</string>
+    <string name="no_external_space_message">Det er ikke nok ekstern applikasjonslagring på enheten din.</string>
+    <string name="no_mxc_space_message">Det er ikke nok intern applikasjonslagring på enheten din til å installere oppslagdatabasen for celleoperatøren. Enhetsleverte ID-er vil bli brukt.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pl/strings.xml
@@ -345,8 +345,13 @@
     <string name="search_empty">Wyniki Empty</string>
     <string name="search_query_limit">Masz już maksymalną liczbę wyszukiwań. Twój limit zostanie zresetowany jutro.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0) ogranicza skanowanie Wi-Fi do 2 na minutę. Zaktualizuj Androida, jeśli to możliwe.</string>
+    <string name="q_bad">Android 10 ogranicza skanowanie Wi-Fi, chyba że jest wyłączone w Ustawieniach programisty.</string>
+    <string name="enable_developer">Aby włączyć opcje programisty: Ustawienia -> Informacje o telefonie -> Stuknij Numer kompilacji 7 razy.</string>
+    <string name="disable_throttle">Aby wyłączyć ograniczanie skanowania Wi-Fi: System -> Zaawansowane -> Opcje programisty -> Ograniczanie skanowania Wi-Fi, aby wyłączyć.</string>
+    <string name="no_internal_space_title">Brak dostępnego miejsca</string>
+    <string name="no_internal_space_message">W urządzeniu nie ma wystarczającej ilości pamięci wewnętrznej na aplikacje.</string>
+    <string name="no_external_space_title">Brak dostępnego miejsca</string>
+    <string name="no_external_space_message">W urządzeniu nie ma wystarczającej ilości pamięci zewnętrznej na aplikacje.</string>
+    <string name="no_mxc_space_message">W urządzeniu nie ma wystarczającej ilości pamięci wewnętrznej do zainstalowania bazy danych wyszukiwania operatora komórki. Zostaną użyte identyfikatory dostarczone przez urządzenie.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
@@ -358,8 +358,13 @@
     <string name="search_empty">Resultados vazios</string>
     <string name="search_query_limit">Você atingiu o número máximo de pesquisas hoje. Seu limite será redefinido amanhã.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">O Android Pie (9.0) faz a varredura do WiFi para 2 por minuto. Atualize o Android, se possível.</string>
+    <string name="q_bad">O Android 10 limita as verificações de Wi-Fi, a menos que seja desativado nas Configurações do desenvolvedor.</string>
+    <string name="enable_developer">Para ativar as opções do desenvolvedor: Configurações -> Sobre o telefone -> Toque em Número da compilação 7 vezes.</string>
+    <string name="disable_throttle">Para desativar a otimização da varredura WiFi: Sistema -> Avançado -> Opções do desenvolvedor -> Otimização da varredura WiFi para desativado.</string>
+    <string name="no_internal_space_title">Nenhum espaço disponível</string>
+    <string name="no_internal_space_message">Não há armazenamento de aplicativos interno suficiente no seu dispositivo.</string>
+    <string name="no_external_space_title">Nenhum espaço disponível</string>
+    <string name="no_external_space_message">Não há armazenamento de aplicativos externos suficiente no seu dispositivo.</string>
+    <string name="no_mxc_space_message">Não há armazenamento de aplicativo interno suficiente no seu dispositivo para instalar o banco de dados de pesquisa do operador de célula. IDs fornecidos pelo dispositivo serão usados.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt/strings.xml
@@ -345,8 +345,13 @@
     <string name="search_empty">Resultados vazios</string>
     <string name="search_query_limit">Você atingiu o número máximo de pesquisas hoje. Seu limite será redefinido amanhã.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">O Android Pie (9.0) faz a varredura do WiFi para 2 por minuto. Atualize o Android, se possível.</string>
+    <string name="q_bad">O Android 10 limita as verificações de Wi-Fi, a menos que seja desativado nas Configurações do desenvolvedor.</string>
+    <string name="enable_developer">Para ativar as opções do desenvolvedor: Configurações -> Sobre o telefone -> Toque em Número da compilação 7 vezes.</string>
+    <string name="disable_throttle">Para desativar a otimização da varredura WiFi: Sistema -> Avançado -> Opções do desenvolvedor -> Otimização da varredura WiFi para desativado.</string>
+    <string name="no_internal_space_title">Nenhum espaço disponível</string>
+    <string name="no_internal_space_message">Não há armazenamento de aplicativos interno suficiente no seu dispositivo.</string>
+    <string name="no_external_space_title">Nenhum espaço disponível</string>
+    <string name="no_external_space_message">Não há armazenamento de aplicativos externos suficiente no seu dispositivo.</string>
+    <string name="no_mxc_space_message">Não há armazenamento de aplicativo interno suficiente no seu dispositivo para instalar o banco de dados de pesquisa do operador de célula. IDs fornecidos pelo dispositivo serão usados.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ru/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ru/strings.xml
@@ -357,8 +357,13 @@
     <string name="search_empty">Результаты Пусто</string>
     <string name="search_query_limit">Вы достигли максимального числа поисков сегодня. Ваш лимит будет сброшен завтра.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0) снижает скорость сканирования WiFi до 2 в минуту. Обновите Android, если это возможно.</string>
+    <string name="q_bad">Android 10 регулирует сканирование WiFi, если не отключено в настройках разработчика.</string>
+    <string name="enable_developer">Чтобы включить параметры разработчика: Настройки -> О телефоне -> Нажмите Построить номер 7 раз.</string>
+    <string name="disable_throttle">Чтобы отключить регулирование сканирования WiFi: Система -> Дополнительно -> Параметры разработчика -> Регулирование сканирования WiFi отключено.</string>
+    <string name="no_internal_space_title">Нет свободного места</string>
+    <string name="no_internal_space_message">На вашем устройстве недостаточно внутреннего хранилища приложений.</string>
+    <string name="no_external_space_title">Нет свободного места</string>
+    <string name="no_external_space_message">На вашем устройстве недостаточно внешнего хранилища приложений.</string>
+    <string name="no_mxc_space_message">На вашем устройстве недостаточно внутренней памяти для установки базы данных поиска сотовых операторов. Будут использоваться предоставленные устройством идентификаторы.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-sv/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-sv/strings.xml
@@ -345,8 +345,13 @@
     <string name="search_empty">Resultat tom</string>
     <string name="search_query_limit">Du har nått det maximala antalet sökningar idag. Din gräns återställs i morgon.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0) stänger av WiFi-skanningar till 2 per minut. Uppgradera Android om möjligt.</string>
+    <string name="q_bad">Android 10 stänger av WiFi-skanningar såvida det inte är inaktiverat i utvecklarinställningarna.</string>
+    <string name="enable_developer">För att aktivera utvecklaralternativ: Inställningar -> Om telefon -> Tryck på Byggnummer 7 gånger.</string>
+    <string name="disable_throttle">Så här avaktiverar du gasspjäll av WiFi-skanning: System -> Avancerat -> Utvecklaralternativ -> WiFi-skottreglage till av.</string>
+    <string name="no_internal_space_title">Inget utrymme tillgängligt</string>
+    <string name="no_internal_space_message">Det finns inte tillräckligt med intern applikationslagring på din enhet.</string>
+    <string name="no_external_space_title">Inget utrymme tillgängligt</string>
+    <string name="no_external_space_message">Det finns inte tillräckligt med extern applikationslagring på din enhet.</string>
+    <string name="no_mxc_space_message">Det finns inte tillräckligt med internt applikationslagringsutrymme på din enhet för att installera sökoperatörsdatabasen. Enhets-ID som används kommer att användas.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-tr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-tr/strings.xml
@@ -345,8 +345,13 @@
     <string name="search_empty">Boş Sonuçlar</string>
     <string name="search_query_limit">Bugün maksimum arama sayısına ulaştınız. Sınırın yarın sıfırlanacak.</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie (9.0), WiFi taramalarını dakikada 2\'ye kadar atıyor. Mümkünse Android\'i yükseltin.</string>
+    <string name="q_bad">Android 10, Geliştirici Ayarlarında devre dışı bırakılmadığı sürece WiFi taramalarını engellemektedir.</string>
+    <string name="enable_developer">Geliştirici seçeneklerini etkinleştirmek için: Ayarlar -> Telefon Hakkında -> Yapı Numarası 7 kez dokunun.</string>
+    <string name="disable_throttle">WiFi taramasını azaltma işlevini devre dışı bırakmak için: Sistem -> Gelişmiş -> Geliştirici seçenekleri -> WiFi taramasını kısma.</string>
+    <string name="no_internal_space_title">Boş Alan Yok</string>
+    <string name="no_internal_space_message">Cihazınızda yeterli dahili uygulama depolama alanı yok.</string>
+    <string name="no_external_space_title">Boş Alan Yok</string>
+    <string name="no_external_space_message">Cihazınızda yeterli harici uygulama depolama alanı yok.</string>
+    <string name="no_mxc_space_message">Hücre operatörü arama veritabanını yüklemek için cihazınızda yeterli dahili uygulama depolama alanı yok. Cihaz tarafından sağlanan ID\'ler kullanılacaktır.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rCN/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rCN/strings.xml
@@ -402,8 +402,13 @@
     <string name="search_empty">结果为空</string>
     <string name="search_query_limit">您今天已达到最大搜索次数。你的限额将在明天重置。</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie（9.0）将WiFi扫描限制为每分钟2次。尽可能升级Android。</string>
+    <string name="q_bad">除非在“开发者设置”中禁用，否则Android 10 会限制WiFi扫描。</string>
+    <string name="enable_developer">启用开发人员选项：设置 - >关于手机 - >点击内置编号7次。</string>
+    <string name="disable_throttle">要禁用WiFi扫描限制：系统 - >高级 - >开发人员选项 - > WiFi扫描限制为关闭。</string>
+    <string name="no_internal_space_title">没有可用空间</string>
+    <string name="no_internal_space_message">您的设备上没有足够的内部应用程序存储空间。</string>
+    <string name="no_external_space_title">没有可用空间</string>
+    <string name="no_external_space_message">您的设备上没有足够的外部应用程序存储空间。</string>
+    <string name="no_mxc_space_message">您的设备上没有足够的内部应用程序存储来安装单元操作员查找数据库。将使用设备提供的ID。</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rHK/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rHK/strings.xml
@@ -402,8 +402,13 @@
     <string name="search_empty">結果為空</string>
     <string name="search_query_limit">您今天已達到最大搜索次數。你的限額將在明天重置。</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie（9.0）將WiFi掃描限制為每分鐘2次。盡可能升級Android。</string>
+    <string name="q_bad">除非在“開發者設置”中禁用，否則Android 10 會限制WiFi掃描。</string>
+    <string name="enable_developer">啟用開發人員選項：設置 - >關於手機 - >點擊內置編號7次。</string>
+    <string name="disable_throttle">要禁用WiFi掃描限制：系統 - >高級 - >開發人員選項 - > WiFi掃描限制為關閉。</string>
+    <string name="no_internal_space_title">沒有可用空間</string>
+    <string name="no_internal_space_message">您的設備上沒有足夠的內部應用程序存儲空間。</string>
+    <string name="no_external_space_title">沒有可用空間</string>
+    <string name="no_external_space_message">您的設備上沒有足夠的外部應用程序存儲空間。</string>
+    <string name="no_mxc_space_message">您的設備上沒有足夠的內部應用程序存儲來安裝單元操作員查找數據庫。將使用設備提供的ID。</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rTW/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rTW/strings.xml
@@ -402,8 +402,13 @@
     <string name="search_empty">結果為空</string>
     <string name="search_query_limit">您今天已達到最大搜索次數。你的限額將在明天重置。</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie（9.0）將WiFi掃描限制為每分鐘2次。盡可能升級Android。</string>
+    <string name="q_bad">除非在“開發者設置”中禁用，否則Android 10 會限制WiFi掃描。</string>
+    <string name="enable_developer">啟用開發人員選項：設置 - >關於手機 - >點擊內置編號7次。</string>
+    <string name="disable_throttle">要禁用WiFi掃描限制：系統 - >高級 - >開發人員選項 - > WiFi掃描限制為關閉。</string>
+    <string name="no_internal_space_title">沒有可用空間</string>
+    <string name="no_internal_space_message">您的設備上沒有足夠的內部應用程序存儲空間。</string>
+    <string name="no_external_space_title">沒有可用空間</string>
+    <string name="no_external_space_message">您的設備上沒有足夠的外部應用程序存儲空間。</string>
+    <string name="no_mxc_space_message">您的設備上沒有足夠的內部應用程序存儲來安裝單元操作員查找數據庫。將使用設備提供的ID。</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh/strings.xml
@@ -402,8 +402,13 @@
     <string name="search_empty">结果为空</string>
     <string name="search_query_limit">您今天已达到最大搜索次数。你的限额将在明天重置。</string>
     <string name="menu_debug">Debug</string>
-    <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="pie_bad">Android Pie（9.0）将WiFi扫描限制为每分钟2次。尽可能升级Android。</string>
+    <string name="q_bad">除非在“开发者设置”中禁用，否则Android 10 会限制WiFi扫描。</string>
+    <string name="enable_developer">启用开发人员选项：设置 - >关于手机 - >点击内置编号7次。</string>
+    <string name="disable_throttle">要禁用WiFi扫描限制：系统 - >高级 - >开发人员选项 - > WiFi扫描限制为关闭。</string>
+    <string name="no_internal_space_title">没有可用空间</string>
+    <string name="no_internal_space_message">您的设备上没有足够的内部应用程序存储空间。</string>
+    <string name="no_external_space_title">没有可用空间</string>
+    <string name="no_external_space_message">您的设备上没有足够的外部应用程序存储空间。</string>
+    <string name="no_mxc_space_message">您的设备上没有足够的内部应用程序存储来安装单元操作员查找数据库。将使用设备提供的ID。</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values/strings.xml
@@ -416,7 +416,12 @@
     <string name="total_bt">Total Bluetooth</string>
     <string name="menu_debug">Debug</string>
     <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
-    <string name="q_bad">Android Q (10.0) throttles WiFi scans unless disabled in Developer Settings.</string>
-    <string name="enable_developer">To enabled developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
+    <string name="q_bad">Android 10 throttles WiFi scans unless disabled in Developer Settings.</string>
+    <string name="enable_developer">To enable developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
     <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="no_internal_space_title">No Space Available</string>
+    <string name="no_internal_space_message">There isn\'t enough internal application storage on your device.</string>
+    <string name="no_external_space_title">No Space Available</string>
+    <string name="no_external_space_message">There isn\'t enough external application storage on your device.</string>
+    <string name="no_mxc_space_message">There isn\'t enough internal application storage on your device to install the cell operator lookup database. Device-supplied IDs will be used.</string>
 </resources>


### PR DESCRIPTION
this will be slower, but won't crash on old (4.x) Android devices. Notes that instr() support seems to be occasionally present but unreliable on these devices.