### PR TITLE
[ENH] User Stats view condensation/refactor

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UserStatsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UserStatsFragment.java
@@ -1,6 +1,7 @@
 package net.wigle.wigleandroid;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Color;
@@ -277,7 +278,10 @@ public class UserStatsFragment extends Fragment {
     public void onResume() {
         MainActivity.info("STATS: onResume");
         super.onResume();
-        getActivity().setTitle(R.string.user_stats_app_name);
+        Activity a = getActivity();
+        if (null != a) {
+            getActivity().setTitle(R.string.user_stats_app_name);
+        }
     }
 
     @Override

--- a/wiglewifiwardriving/src/main/res/layout/userstats.xml
+++ b/wiglewifiwardriving/src/main/res/layout/userstats.xml
@@ -34,7 +34,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
                 android:text="@string/unknown_number"
-                android:textColor="#ffff00"
+                style="@style/UploadColor"
                 android:textSize="24sp"
                 android:paddingRight="5dip"/>
 
@@ -64,7 +64,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"
                 android:text="@string/unknown_number"
-                android:textColor="#d0d000"
+                style="@style/UploadColor"
                 android:textSize="20sp"
                 android:paddingRight="5dip" />
 
@@ -75,11 +75,17 @@
                 android:text="@string/unknown_number"
                 android:textSize="20sp" />
         </LinearLayout>
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@android:color/darker_gray"
+            />
         <LinearLayout
             android:orientation="horizontal"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:paddingBottom="10dp">
+            android:paddingTop="4dp"
+            android:paddingBottom="4dp">
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -103,13 +109,13 @@
             android:orientation="horizontal"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:paddingBottom="10dp"
-            android:weightSum="3">
+            android:paddingBottom="3dp"
+            android:weightSum="3"
+            android:baselineAligned="false">
             <LinearLayout
                 android:orientation="horizontal"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:paddingBottom="10dp"
                 android:layout_weight="1">
                 <androidx.appcompat.widget.AppCompatImageView
                     android:layout_width="wrap_content"
@@ -129,7 +135,6 @@
                 android:orientation="horizontal"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:paddingBottom="10dp"
                 android:layout_weight="1">
                 <androidx.appcompat.widget.AppCompatImageView
                     android:layout_width="wrap_content"
@@ -149,7 +154,6 @@
                 android:orientation="horizontal"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:paddingBottom="10dp"
                 android:layout_weight="1">
                 <androidx.appcompat.widget.AppCompatImageView
                     android:layout_width="wrap_content"
@@ -171,39 +175,96 @@
             android:layout_height="1dp"
             android:background="@android:color/darker_gray"
             />
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="4dp"
+            android:paddingBottom="4dp">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/total_seen"
+                android:textSize="20sp"
+                />
+        </LinearLayout>
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="3dp"
+            android:weightSum="3"
+            android:baselineAligned="false">
+            <LinearLayout
+                android:orientation="horizontal"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1">
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    app:srcCompat="@drawable/wifi"/>
+                <TextView
+                    android:id="@+id/discoveredWiFi"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/status_unknown"
+                    android:textSize="15sp"
+                    android:paddingBottom="2dp"
+                    style="@style/WiFiColor"
+                    android:paddingLeft="4dip"/>
+            </LinearLayout>
+            <LinearLayout
+                android:orientation="horizontal"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1">
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    app:srcCompat="@drawable/bluetooth"/>
+                <TextView
+                    android:id="@+id/discoveredBt"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/status_unknown"
+                    android:textSize="15sp"
+                    android:paddingBottom="2dp"
+                    style="@style/BtColor"
+                    android:paddingLeft="2dip"/>
+            </LinearLayout>
+            <LinearLayout
+                android:orientation="horizontal"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_weight="1">
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    app:srcCompat="@drawable/cell"/>
+                <TextView
+                    android:id="@+id/discoveredCell"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/status_unknown"
+                    android:textSize="15sp"
+                    android:paddingBottom="2dp"
+                    style="@style/CellColor"
+                    android:paddingLeft="4dip"/>
+            </LinearLayout>
+        </LinearLayout>
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="@android:color/darker_gray"
+            />
 
         <LinearLayout
             android:orientation="horizontal"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:paddingTop="10dp">
-            <TextView
-                android:id="@+id/discoveredWiFi"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/status_unknown"
-                android:textSize="16sp"
-                android:paddingBottom="2dip"
-                style="@style/WiFiColor"
-                android:paddingRight="3dip"/>
-            <androidx.appcompat.widget.AppCompatImageView
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                app:srcCompat="@drawable/wifi"/>
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/total_title"
-                android:textSize="16sp"
-                />
-
-        </LinearLayout>
-        <LinearLayout
-            android:orientation="horizontal"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content">
-
+            android:paddingTop="4dp"
+            >
             <TextView
                 android:id="@+id/totalWiFiLocations"
                 android:layout_width="wrap_content"
@@ -214,10 +275,6 @@
                 style="@style/WiFiColor"
                 android:paddingRight="3dip"
                 />
-            <androidx.appcompat.widget.AppCompatImageView
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                app:srcCompat="@drawable/wifi"/>
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -225,57 +282,6 @@
                 android:textSize="16sp"
                 />
         </LinearLayout>
-
-        <LinearLayout
-            android:orientation="horizontal"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content">
-            <TextView
-                android:id="@+id/discoveredBt"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/status_unknown"
-                android:textSize="16sp"
-                android:paddingBottom="2dip"
-                style="@style/BtColor"
-                android:paddingRight="3dip" />
-            <androidx.appcompat.widget.AppCompatImageView
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                app:srcCompat="@drawable/bluetooth"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/bttotal_title"
-                android:textSize="16sp"
-                />
-        </LinearLayout>
-
-        <LinearLayout
-            android:orientation="horizontal"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content">
-            <TextView
-                android:id="@+id/discoveredCell"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/status_unknown"
-                android:textSize="16sp"
-                android:paddingBottom="2dip"
-                style="@style/CellColor"
-                android:paddingRight="3dip" />
-            <androidx.appcompat.widget.AppCompatImageView
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                app:srcCompat="@drawable/cell"/>
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/gentotal_title"
-                android:textSize="16sp"
-                />
-        </LinearLayout>
-
         <LinearLayout
             android:orientation="horizontal"
             android:layout_width="fill_parent"
@@ -289,10 +295,6 @@
                 android:paddingBottom="2dip"
                 style="@style/WiFiColor"
                 android:paddingRight="3dip" />
-            <androidx.appcompat.widget.AppCompatImageView
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                app:srcCompat="@drawable/wifi"/>
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -313,10 +315,6 @@
                 android:paddingBottom="2dp"
                 style="@style/WiFiColor"
                 android:paddingRight="3dip" />
-            <androidx.appcompat.widget.AppCompatImageView
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                app:srcCompat="@drawable/wifi"/>
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/wiglewifiwardriving/src/main/res/layout/userstats.xml
+++ b/wiglewifiwardriving/src/main/res/layout/userstats.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/stats_scrolllayout"
     android:orientation="vertical"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:keepScreenOn="true" >
+    android:keepScreenOn="true">
 
     <LinearLayout
         android:id="@+id/linearlayout"
@@ -78,23 +79,92 @@
             android:orientation="horizontal"
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:paddingBottom="10dp"
-            >
-            <TextView
-                android:id="@+id/discoveredWiFiGPS"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/status_unknown"
-                android:textSize="20sp"
-                android:paddingBottom="2dp"
-                android:textColor="#00ff00"
-                android:paddingRight="4dip"/>
+            android:paddingBottom="10dp">
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/discovered_title"
+                android:text="@string/discovered"
                 android:textSize="20sp"
                 />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text=" "
+                android:textSize="20sp"
+                />
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/new_to_us"
+                android:textSize="20sp"
+                />
+        </LinearLayout>
+        <LinearLayout
+            android:orientation="horizontal"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:paddingBottom="10dp"
+            android:weightSum="3">
+            <LinearLayout
+                android:orientation="horizontal"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="10dp"
+                android:layout_weight="1">
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    app:srcCompat="@drawable/wifi"/>
+                <TextView
+                    android:id="@+id/discoveredWiFiGPS"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/status_unknown"
+                    android:textSize="17sp"
+                    android:paddingBottom="2dp"
+                    style="@style/WiFiColor"
+                    android:paddingLeft="4dip"/>
+            </LinearLayout>
+            <LinearLayout
+                android:orientation="horizontal"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="10dp"
+                android:layout_weight="1">
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    app:srcCompat="@drawable/bluetooth"/>
+                <TextView
+                    android:id="@+id/discoveredBtGPS"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/status_unknown"
+                    android:textSize="17sp"
+                    android:paddingBottom="2dp"
+                    style="@style/BtColor"
+                    android:paddingLeft="2dip"/>
+            </LinearLayout>
+            <LinearLayout
+                android:orientation="horizontal"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:paddingBottom="10dp"
+                android:layout_weight="1">
+                <androidx.appcompat.widget.AppCompatImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    app:srcCompat="@drawable/cell"/>
+                <TextView
+                    android:id="@+id/discoveredCellGPS"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/status_unknown"
+                    android:textSize="17sp"
+                    android:paddingBottom="2dp"
+                    style="@style/CellColor"
+                    android:paddingLeft="4dip"/>
+            </LinearLayout>
         </LinearLayout>
         <View
             android:layout_width="match_parent"
@@ -114,8 +184,12 @@
                 android:text="@string/status_unknown"
                 android:textSize="16sp"
                 android:paddingBottom="2dip"
-                android:textColor="#4aceff"
+                style="@style/WiFiColor"
                 android:paddingRight="3dip"/>
+            <androidx.appcompat.widget.AppCompatImageView
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                app:srcCompat="@drawable/wifi"/>
 
             <TextView
                 android:layout_width="wrap_content"
@@ -137,9 +211,13 @@
                 android:text="@string/status_unknown"
                 android:textSize="16sp"
                 android:paddingBottom="2dip"
-                android:textColor="#4aceff"
+                style="@style/WiFiColor"
                 android:paddingRight="3dip"
                 />
+            <androidx.appcompat.widget.AppCompatImageView
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                app:srcCompat="@drawable/wifi"/>
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -153,34 +231,18 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content">
             <TextView
-                android:id="@+id/discoveredBtGPS"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/status_unknown"
-                android:textSize="16sp"
-                android:paddingBottom="2dip"
-                android:textColor="#4aceff"
-                android:paddingRight="3dip" />
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/btdisc_title"
-                android:textSize="16sp"
-                />
-        </LinearLayout>
-        <LinearLayout
-            android:orientation="horizontal"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content">
-            <TextView
                 android:id="@+id/discoveredBt"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/status_unknown"
                 android:textSize="16sp"
                 android:paddingBottom="2dip"
-                android:textColor="#4aceff"
+                style="@style/BtColor"
                 android:paddingRight="3dip" />
+            <androidx.appcompat.widget.AppCompatImageView
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                app:srcCompat="@drawable/bluetooth"/>
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -194,34 +256,18 @@
             android:layout_width="fill_parent"
             android:layout_height="wrap_content">
             <TextView
-                android:id="@+id/discoveredCellGPS"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/status_unknown"
-                android:textSize="16sp"
-                android:paddingBottom="2dip"
-                android:textColor="#4aceff"
-                android:paddingRight="3dip" />
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/gendisc_title"
-                android:textSize="16sp"
-                />
-        </LinearLayout>
-        <LinearLayout
-            android:orientation="horizontal"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content">
-            <TextView
                 android:id="@+id/discoveredCell"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/status_unknown"
                 android:textSize="16sp"
                 android:paddingBottom="2dip"
-                android:textColor="#4aceff"
+                style="@style/CellColor"
                 android:paddingRight="3dip" />
+            <androidx.appcompat.widget.AppCompatImageView
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                app:srcCompat="@drawable/cell"/>
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -241,8 +287,12 @@
                 android:text="@string/status_unknown"
                 android:textSize="16sp"
                 android:paddingBottom="2dip"
-                android:textColor="#4aceff"
+                style="@style/WiFiColor"
                 android:paddingRight="3dip" />
+            <androidx.appcompat.widget.AppCompatImageView
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                app:srcCompat="@drawable/wifi"/>
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -261,8 +311,12 @@
                 android:text="@string/status_unknown"
                 android:textSize="16sp"
                 android:paddingBottom="2dp"
-                android:textColor="#4aceff"
+                style="@style/WiFiColor"
                 android:paddingRight="3dip" />
+            <androidx.appcompat.widget.AppCompatImageView
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                app:srcCompat="@drawable/wifi"/>
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -281,7 +335,7 @@
                 android:text="@string/status_unknown"
                 android:textSize="16sp"
                 android:paddingBottom="2dp"
-                android:textColor="#4aceff"
+                style="@style/FgStatColor"
                 android:paddingRight="3dip" />
             <TextView
                 android:layout_width="wrap_content"
@@ -300,7 +354,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/status_unknown"
                 android:textSize="16sp"
-                android:textColor="#4aceff"
+                style="@style/FgStatColor"
                 android:paddingRight="3dip" />
             <TextView
                 android:layout_width="wrap_content"
@@ -319,7 +373,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/status_unknown"
                 android:textSize="16sp"
-                android:textColor="#4aceff"
+                style="@style/FgStatColor"
                 android:paddingRight="3dip" />
             <TextView
                 android:layout_width="wrap_content"
@@ -338,7 +392,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/status_unknown"
                 android:textSize="16sp"
-                android:textColor="#4aceff"
+                style="@style/FgStatColor"
                 android:paddingRight="3dip" />
             <TextView
                 android:layout_width="wrap_content"

--- a/wiglewifiwardriving/src/main/res/values-ar/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ar/strings.xml
@@ -289,10 +289,8 @@
     <string name="netwepunknown_title">Unknown</string>
     <string name="user_stats_app_name">إحصائيات المستخدم</string>
     <string name="rank_title">ترتيب العضو:</string>
-    <string name="discovered_title">شبكات WiFi التي تم اكتشافها (جديد إلى WiGLE)</string>
     <string name="total_title">مجموع شبكات واي فاي</string>
     <string name="totallocs_title">مجموع مشاهدات واي فاي المسجلة</string>
-    <string name="gendisc_title">شبكات الخلايا المكتشفة (جديد إلى WiGLE)</string>
     <string name="gentotal_title">مجموع شبكات الخلايا</string>
     <string name="monthcount_title">واي فاي اكتشف هذا الشهر</string>
     <string name="prevmonthcount_title">واي فاي اكتشف الشهر الماضي</string>
@@ -422,4 +420,6 @@
     <string name="gpx_no_points">سيكون ملف تصدير توجيه GPX فارغًا.</string>
     <string name="gpx_preparing">إعداد تصدير GPX</string>
     <string name="gpx_exporting">تصدير ملف GPX.</string>
+    <string name="discovered">مكتشف</string>
+    <string name="new_to_us">(جديد إلى WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ar/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ar/strings.xml
@@ -289,9 +289,7 @@
     <string name="netwepunknown_title">Unknown</string>
     <string name="user_stats_app_name">إحصائيات المستخدم</string>
     <string name="rank_title">ترتيب العضو:</string>
-    <string name="total_title">مجموع شبكات واي فاي</string>
     <string name="totallocs_title">مجموع مشاهدات واي فاي المسجلة</string>
-    <string name="gentotal_title">مجموع شبكات الخلايا</string>
     <string name="monthcount_title">واي فاي اكتشف هذا الشهر</string>
     <string name="prevmonthcount_title">واي فاي اكتشف الشهر الماضي</string>
     <string name="firsttransid_title">معرف المعاملة الأول</string>
@@ -422,4 +420,5 @@
     <string name="gpx_exporting">تصدير ملف GPX.</string>
     <string name="discovered">مكتشف</string>
     <string name="new_to_us">(جديد إلى WiGLE)</string>
+    <string name="total_seen">مجموع لوحظ</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-cs/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-cs/strings.xml
@@ -289,9 +289,7 @@
     <string name="netwepunknown_title">Neznámý</string>
     <string name="user_stats_app_name">Statistiky uživatelů</string>
     <string name="rank_title">Hodnocení uživatelů:</string>
-    <string name="total_title">Všechny spatřené WiFi sítě</string>
     <string name="totallocs_title">Celkový zaznamenaný počet spatřených WiFi</string>
-    <string name="gentotal_title">Celkem spatřených vysílačů</string>
     <string name="monthcount_title">Objevené WiFi tento měsíc</string>
     <string name="prevmonthcount_title">Objevené WiFi poslední měsíc</string>
     <string name="firsttransid_title">První ID transakce</string>
@@ -422,4 +420,5 @@
     <string name="gpx_exporting">Exportuje se soubor GPX.</string>
     <string name="discovered">Objevené</string>
     <string name="new_to_us">(nové pro WiGLE)</string>
+    <string name="total_seen">Celkem viděno</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-cs/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-cs/strings.xml
@@ -289,10 +289,8 @@
     <string name="netwepunknown_title">Neznámý</string>
     <string name="user_stats_app_name">Statistiky uživatelů</string>
     <string name="rank_title">Hodnocení uživatelů:</string>
-    <string name="discovered_title">Objevené Wi-Fi sítě (nové pro WiGLE)</string>
     <string name="total_title">Všechny spatřené WiFi sítě</string>
     <string name="totallocs_title">Celkový zaznamenaný počet spatřených WiFi</string>
-    <string name="gendisc_title">Objevené vysílače (nové pro WiGLE)</string>
     <string name="gentotal_title">Celkem spatřených vysílačů</string>
     <string name="monthcount_title">Objevené WiFi tento měsíc</string>
     <string name="prevmonthcount_title">Objevené WiFi poslední měsíc</string>
@@ -422,4 +420,6 @@
     <string name="gpx_no_points">Exportní soubor trasy GPX by byl prázdný.</string>
     <string name="gpx_preparing">Příprava exportu GPX</string>
     <string name="gpx_exporting">Exportuje se soubor GPX.</string>
+    <string name="discovered">Objevené</string>
+    <string name="new_to_us">(nové pro WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-da/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-da/strings.xml
@@ -289,10 +289,8 @@
     <string name="netwepunknown_title">Ukendt</string>
     <string name="user_stats_app_name">Brugerstatistik</string>
     <string name="rank_title">Bruger Ranking:</string>
-    <string name="discovered_title">Opdagede WiFi-netværk (nyt til WiGLE)</string>
     <string name="total_title">Samlet antal WiFi-netværk set</string>
     <string name="totallocs_title">Samlet antal WiFi-observationer optaget</string>
-    <string name="gendisc_title">Opdagede Cell Networks (nyt til WiGLE)</string>
     <string name="gentotal_title">Samlede Cell Networks Seen</string>
     <string name="monthcount_title">WiFi opdaget denne måned</string>
     <string name="prevmonthcount_title">WiFi Discovered sidste måned</string>
@@ -422,4 +420,6 @@
     <string name="gpx_no_points">GPX-ruteeksportfilen ville være tom.</string>
     <string name="gpx_preparing">Forbereder GPX-eksport</string>
     <string name="gpx_exporting">Eksporterer GPX-fil.</string>
+    <string name="discovered">Opdagede</string>
+    <string name="new_to_us">(nyt til WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-da/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-da/strings.xml
@@ -289,9 +289,7 @@
     <string name="netwepunknown_title">Ukendt</string>
     <string name="user_stats_app_name">Brugerstatistik</string>
     <string name="rank_title">Bruger Ranking:</string>
-    <string name="total_title">Samlet antal WiFi-netværk set</string>
     <string name="totallocs_title">Samlet antal WiFi-observationer optaget</string>
-    <string name="gentotal_title">Samlede Cell Networks Seen</string>
     <string name="monthcount_title">WiFi opdaget denne måned</string>
     <string name="prevmonthcount_title">WiFi Discovered sidste måned</string>
     <string name="firsttransid_title">Første transaktions-id</string>
@@ -422,4 +420,5 @@
     <string name="gpx_exporting">Eksporterer GPX-fil.</string>
     <string name="discovered">Opdagede</string>
     <string name="new_to_us">(nyt til WiGLE)</string>
+    <string name="total_seen">I alt observeret</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-de/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-de/strings.xml
@@ -289,10 +289,8 @@
     <string name="netwepunknown_title">unbekannt</string>
     <string name="user_stats_app_name">Benutzerstatistiken</string>
     <string name="rank_title">Rang:</string>
-    <string name="discovered_title">für WiGLE neue WLAN gefunden</string>
     <string name="total_title">WLAN-Netzwerke gefunden</string>
     <string name="totallocs_title">WLAN-Netzwerke gesehen</string>
-    <string name="gendisc_title">gefundene Funkzellen (neu für WiGLE)</string>
     <string name="gentotal_title">gesehene Funkzellen</string>
     <string name="monthcount_title">WLAN gefunden (dieser Monat)</string>
     <string name="prevmonthcount_title">WLAN gefunden (letzter Monat)</string>
@@ -422,4 +420,6 @@
     <string name="gpx_no_points">Die GPX-Route-Exportdatei wäre leer.</string>
     <string name="gpx_preparing">GPX-Export wird vorbereitet</string>
     <string name="gpx_exporting">GPX-Datei wird exportiert.</string>
+    <string name="discovered">gefunden</string>
+    <string name="new_to_us">(neu für WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-de/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-de/strings.xml
@@ -289,9 +289,7 @@
     <string name="netwepunknown_title">unbekannt</string>
     <string name="user_stats_app_name">Benutzerstatistiken</string>
     <string name="rank_title">Rang:</string>
-    <string name="total_title">WLAN-Netzwerke gefunden</string>
     <string name="totallocs_title">WLAN-Netzwerke gesehen</string>
-    <string name="gentotal_title">gesehene Funkzellen</string>
     <string name="monthcount_title">WLAN gefunden (dieser Monat)</string>
     <string name="prevmonthcount_title">WLAN gefunden (letzter Monat)</string>
     <string name="firsttransid_title">Erste Upload-ID</string>
@@ -422,4 +420,5 @@
     <string name="gpx_exporting">GPX-Datei wird exportiert.</string>
     <string name="discovered">gefunden</string>
     <string name="new_to_us">(neu für WiGLE)</string>
+    <string name="total_seen">Insgesamt gesehen</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-es/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-es/strings.xml
@@ -370,5 +370,5 @@
     <string name="gpx_exporting">Exportando archivo GPX.</string>
     <string name="discovered">Descubiertas</string>
     <string name="new_to_us">(Nuevo en WiGLE)</string>
-
+    <string name="total_seen">Total visto</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-es/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-es/strings.xml
@@ -368,4 +368,7 @@
     <string name="gpx_no_points">El archivo de exportación de ruta GPX estaría vacío.</string>
     <string name="gpx_preparing">Preparando la exportación GPX</string>
     <string name="gpx_exporting">Exportando archivo GPX.</string>
+    <string name="discovered">Descubiertas</string>
+    <string name="new_to_us">(Nuevo en WiGLE)</string>
+
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fi/strings.xml
@@ -370,5 +370,5 @@
     <string name="gpx_exporting">Viedään GPX-tiedostoa.</string>
     <string name="discovered">löydetty</string>
     <string name="new_to_us">(Uusi WiGLE: lle)</string>
-
+    <string name="total_seen">Yhteensä nähty</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fi/strings.xml
@@ -368,4 +368,7 @@
     <string name="gpx_no_points">GPX-reitin vientitiedosto olisi tyhjä.</string>
     <string name="gpx_preparing">GPX-viennin valmistelu</string>
     <string name="gpx_exporting">Viedään GPX-tiedostoa.</string>
+    <string name="discovered">löydetty</string>
+    <string name="new_to_us">(Uusi WiGLE: lle)</string>
+
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fr/strings.xml
@@ -289,9 +289,7 @@
     <string name="netwepunknown_title">Inconnu</string>
     <string name="user_stats_app_name">Statistiques utilisateur</string>
     <string name="rank_title">Classement utilisateur :</string>
-    <string name="total_title">Total des réseaux WiFi vus</string>
     <string name="totallocs_title">Total des observations WiFi enregistrées</string>
-    <string name="gentotal_title">Total des tours cellulaires vues</string>
     <string name="monthcount_title">WiFi découverts ce mois</string>
     <string name="prevmonthcount_title">WiFi découverts le mois dernier</string>
     <string name="firsttransid_title">ID première transaction</string>
@@ -422,4 +420,5 @@
     <string name="gpx_exporting">Exporter un fichier GPX.</string>
     <string name="discovered">Ddécouverts</string>
     <string name="new_to_us">(Nouveau sur WiGLE)</string>
+    <string name="total_seen">Total vues</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fr/strings.xml
@@ -289,10 +289,8 @@
     <string name="netwepunknown_title">Inconnu</string>
     <string name="user_stats_app_name">Statistiques utilisateur</string>
     <string name="rank_title">Classement utilisateur :</string>
-    <string name="discovered_title">Réseaux WiFi découverts (nouveau pour WiGLE)</string>
     <string name="total_title">Total des réseaux WiFi vus</string>
     <string name="totallocs_title">Total des observations WiFi enregistrées</string>
-    <string name="gendisc_title">Tours cellulaires découvertes (nouvelles pour WiGLE)</string>
     <string name="gentotal_title">Total des tours cellulaires vues</string>
     <string name="monthcount_title">WiFi découverts ce mois</string>
     <string name="prevmonthcount_title">WiFi découverts le mois dernier</string>
@@ -422,4 +420,6 @@
     <string name="gpx_no_points">Le fichier d\'exportation de la route GPX serait vide.</string>
     <string name="gpx_preparing">Préparation de l\'exportation GPX</string>
     <string name="gpx_exporting">Exporter un fichier GPX.</string>
+    <string name="discovered">Ddécouverts</string>
+    <string name="new_to_us">(Nouveau sur WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fy/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fy/strings.xml
@@ -391,4 +391,5 @@
     <string name="gpx_exporting">GPX-bestân eksportearje.</string>
     <string name="discovered">Ontdekt</string>
     <string name="new_to_us">(Nieuw bij WiGLE)</string>
+    <string name="total_seen">Totaal gezien</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fy/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fy/strings.xml
@@ -389,4 +389,6 @@
     <string name="gpx_no_points">It eksportbestân fan de GPX-rûte soe leech wêze.</string>
     <string name="gpx_preparing">GPX-eksport tariede</string>
     <string name="gpx_exporting">GPX-bestân eksportearje.</string>
+    <string name="discovered">Ontdekt</string>
+    <string name="new_to_us">(Nieuw bij WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-he/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-he/strings.xml
@@ -289,9 +289,7 @@
     <string name="netwepunknown_title">לא ידוע</string>
     <string name="user_stats_app_name">סטטיסטיקות משתמש</string>
     <string name="rank_title">דירוג משתמש:</string>
-    <string name="total_title">סה"כ רשתות WiFi</string>
     <string name="totallocs_title">סה"כ תצפיות WiFi</string>
-    <string name="gentotal_title">סה"כ רשתות סלולריות</string>
     <string name="monthcount_title">התגלה החודש WiFi</string>
     <string name="prevmonthcount_title">WiFi התגלה בחודש שעבר</string>
     <string name="firsttransid_title">מזהה עסקה ראשון</string>
@@ -422,4 +420,5 @@
     <string name="gpx_exporting">מייצא קובץ GPX.</string>
     <string name="discovered">גילה</string>
     <string name="new_to_us">(חדשות ל- WiGLE)</string>
+    <string name="total_seen">סך הכל נצפה</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-he/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-he/strings.xml
@@ -289,10 +289,8 @@
     <string name="netwepunknown_title">לא ידוע</string>
     <string name="user_stats_app_name">סטטיסטיקות משתמש</string>
     <string name="rank_title">דירוג משתמש:</string>
-    <string name="discovered_title">רשתות WiFi נתגלו (חדשות ל- WiGLE)</string>
     <string name="total_title">סה"כ רשתות WiFi</string>
     <string name="totallocs_title">סה"כ תצפיות WiFi</string>
-    <string name="gendisc_title">רשתות סלולריות שהתגלו (חדשות ל- WiGLE)</string>
     <string name="gentotal_title">סה"כ רשתות סלולריות</string>
     <string name="monthcount_title">התגלה החודש WiFi</string>
     <string name="prevmonthcount_title">WiFi התגלה בחודש שעבר</string>
@@ -422,4 +420,6 @@
     <string name="gpx_no_points">קובץ הייצוא של מסלול GPX יהיה ריק.</string>
     <string name="gpx_preparing">מכין ייצוא של GPX</string>
     <string name="gpx_exporting">מייצא קובץ GPX.</string>
+    <string name="discovered">גילה</string>
+    <string name="new_to_us">(חדשות ל- WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hi/strings.xml
@@ -365,4 +365,6 @@
     <string name="gpx_no_points">GPX मार्ग निर्यात फ़ाइल खाली होगी।</string>
     <string name="gpx_preparing">GPX निर्यात तैयार करना</string>
     <string name="gpx_exporting">GPX फ़ाइल निर्यात कर रहा है।</string>
+    <string name="discovered">की खोज की</string>
+    <string name="new_to_us">(नए के लिए)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hi/strings.xml
@@ -367,4 +367,5 @@
     <string name="gpx_exporting">GPX फ़ाइल निर्यात कर रहा है।</string>
     <string name="discovered">की खोज की</string>
     <string name="new_to_us">(नए के लिए)</string>
+    <string name="total_seen">कुल देखा गया</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hu/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hu/strings.xml
@@ -369,4 +369,5 @@
     <string name="gpx_exporting">GPX fájl exportálása.</string>
     <string name="discovered">Felfedezett</string>
     <string name="new_to_us">(Új a WiGLE-ben)</string>
+    <string name="total_seen">Összesen megfigyelt</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hu/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hu/strings.xml
@@ -367,4 +367,6 @@
     <string name="gpx_no_points">A GPX útvonal-export fájl üres.</string>
     <string name="gpx_preparing">A GPX exportjának előkészítése</string>
     <string name="gpx_exporting">GPX fájl exportálása.</string>
+    <string name="discovered">Felfedezett</string>
+    <string name="new_to_us">(Új a WiGLE-ben)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-it/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-it/strings.xml
@@ -289,10 +289,8 @@
     <string name="netwepunknown_title">Sconosciuto</string>
     <string name="user_stats_app_name">Individuali</string>
     <string name="rank_title">Classifica utente:</string>
-    <string name="discovered_title">Reti WiFi Scoperte (Nuove per WiGLE)</string>
     <string name="total_title">Totale Reti WiFi Viste</string>
     <string name="totallocs_title">WiFi rilevate (compreso ripetute)</string>
-    <string name="gendisc_title">Torri GSM Scoperte (Nuove per WiGLE)</string>
     <string name="gentotal_title">Totale Torri GSM Viste</string>
     <string name="monthcount_title">WiFi Scoperte Questo Mese</string>
     <string name="prevmonthcount_title">WiFi Scoperte Lo Scorso Mese</string>
@@ -422,4 +420,6 @@
     <string name="gpx_no_points">Il file di esportazione della route GPX sarebbe vuoto.</string>
     <string name="gpx_preparing">Preparazione all\'esportazione GPX</string>
     <string name="gpx_exporting">Esportazione di file GPX.</string>
+    <string name="discovered">Scoperte</string>
+    <string name="new_to_us">(Nuove per WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-it/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-it/strings.xml
@@ -289,9 +289,7 @@
     <string name="netwepunknown_title">Sconosciuto</string>
     <string name="user_stats_app_name">Individuali</string>
     <string name="rank_title">Classifica utente:</string>
-    <string name="total_title">Totale Reti WiFi Viste</string>
     <string name="totallocs_title">WiFi rilevate (compreso ripetute)</string>
-    <string name="gentotal_title">Totale Torri GSM Viste</string>
     <string name="monthcount_title">WiFi Scoperte Questo Mese</string>
     <string name="prevmonthcount_title">WiFi Scoperte Lo Scorso Mese</string>
     <string name="firsttransid_title">ID Prima Transazione</string>
@@ -422,4 +420,5 @@
     <string name="gpx_exporting">Esportazione di file GPX.</string>
     <string name="discovered">Scoperte</string>
     <string name="new_to_us">(Nuove per WiGLE)</string>
+    <string name="total_seen">Totale osservato</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ja/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ja/strings.xml
@@ -289,9 +289,7 @@
     <string name="netwepunknown_title">Unknown</string>
     <string name="user_stats_app_name">ユーザー統計</string>
     <string name="rank_title">ユーザーランキング：</string>
-    <string name="total_title">見たWiFiネットワークの総数</string>
     <string name="totallocs_title">録画された全WiFi観測</string>
-    <string name="gentotal_title">見た総細胞ネットワーク</string>
     <string name="monthcount_title">今月発見されたWiFi</string>
     <string name="prevmonthcount_title">先月発見されたWiFi</string>
     <string name="firsttransid_title">最初のトランザクションID</string>
@@ -422,4 +420,5 @@
     <string name="gpx_exporting">GPXファイルをエクスポートしています。</string>
     <string name="discovered">発見された</string>
     <string name="new_to_us">（WiGLEの新機能)</string>
+    <string name="total_seen">観測合計</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ja/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ja/strings.xml
@@ -289,10 +289,8 @@
     <string name="netwepunknown_title">Unknown</string>
     <string name="user_stats_app_name">ユーザー統計</string>
     <string name="rank_title">ユーザーランキング：</string>
-    <string name="discovered_title">発見されたWiFiネットワーク（Wi-Fiの新機能）</string>
     <string name="total_title">見たWiFiネットワークの総数</string>
     <string name="totallocs_title">録画された全WiFi観測</string>
-    <string name="gendisc_title">発見されたセルネットワーク（WiGLEの新機能）</string>
     <string name="gentotal_title">見た総細胞ネットワーク</string>
     <string name="monthcount_title">今月発見されたWiFi</string>
     <string name="prevmonthcount_title">先月発見されたWiFi</string>
@@ -422,4 +420,6 @@
     <string name="gpx_no_points">GPXルートエクスポートファイルは空になります。</string>
     <string name="gpx_preparing">GPXエクスポートの準備</string>
     <string name="gpx_exporting">GPXファイルをエクスポートしています。</string>
+    <string name="discovered">発見された</string>
+    <string name="new_to_us">（WiGLEの新機能)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ko/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ko/strings.xml
@@ -367,4 +367,5 @@
     <string name="gpx_exporting">GPX 파일을 내보내는 중입니다.</string>
     <string name="discovered">발견</string>
     <string name="new_to_us">(WiGLE을 처음 사용함)</string>
+    <string name="total_seen">총 관찰</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ko/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ko/strings.xml
@@ -365,4 +365,6 @@
     <string name="gpx_no_points">GPX 경로 내보내기 파일이 비어 있습니다.</string>
     <string name="gpx_preparing">GPX 내보내기 준비</string>
     <string name="gpx_exporting">GPX 파일을 내보내는 중입니다.</string>
+    <string name="discovered">발견</string>
+    <string name="new_to_us">(WiGLE을 처음 사용함)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-nl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nl/strings.xml
@@ -400,4 +400,6 @@
     <string name="gpx_no_points">Het GPX-route-exportbestand zou leeg zijn.</string>
     <string name="gpx_preparing">GPX-export voorbereiden</string>
     <string name="gpx_exporting">GPX-bestand exporteren.</string>
+    <string name="discovered">Ontdekt</string>
+    <string name="new_to_us">(Nieuw bij WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-nl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nl/strings.xml
@@ -402,4 +402,5 @@
     <string name="gpx_exporting">GPX-bestand exporteren.</string>
     <string name="discovered">Ontdekt</string>
     <string name="new_to_us">(Nieuw bij WiGLE)</string>
+    <string name="total_seen">Totaal gezien</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-nn/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nn/strings.xml
@@ -289,9 +289,7 @@
     <string name="netwepunknown_title">Unknown</string>
     <string name="user_stats_app_name">User Statistics</string>
     <string name="rank_title">User Ranking:</string>
-    <string name="total_title">Total Wifi Networks Seen</string>
     <string name="totallocs_title">Total Wifi Observations Recorded</string>
-    <string name="gentotal_title">Total Cell Networks Seen</string>
     <string name="monthcount_title">Wifi Discovered This Month</string>
     <string name="prevmonthcount_title">Wifi Discovered Last Month</string>
     <string name="firsttransid_title">First Transaction ID</string>
@@ -400,4 +398,5 @@
     <string name="gpx_exporting">Eksporterer GPX-fil.</string>
     <string name="discovered">Oppdaget</string>
     <string name="new_to_us">(Ny hos WiGLE)</string>
+    <string name="total_seen">Totalt observert</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-nn/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nn/strings.xml
@@ -289,10 +289,8 @@
     <string name="netwepunknown_title">Unknown</string>
     <string name="user_stats_app_name">User Statistics</string>
     <string name="rank_title">User Ranking:</string>
-    <string name="discovered_title">Discovered Wifi Networks (New to WiGLE)</string>
     <string name="total_title">Total Wifi Networks Seen</string>
     <string name="totallocs_title">Total Wifi Observations Recorded</string>
-    <string name="gendisc_title">Discovered Cell Networks (New to WiGLE)</string>
     <string name="gentotal_title">Total Cell Networks Seen</string>
     <string name="monthcount_title">Wifi Discovered This Month</string>
     <string name="prevmonthcount_title">Wifi Discovered Last Month</string>
@@ -400,4 +398,6 @@
     <string name="gpx_no_points">GPX-ruteeksportfilen vil være tom.</string>
     <string name="gpx_preparing">Forbereder GPX-eksport</string>
     <string name="gpx_exporting">Eksporterer GPX-fil.</string>
+    <string name="discovered">Oppdaget</string>
+    <string name="new_to_us">(Ny hos WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-no/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-no/strings.xml
@@ -365,4 +365,6 @@
     <string name="gpx_no_points">GPX-ruteeksportfilen vil være tom.</string>
     <string name="gpx_preparing">Forbereder GPX-eksport</string>
     <string name="gpx_exporting">Eksporterer GPX-fil.</string>
+    <string name="discovered">Oppdaget</string>
+    <string name="new_to_us">(Ny hos WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-no/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-no/strings.xml
@@ -367,4 +367,5 @@
     <string name="gpx_exporting">Eksporterer GPX-fil.</string>
     <string name="discovered">Oppdaget</string>
     <string name="new_to_us">(Ny hos WiGLE)</string>
+    <string name="total_seen">Totalt observert</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pl/strings.xml
@@ -365,4 +365,6 @@
     <string name="gpx_no_points">Plik eksportu trasy GPX byłby pusty.</string>
     <string name="gpx_preparing">Przygotowywanie eksportu GPX</string>
     <string name="gpx_exporting">Eksportowanie pliku GPX.</string>
+    <string name="discovered">Odkryte</string>
+    <string name="new_to_us">(Nowy w WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pl/strings.xml
@@ -367,4 +367,5 @@
     <string name="gpx_exporting">Eksportowanie pliku GPX.</string>
     <string name="discovered">Odkryte</string>
     <string name="new_to_us">(Nowy w WiGLE)</string>
+    <string name="total_seen">Łącznie zaobserwowane</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
@@ -380,4 +380,5 @@
     <string name="gpx_exporting">Exportando arquivo GPX.</string>
     <string name="discovered">Descobertas</string>
     <string name="new_to_us">(Novo no WiGLE)</string>
+    <string name="total_seen">Total observado</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
@@ -378,4 +378,6 @@
     <string name="gpx_no_points">O arquivo de exportação de rota GPX estaria vazio.</string>
     <string name="gpx_preparing">Preparando a exportação GPX</string>
     <string name="gpx_exporting">Exportando arquivo GPX.</string>
+    <string name="discovered">Descobertas</string>
+    <string name="new_to_us">(Novo no WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt/strings.xml
@@ -365,4 +365,6 @@
     <string name="gpx_no_points">O arquivo de exportação de rota GPX estaria vazio.</string>
     <string name="gpx_preparing">Preparando a exportação GPX</string>
     <string name="gpx_exporting">Exportando arquivo GPX.</string>
+    <string name="discovered">Descobertas</string>
+    <string name="new_to_us">(Novo no WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt/strings.xml
@@ -367,4 +367,5 @@
     <string name="gpx_exporting">Exportando arquivo GPX.</string>
     <string name="discovered">Descobertas</string>
     <string name="new_to_us">(Novo no WiGLE)</string>
+    <string name="total_seen">Total observado</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ru/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ru/strings.xml
@@ -379,4 +379,5 @@
     <string name="gpx_exporting">Экспорт файла GPX.</string>
     <string name="discovered">открытый</string>
     <string name="new_to_us">(Новое в WiGLE)</string>
+    <string name="total_seen">Всего наблюдено</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ru/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ru/strings.xml
@@ -377,4 +377,6 @@
     <string name="gpx_no_points">Файл экспорта маршрута GPX будет пустым.</string>
     <string name="gpx_preparing">Подготовка экспорта GPX</string>
     <string name="gpx_exporting">Экспорт файла GPX.</string>
+    <string name="discovered">открытый</string>
+    <string name="new_to_us">(Новое в WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-sv/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-sv/strings.xml
@@ -367,4 +367,5 @@
     <string name="gpx_exporting">Exporterar GPX-fil.</string>
     <string name="discovered">Upptäckt</string>
     <string name="new_to_us">(Nytt för WiGLE)</string>
+    <string name="total_seen">Totalt observerat</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-sv/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-sv/strings.xml
@@ -365,4 +365,6 @@
     <string name="gpx_no_points">GPX-ruttexportfilen skulle vara tom.</string>
     <string name="gpx_preparing">Förbereder GPX-export</string>
     <string name="gpx_exporting">Exporterar GPX-fil.</string>
+    <string name="discovered">Upptäckt</string>
+    <string name="new_to_us">(Nytt för WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-tr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-tr/strings.xml
@@ -365,4 +365,6 @@
     <string name="gpx_no_points">GPX yolu dışa aktarma dosyası boş olacaktı.</string>
     <string name="gpx_preparing">GPX ihracatını hazırlama</string>
     <string name="gpx_exporting">GPX dosyasını dışa aktarma.</string>
+    <string name="discovered">Bulundu</string>
+    <string name="new_to_us">(WiGLE’de yeni)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-tr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-tr/strings.xml
@@ -367,4 +367,5 @@
     <string name="gpx_exporting">GPX dosyasını dışa aktarma.</string>
     <string name="discovered">Bulundu</string>
     <string name="new_to_us">(WiGLE’de yeni)</string>
+    <string name="total_seen">Toplam Gözlenen</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rCN/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rCN/strings.xml
@@ -289,9 +289,7 @@
     <string name="netwepunknown_title">未知</string>
     <string name="user_stats_app_name">用户统计</string>
     <string name="rank_title">用户排名</string>
-    <string name="total_title">看到全部WiFi网络</string>
     <string name="totallocs_title">录制的WiFi观测总数</string>
-    <string name="gentotal_title">看到的全部单元网络</string>
     <string name="monthcount_title">本月发现WiFi</string>
     <string name="prevmonthcount_title">上个月发现WiFi</string>
     <string name="firsttransid_title">第一个交易ID</string>
@@ -422,4 +420,5 @@
     <string name="gpx_exporting">导出GPX文件。</string>
     <string name="discovered">发现</string>
     <string name="new_to_us">（WiGLE新手)</string>
+    <string name="total_seen">观察总数</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rCN/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rCN/strings.xml
@@ -289,10 +289,8 @@
     <string name="netwepunknown_title">未知</string>
     <string name="user_stats_app_name">用户统计</string>
     <string name="rank_title">用户排名</string>
-    <string name="discovered_title">发现的WiFi网络（WiGLE新手）</string>
     <string name="total_title">看到全部WiFi网络</string>
     <string name="totallocs_title">录制的WiFi观测总数</string>
-    <string name="gendisc_title">已发现的Cell Networks（WiGLE新手</string>
     <string name="gentotal_title">看到的全部单元网络</string>
     <string name="monthcount_title">本月发现WiFi</string>
     <string name="prevmonthcount_title">上个月发现WiFi</string>
@@ -422,4 +420,6 @@
     <string name="gpx_no_points">GPX路由导出文件将为空。</string>
     <string name="gpx_preparing">准备GPX导出</string>
     <string name="gpx_exporting">导出GPX文件。</string>
+    <string name="discovered">发现</string>
+    <string name="new_to_us">（WiGLE新手)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rHK/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rHK/strings.xml
@@ -289,10 +289,8 @@
     <string name="netwepunknown_title">Unknown</string>
     <string name="user_stats_app_name">用户统计</string>
     <string name="rank_title">用户排名</string>
-    <string name="discovered_title">发现的WiFi网络（WiGLE新手）</string>
     <string name="total_title">看到全部WiFi网络</string>
     <string name="totallocs_title">录制的WiFi观测总数</string>
-    <string name="gendisc_title">已发现的Cell Networks（WiGLE新手</string>
     <string name="gentotal_title">看到的全部单元网络</string>
     <string name="monthcount_title">本月发现WiFi</string>
     <string name="prevmonthcount_title">上个月发现WiFi</string>
@@ -413,7 +411,6 @@
     <string name="no_external_space_title">沒有可用空間</string>
     <string name="no_external_space_message">您的設備上沒有足夠的外部應用程序存儲空間。</string>
     <string name="no_mxc_space_message">您的設備上沒有足夠的內部應用程序存儲來安裝單元操作員查找數據庫。將使用設備提供的ID。</string>
-
     <string name="enable_route_logging">記錄執行路徑</string>
     <string name="enable_route_map_display">顯示執行路線</string>
     <string name="export_gpx_button">導出GPX</string>
@@ -423,4 +420,6 @@
     <string name="gpx_no_points">GPX路由導出文件將為空。</string>
     <string name="gpx_preparing">準備GPX導出</string>
     <string name="gpx_exporting">導出GPX文件。</string>
+    <string name="discovered">發現</string>
+    <string name="new_to_us">（WiGLE新手）</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rHK/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rHK/strings.xml
@@ -289,9 +289,7 @@
     <string name="netwepunknown_title">Unknown</string>
     <string name="user_stats_app_name">用户统计</string>
     <string name="rank_title">用户排名</string>
-    <string name="total_title">看到全部WiFi网络</string>
     <string name="totallocs_title">录制的WiFi观测总数</string>
-    <string name="gentotal_title">看到的全部单元网络</string>
     <string name="monthcount_title">本月发现WiFi</string>
     <string name="prevmonthcount_title">上个月发现WiFi</string>
     <string name="firsttransid_title">第一个交易ID</string>
@@ -422,4 +420,5 @@
     <string name="gpx_exporting">導出GPX文件。</string>
     <string name="discovered">發現</string>
     <string name="new_to_us">（WiGLE新手）</string>
+    <string name="total_seen">觀察總數</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rTW/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rTW/strings.xml
@@ -289,10 +289,8 @@
     <string name="netwepunknown_title">Unknown</string>
     <string name="user_stats_app_name">用户统计</string>
     <string name="rank_title">用户排名</string>
-    <string name="discovered_title">发现的WiFi网络（WiGLE新手）</string>
     <string name="total_title">看到全部WiFi网络</string>
     <string name="totallocs_title">录制的WiFi观测总数</string>
-    <string name="gendisc_title">已发现的Cell Networks（WiGLE新手</string>
     <string name="gentotal_title">看到的全部单元网络</string>
     <string name="monthcount_title">本月发现WiFi</string>
     <string name="prevmonthcount_title">上个月发现WiFi</string>
@@ -413,7 +411,6 @@
     <string name="no_external_space_title">沒有可用空間</string>
     <string name="no_external_space_message">您的設備上沒有足夠的外部應用程序存儲空間。</string>
     <string name="no_mxc_space_message">您的設備上沒有足夠的內部應用程序存儲來安裝單元操作員查找數據庫。將使用設備提供的ID。</string>
-
     <string name="enable_route_logging">記錄執行路徑</string>
     <string name="enable_route_map_display">顯示執行路線</string>
     <string name="export_gpx_button">導出GPX</string>
@@ -423,4 +420,6 @@
     <string name="gpx_no_points">GPX路由導出文件將為空。</string>
     <string name="gpx_preparing">準備GPX導出</string>
     <string name="gpx_exporting">導出GPX文件。</string>
+    <string name="discovered">發現</string>
+    <string name="new_to_us">（WiGLE新手）</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rTW/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rTW/strings.xml
@@ -289,9 +289,7 @@
     <string name="netwepunknown_title">Unknown</string>
     <string name="user_stats_app_name">用户统计</string>
     <string name="rank_title">用户排名</string>
-    <string name="total_title">看到全部WiFi网络</string>
     <string name="totallocs_title">录制的WiFi观测总数</string>
-    <string name="gentotal_title">看到的全部单元网络</string>
     <string name="monthcount_title">本月发现WiFi</string>
     <string name="prevmonthcount_title">上个月发现WiFi</string>
     <string name="firsttransid_title">第一个交易ID</string>
@@ -422,4 +420,5 @@
     <string name="gpx_exporting">導出GPX文件。</string>
     <string name="discovered">發現</string>
     <string name="new_to_us">（WiGLE新手）</string>
+    <string name="total_seen">觀察總數</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh/strings.xml
@@ -289,9 +289,7 @@
     <string name="netwepunknown_title">未知</string>
     <string name="user_stats_app_name">用户统计</string>
     <string name="rank_title">用户排名</string>
-    <string name="total_title">看到全部WiFi网络</string>
     <string name="totallocs_title">录制的WiFi观测总数</string>
-    <string name="gentotal_title">看到的全部单元网络</string>
     <string name="monthcount_title">本月发现WiFi</string>
     <string name="prevmonthcount_title">上个月发现WiFi</string>
     <string name="firsttransid_title">第一个交易ID</string>
@@ -422,4 +420,5 @@
     <string name="gpx_exporting">导出GPX文件。</string>
     <string name="discovered">发现</string>
     <string name="new_to_us">（WiGLE新手)</string>
+    <string name="total_seen">观察总数</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh/strings.xml
@@ -289,10 +289,8 @@
     <string name="netwepunknown_title">未知</string>
     <string name="user_stats_app_name">用户统计</string>
     <string name="rank_title">用户排名</string>
-    <string name="discovered_title">发现的WiFi网络（WiGLE新手）</string>
     <string name="total_title">看到全部WiFi网络</string>
     <string name="totallocs_title">录制的WiFi观测总数</string>
-    <string name="gendisc_title">已发现的Cell Networks（WiGLE新手</string>
     <string name="gentotal_title">看到的全部单元网络</string>
     <string name="monthcount_title">本月发现WiFi</string>
     <string name="prevmonthcount_title">上个月发现WiFi</string>
@@ -422,4 +420,6 @@
     <string name="gpx_no_points">GPX路由导出文件将为空。</string>
     <string name="gpx_preparing">准备GPX导出</string>
     <string name="gpx_exporting">导出GPX文件。</string>
+    <string name="discovered">发现</string>
+    <string name="new_to_us">（WiGLE新手)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values/strings.xml
@@ -290,9 +290,7 @@
     <string name="netwepunknown_title">Unknown</string>
     <string name="user_stats_app_name">User Statistics</string>
     <string name="rank_title">User Ranking:</string>
-    <string name="total_title">Total WiFi Networks Seen</string>
     <string name="totallocs_title">Total WiFi Observations Recorded</string>
-    <string name="gentotal_title">Total Cell Networks Seen</string>
     <string name="monthcount_title">WiFi Discovered This Month</string>
     <string name="prevmonthcount_title">WiFi Discovered Last Month</string>
     <string name="firsttransid_title">First Transaction ID</string>
@@ -411,7 +409,6 @@
     <string name="calculating_m8b">Calculating oracle</string>
     <string name="bt_gps">BT GPS</string>
     <string name="btloc_title">WiGLE.net Bluetooth Devices with Location</string>
-    <string name="bttotal_title">Total Bluetooth Devices Seen</string>
     <string name="total_bt">Total Bluetooth</string>
     <string name="menu_debug">Debug</string>
     <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
@@ -434,4 +431,5 @@
     <string name="gpx_exporting">Exporting GPX file.</string>
     <string name="discovered">Discovered</string>
     <string name="new_to_us">(New to WiGLE)</string>
+    <string name="total_seen">Total Seen</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values/strings.xml
@@ -290,10 +290,8 @@
     <string name="netwepunknown_title">Unknown</string>
     <string name="user_stats_app_name">User Statistics</string>
     <string name="rank_title">User Ranking:</string>
-    <string name="discovered_title">Discovered WiFi Networks (New to WiGLE)</string>
     <string name="total_title">Total WiFi Networks Seen</string>
     <string name="totallocs_title">Total WiFi Observations Recorded</string>
-    <string name="gendisc_title">Discovered Cell Networks (New to WiGLE)</string>
     <string name="gentotal_title">Total Cell Networks Seen</string>
     <string name="monthcount_title">WiFi Discovered This Month</string>
     <string name="prevmonthcount_title">WiFi Discovered Last Month</string>
@@ -413,7 +411,6 @@
     <string name="calculating_m8b">Calculating oracle</string>
     <string name="bt_gps">BT GPS</string>
     <string name="btloc_title">WiGLE.net Bluetooth Devices with Location</string>
-    <string name="btdisc_title">Discovered Bluetooth Devices (New to WiGLE)</string>
     <string name="bttotal_title">Total Bluetooth Devices Seen</string>
     <string name="total_bt">Total Bluetooth</string>
     <string name="menu_debug">Debug</string>
@@ -435,4 +432,6 @@
     <string name="gpx_no_points">The GPX route export file would be empty.</string>
     <string name="gpx_preparing">Preparing GPX export</string>
     <string name="gpx_exporting">Exporting GPX file.</string>
+    <string name="discovered">Discovered</string>
+    <string name="new_to_us">(New to WiGLE)</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values/styles.xml
+++ b/wiglewifiwardriving/src/main/res/values/styles.xml
@@ -30,6 +30,9 @@
     <style name="SmallStats" parent="TextAppearance.AppCompat.Small">
         <item name="android:textColor">#B0B0B0</item>
     </style>
+    <style name="FgStatColor" parent="TextAppearance.AppCompat">
+        <item name="android:textColor">#E0E0E0</item>
+    </style>
     <style name="UserNameColor" parent="TextAppearance.AppCompat">
         <item name="android:textColor">#4aceff</item>
     </style>

--- a/wiglewifiwardriving/src/main/res/values/styles.xml
+++ b/wiglewifiwardriving/src/main/res/values/styles.xml
@@ -31,7 +31,7 @@
         <item name="android:textColor">#B0B0B0</item>
     </style>
     <style name="FgStatColor" parent="TextAppearance.AppCompat">
-        <item name="android:textColor">#E0E0E0</item>
+        <item name="android:textColor">#E0E0F0</item>
     </style>
     <style name="UserNameColor" parent="TextAppearance.AppCompat">
         <item name="android:textColor">#4aceff</item>


### PR DESCRIPTION
as a frequent viewer of the user stats page, it was hard to read at a glance.

- updated "discovered" and "seen" entries for WiFi/BT/Cell into organized horizontal bars
- used WiGLE icons and style colors to help improve readability
- text heavy format was bad for responsive layout/translation
- many translations were absent for the existing text-heavy presentation

future directions:

- observations should be a section as well, but we don't condense cell and BT in the same way as wifi, so this is a half-measure until we add those stats.
- this/last month should be a section, but the API doesn't publish those yet