### PR TITLE
[FIX] cause of hanging process?

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -1952,6 +1952,7 @@ public final class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
         // Check which request we're responding to
         if (requestCode == ACTION_WIFI_CODE) {
             // Make sure the request was successful


### PR DESCRIPTION
when enabling (disabled at launch-time) WiFi from within the app's pop-up in Android 10, app would go into a zombie scanning/notification mode, leaving the service running after app termination. This should fix that.