### PR TITLE
[ENH] Centralize FileSystem access - refactor refactor in preparation for Android R

### DIFF
--- a/wiglewifiwardriving/build.gradle
+++ b/wiglewifiwardriving/build.gradle
@@ -71,6 +71,7 @@ dependencies {
     implementation 'ru.egslava:MaskedEditText:1.0.5'
     implementation 'uk.co.alt236:bluetooth-le-library-android:1.0.0'
     implementation 'com.goebl:simplify:1.0.0'
+    implementation 'commons-io:commons-io:2.6'
     //TODO: MinAPI issue: implementation 'com.babylon.certificatetransparency:certificatetransparency-android:0.2.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'androidx.test:core:1.2.0'

--- a/wiglewifiwardriving/src/main/AndroidManifest.xml
+++ b/wiglewifiwardriving/src/main/AndroidManifest.xml
@@ -206,6 +206,7 @@
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value=".MainActivity" />
         </activity>
+        <!-- here at WiGLE, we give you ALL the file types! -->
         <provider
             android:name=".util.KmlFileProvider"
             android:authorities="${applicationId}.kmlprovider"
@@ -241,6 +242,15 @@
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/sqlite_paths" />
+        </provider>
+        <provider
+            android:name=".util.CsvGzFileProvider"
+            android:authorities="${applicationId}.csvgzprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/csvgz_paths" />
         </provider>
         <receiver android:name=".listener.TerminationReceiver" >
             <intent-filter>

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
@@ -61,9 +61,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import static net.wigle.wigleandroid.ListFragment.PREF_LOG_ROUTES;
-import static net.wigle.wigleandroid.util.FileUtility.GPX_DIR;
 import static net.wigle.wigleandroid.util.FileUtility.GPX_EXT;
-import static net.wigle.wigleandroid.util.FileUtility.M8B_DIR;
 import static net.wigle.wigleandroid.util.FileUtility.M8B_EXT;
 import static net.wigle.wigleandroid.util.FileUtility.M8B_FILE_PREFIX;
 
@@ -230,12 +228,15 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
     }
 
     private void setupBackupDbButton( final View view ) {
-        final Button kmlExportButton = view.findViewById( R.id.backup_db_button );
+        final Button dbBackupButton = view.findViewById( R.id.backup_db_button );
+
+        //TODO: there's a question here: if the backupDb option shouldn't be used w/out SD
+        //  should we also disable the export to KML/CSV options, since they'll certainly be larger?
         if ( ! FileUtility.hasSD() ) {
-            kmlExportButton.setEnabled(false);
+            dbBackupButton.setEnabled(false);
         }
 
-        kmlExportButton.setOnClickListener( new OnClickListener() {
+        dbBackupButton.setOnClickListener( new OnClickListener() {
             @Override
             public void onClick( final View buttonView ) {
                 final FragmentActivity fa = getActivity();
@@ -769,28 +770,34 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
 
             try {
                 if ( hasSD ) {
-                    final String basePath = MainActivity.safeFilePath(
-                            Environment.getExternalStorageDirectory() ) + M8B_DIR;
-                    final File path = new File( basePath );
-                    //noinspection ResultOfMethodCallIgnored
-                    path.mkdirs();
-                    if (!path.exists()) {
-                        MainActivity.info("Got '!exists': " + path);
+                    final String basePath = FileUtility.getM8bPath();
+                    if (null != basePath) {
+                        final File path = new File( basePath );
+                        //noinspection ResultOfMethodCallIgnored
+                        path.mkdirs();
+                        if (!path.exists()) {
+                            MainActivity.info("Got '!exists': " + path);
+                        }
+                        String openString = basePath + M8B_FILE_PREFIX +  M8B_EXT;
+                        //DEBUG: MainActivity.info("Opening file: " + openString);
+                        m8bDestFile = new File( openString );
+                    } else {
+                        MainActivity.error("Unable to determine m8b output base path.");
+                        return "ERROR";
                     }
-                    String openString = basePath + M8B_FILE_PREFIX +  M8B_EXT;
-                    //DEBUG: MainActivity.info("Opening file: " + openString);
-                    m8bDestFile = new File( openString );
-
                 } else {
-                    m8bDestFile = new File(getActivity().getApplication().getFilesDir(),
+                    Activity a = getActivity();
+                    if (a == null) {
+                        return "ERROR";
+                    }
+                    m8bDestFile = new File(a.getApplication().getFilesDir(),
                             M8B_FILE_PREFIX + M8B_EXT);
                 }
                 //ALIBI: always start fresh
-                boolean append = false;
-                out = new FileOutputStream(m8bDestFile, append).getChannel();
+                out = new FileOutputStream(m8bDestFile, false).getChannel();
 
             } catch (IOException ioex) {
-                MainActivity.error("Unable to open ouput: ", ioex);
+                MainActivity.error("Unable to open output: ", ioex);
                 return "ERROR";
             }
 
@@ -1000,8 +1007,11 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
 
             try {
                 if ( hasSD ) {
-                    final String basePath = MainActivity.safeFilePath(
-                            Environment.getExternalStorageDirectory() ) + GPX_DIR;
+                    final String basePath = FileUtility.getGpxPath();
+                    if (null == basePath) {
+                        MainActivity.error("Unable to determine external GPX path");
+                        return null;
+                    }
                     final File path = new File( basePath );
                     //noinspection ResultOfMethodCallIgnored
                     path.mkdirs();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
@@ -10,13 +10,17 @@ import net.wigle.wigleandroid.background.QueryThread;
 import net.wigle.wigleandroid.background.TransferListener;
 import net.wigle.wigleandroid.background.KmlWriter;
 import net.wigle.wigleandroid.db.DBException;
+import net.wigle.wigleandroid.db.DatabaseHelper;
 import net.wigle.wigleandroid.model.Pair;
 import net.wigle.wigleandroid.ui.WiGLEToast;
+import net.wigle.wigleandroid.util.FileUtility;
 import net.wigle.wigleandroid.util.MagicEightUtil;
 import net.wigle.wigleandroid.util.SearchUtil;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
@@ -29,6 +33,8 @@ import android.os.Bundle;
 import android.os.Environment;
 import androidx.fragment.app.Fragment;
 import androidx.core.content.FileProvider;
+import androidx.fragment.app.FragmentActivity;
+
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -55,6 +61,11 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import static net.wigle.wigleandroid.ListFragment.PREF_LOG_ROUTES;
+import static net.wigle.wigleandroid.util.FileUtility.GPX_DIR;
+import static net.wigle.wigleandroid.util.FileUtility.GPX_EXT;
+import static net.wigle.wigleandroid.util.FileUtility.M8B_DIR;
+import static net.wigle.wigleandroid.util.FileUtility.M8B_EXT;
+import static net.wigle.wigleandroid.util.FileUtility.M8B_FILE_PREFIX;
 
 /**
  * configure settings
@@ -75,29 +86,25 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
 
     // constants for Magic (8) Ball export
     //private static final String M8B_SEP = "|";
-    private static final String M8B_FILE_PREFIX = "export";
-    //private static final String M8B_SOURCE_EXTENSION = ".m8bs";
-    private static final String M8B_DIR = "/wiglewifi/m8b/";
-    private static final String M8B_EXTENSION = ".m8b";
     private static final int SLICE_BITS = 30;
 
-    private static final String GPX_DIR = "/wiglewifi/gpx/";
-    private static final String GPX_EXTENSION = ".gpx";
     private final static String GPX_HEADER_A = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?><gpx xmlns=\"http://www.topografix.com/GPX/1/1\" creator=\"";
     private final static String GPX_HEADER_B ="\" version=\"1.1\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"  xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd\"><trk>\n";
     private final static String GPX_FOOTER = "</trkseg></trk></gpx>";
 
 
-    ProgressDialog pd = null;
+    private ProgressDialog pd = null;
     /** Called when the activity is first created. */
     @Override
     public void onCreate( final Bundle savedInstanceState) {
         super.onCreate( savedInstanceState );
         // set language
-        MainActivity.setLocale( getActivity() );
-
-        // force media volume controls
-        getActivity().setVolumeControlStream( AudioManager.STREAM_MUSIC );
+        Activity a = getActivity();
+        if (null != a) {
+            MainActivity.setLocale(getActivity());
+            // force media volume controls
+            a.setVolumeControlStream( AudioManager.STREAM_MUSIC );
+        }
     }
 
     @Override
@@ -116,7 +123,7 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
     }
 
     private void setupQueryButtons( final View view ) {
-        Button button = (Button) view.findViewById( R.id.search_button );
+        Button button = view.findViewById( R.id.search_button );
         button.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(final View buttonView) {
@@ -136,7 +143,7 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
             }
         });
 
-        button = (Button) view.findViewById( R.id.reset_button );
+        button = view.findViewById( R.id.reset_button );
         button.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(final View buttonView) {
@@ -163,64 +170,96 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
     private void setupCsvButtons( final View view ) {
         // actually need this Activity context, for dialogs
 
-        final Button csvRunExportButton = (Button) view.findViewById( R.id.csv_run_export_button );
+        final Button csvRunExportButton = view.findViewById( R.id.csv_run_export_button );
         csvRunExportButton.setOnClickListener( new OnClickListener() {
             @Override
             public void onClick( final View buttonView ) {
-                MainActivity.createConfirmation( getActivity(),
-                        DataFragment.this.getString(R.string.data_export_csv), R.id.nav_data, CSV_RUN_DIALOG);
+                final FragmentActivity fa = getActivity();
+                if (fa != null) {
+                    MainActivity.createConfirmation(fa,
+                            DataFragment.this.getString(R.string.data_export_csv), R.id.nav_data, CSV_RUN_DIALOG);
+                } else {
+                    MainActivity.error("Null FragmentActivity setting up CSV run export button");
+                }
             }
         });
 
-        final Button csvExportButton = (Button) view.findViewById( R.id.csv_export_button );
+        final Button csvExportButton = view.findViewById( R.id.csv_export_button );
         csvExportButton.setOnClickListener( new OnClickListener() {
             @Override
             public void onClick( final View buttonView ) {
-                MainActivity.createConfirmation( getActivity(),
+                final FragmentActivity fa = getActivity();
+                if (fa != null) {
+                    MainActivity.createConfirmation( fa,
                         DataFragment.this.getString(R.string.data_export_csv_db), R.id.nav_data, CSV_DB_DIALOG);
+                } else {
+                    MainActivity.error("Null FragmentActivity setting up CSV export button");
+                }
             }
         });
     }
 
     private void setupKmlButtons( final View view ) {
-        final Button kmlRunExportButton = (Button) view.findViewById( R.id.kml_run_export_button );
+        final Button kmlRunExportButton = view.findViewById( R.id.kml_run_export_button );
         kmlRunExportButton.setOnClickListener( new OnClickListener() {
             @Override
             public void onClick( final View buttonView ) {
-                MainActivity.createConfirmation( getActivity(),
+                final FragmentActivity fa = getActivity();
+                if (fa != null) {
+                    MainActivity.createConfirmation( fa,
                         DataFragment.this.getString(R.string.data_export_kml_run), R.id.nav_data, KML_RUN_DIALOG);
+                } else {
+                    MainActivity.error("Null FragmentActivity setting up KML run export button");
+                }
             }
         });
 
-        final Button kmlExportButton = (Button) view.findViewById( R.id.kml_export_button );
+        final Button kmlExportButton = view.findViewById( R.id.kml_export_button );
         kmlExportButton.setOnClickListener( new OnClickListener() {
             @Override
             public void onClick( final View buttonView ) {
-                MainActivity.createConfirmation( getActivity(),
+                final FragmentActivity fa = getActivity();
+                if (fa != null) {
+                    MainActivity.createConfirmation( fa,
                         DataFragment.this.getString(R.string.data_export_kml_db), R.id.nav_data, KML_DB_DIALOG);
+                } else {
+                    MainActivity.error("Null FragmentActivity setting up KML export button");
+                }
             }
         });
     }
 
     private void setupBackupDbButton( final View view ) {
-        final Button kmlExportButton = (Button) view.findViewById( R.id.backup_db_button );
-        if ( ! MainActivity.hasSD() ) {
+        final Button kmlExportButton = view.findViewById( R.id.backup_db_button );
+        if ( ! FileUtility.hasSD() ) {
             kmlExportButton.setEnabled(false);
         }
 
         kmlExportButton.setOnClickListener( new OnClickListener() {
             @Override
             public void onClick( final View buttonView ) {
-                MainActivity.createConfirmation( getActivity(),
+                final FragmentActivity fa = getActivity();
+                if (fa != null) {
+                    MainActivity.createConfirmation( fa,
                         DataFragment.this.getString(R.string.data_backup_db), R.id.nav_data, BACKUP_DIALOG);
+                } else {
+                    MainActivity.error("Null FragmentActivity setting up backup confirmation");
+                }
             }
         });
     }
 
     private void setupImportObservedButton( final View view ) {
-        final Button importObservedButton = (Button) view.findViewById( R.id.import_observed_button );
-        final SharedPreferences prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
-        final String authname = prefs.getString(ListFragment.PREF_AUTHNAME, null);
+        final Button importObservedButton = view.findViewById( R.id.import_observed_button );
+        SharedPreferences prefs = null;
+        Activity a = getActivity();
+        if (null != a) {
+            prefs = a.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+        }
+        String authname = null;
+        if (prefs != null) {
+            authname = prefs.getString(ListFragment.PREF_AUTHNAME, null);
+        }
 
         if (null == authname) {
             importObservedButton.setEnabled(false);
@@ -230,9 +269,14 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
         importObservedButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(final View buttonView) {
-                MainActivity.createConfirmation(getActivity(),
-                        DataFragment.this.getString(R.string.data_import_observed),
-                        R.id.nav_data, IMPORT_DIALOG);
+                final FragmentActivity fa = getActivity();
+                if (null != fa) {
+                    MainActivity.createConfirmation(fa,
+                            DataFragment.this.getString(R.string.data_import_observed),
+                            R.id.nav_data, IMPORT_DIALOG);
+                } else {
+                    MainActivity.error("unable to get fragment activity");
+                }
             }
         });
     }
@@ -269,71 +313,107 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
 
     @SuppressLint("SetTextI18n")
     private void setupMarkerButtons( final View view ) {
-        final SharedPreferences prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+        SharedPreferences prefs = null;
+        final Activity a = getActivity();
+        if (null != a) {
+            prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+        }
 
         // db marker reset button and text
-        final TextView tv = (TextView) view.findViewById(R.id.reset_maxid_text);
-        tv.setText( getString(R.string.setting_high_up) + " " + prefs.getLong( ListFragment.PREF_DB_MARKER, 0L ) );
+        final TextView tv = view.findViewById(R.id.reset_maxid_text);
+        if (null != prefs) {
+            tv.setText(getString(R.string.setting_high_up) + " " + prefs.getLong(ListFragment.PREF_DB_MARKER, 0L));
+        }
 
-        final Button resetMaxidButton = (Button) view.findViewById(R.id.reset_maxid_button);
+        final Button resetMaxidButton = view.findViewById(R.id.reset_maxid_button);
         resetMaxidButton.setOnClickListener( new OnClickListener() {
             @Override
             public void onClick( final View buttonView ) {
-                MainActivity.createConfirmation( getActivity(), getString(R.string.setting_zero_out),
-                        R.id.nav_data, ZERO_OUT_DIALOG);
+                final FragmentActivity fa = getActivity();
+                if (null != fa) {
+                    MainActivity.createConfirmation(fa, getString(R.string.setting_zero_out),
+                            R.id.nav_data, ZERO_OUT_DIALOG);
+                } else {
+                    MainActivity.error("unable to get fragment activity");
+                }
             }
         });
 
         // db marker maxout button and text
-        final TextView maxtv = (TextView) view.findViewById(R.id.maxout_maxid_text);
-        final long maxDB = prefs.getLong( ListFragment.PREF_MAX_DB, 0L );
-        maxtv.setText( getString(R.string.setting_max_start) + " " + maxDB );
+        if (null != prefs) {
+            final TextView maxtv = view.findViewById(R.id.maxout_maxid_text);
+            final long maxDB = prefs.getLong(ListFragment.PREF_MAX_DB, 0L);
+            maxtv.setText(getString(R.string.setting_max_start) + " " + maxDB);
+        }
 
-        final Button maxoutMaxidButton = (Button) view.findViewById(R.id.maxout_maxid_button);
+        final Button maxoutMaxidButton = view.findViewById(R.id.maxout_maxid_button);
         maxoutMaxidButton.setOnClickListener( new OnClickListener() {
             @Override
             public void onClick( final View buttonView ) {
-                MainActivity.createConfirmation( getActivity(), getString(R.string.setting_max_out),
-                        R.id.nav_data, MAX_OUT_DIALOG);
+                final FragmentActivity fa = getActivity();
+                if (null != fa) {
+                    MainActivity.createConfirmation(fa, getString(R.string.setting_max_out),
+                            R.id.nav_data, MAX_OUT_DIALOG);
+                } else {
+                    MainActivity.error("unable to get fragment activity");
+                }
             }
         } );
 
         //ALIBI: not technically a marker button, but clearly belongs with them visually/logically
-        final Button deleteDbButton = (Button) view.findViewById(R.id.clear_db);
+        final Button deleteDbButton = view.findViewById(R.id.clear_db);
         deleteDbButton.setOnClickListener( new OnClickListener() {
             @Override
             public void onClick( final View buttonView ) {
-                MainActivity.createConfirmation( getActivity(), getString(R.string.delete_db_confirm),
-                        R.id.nav_data, DELETE_DIALOG);
+                final FragmentActivity fa = getActivity();
+                if (null != fa) {
+                    MainActivity.createConfirmation(fa, getString(R.string.delete_db_confirm),
+                            R.id.nav_data, DELETE_DIALOG);
+                } else {
+                    MainActivity.error("unable to get fragment activity");
+                }
             }
         } );
 
     }
 
-    public void setupGpxExport( final View view ) {
-        final SharedPreferences prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
-        //ONLY ENABLE IF WE ARE LOGGING
-        if (prefs.getBoolean(PREF_LOG_ROUTES, false)) {
-            final View exportGpxTools = view.findViewById(R.id.export_gpx_tools);
-            exportGpxTools.setVisibility(View.VISIBLE);
-            final Button exportGpxButton = view.findViewById(R.id.export_gpx_button);
-            exportGpxButton.setOnClickListener(new OnClickListener() {
-                @Override
-                public void onClick(final View buttonView) {
-                    MainActivity.createConfirmation(getActivity(), getString(R.string.export_gpx_detail),
-                            R.id.nav_data, EXPORT_GPX_DIALOG);
-                }
-            });
+    private void setupGpxExport( final View view ) {
+        final Activity a = getActivity();
+        if (a != null) {
+            final SharedPreferences prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+            //ONLY ENABLE IF WE ARE LOGGING
+            if (prefs.getBoolean(PREF_LOG_ROUTES, false)) {
+                final View exportGpxTools = view.findViewById(R.id.export_gpx_tools);
+                exportGpxTools.setVisibility(View.VISIBLE);
+                final Button exportGpxButton = view.findViewById(R.id.export_gpx_button);
+                exportGpxButton.setOnClickListener(new OnClickListener() {
+                    @Override
+                    public void onClick(final View buttonView) {
+                        final FragmentActivity fa = getActivity();
+                        if (null != fa) {
+                            MainActivity.createConfirmation(fa, getString(R.string.export_gpx_detail),
+                                    R.id.nav_data, EXPORT_GPX_DIALOG);
+                        } else {
+                            MainActivity.error("unable to get fragment activity");
+                        }
+                    }
+                });
+            }
         }
     }
 
-    public void setupM8bExport( final View view ) {
-        final Button exportM8bButton = (Button) view.findViewById(R.id.export_m8b_button);
+    private void setupM8bExport( final View view ) {
+        final Button exportM8bButton = view.findViewById(R.id.export_m8b_button);
         exportM8bButton.setOnClickListener(new OnClickListener() {
             @Override
             public void onClick(final View buttonView) {
-                MainActivity.createConfirmation(getActivity(), getString(R.string.export_m8b_detail),
-                        R.id.nav_data, EXPORT_M8B_DIALOG);
+                final FragmentActivity fa = getActivity();
+                if (null != fa) {
+                    MainActivity.createConfirmation(fa, getString(R.string.export_m8b_detail),
+                            R.id.nav_data, EXPORT_M8B_DIALOG);
+                } else {
+                    MainActivity.error("unable to get fragment activity");
+                }
             }
         });
     }
@@ -341,8 +421,14 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
     @SuppressLint("SetTextI18n")
     @Override
     public void handleDialog(final int dialogId) {
-        final SharedPreferences prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
-        final SharedPreferences.Editor editor = prefs.edit();
+        SharedPreferences prefs = null;
+        if (getActivity() != null) {
+            prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+        }
+        SharedPreferences.Editor editor = null;
+        if (null != prefs) {
+            editor = prefs.edit();
+        }
         final View view = getView();
 
         switch (dialogId) {
@@ -371,8 +457,13 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
                 break;
             }
             case BACKUP_DIALOG: {
-                BackupTask task = new BackupTask(DataFragment.this, MainActivity.getMainActivity(DataFragment.this));
-                task.execute();
+                MainActivity ma = MainActivity.getMainActivity(DataFragment.this);
+                if (ma != null) {
+                    BackupTask task = new BackupTask(DataFragment.this, ma);
+                    task.execute();
+                } else {
+                    MainActivity.error("null mainActivity - can't create backup dialog.");
+                }
                 break;
             }
             case IMPORT_DIALOG: {
@@ -380,40 +471,53 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
                 break;
             }
             case ZERO_OUT_DIALOG: {
-                editor.putLong( ListFragment.PREF_DB_MARKER, 0L );
-                editor.apply();
-                if (view != null) {
-                    final TextView tv = (TextView) view.findViewById(R.id.reset_maxid_text);
-                    tv.setText(getString(R.string.setting_max_id) + " 0");
+                if (null != editor) {
+                    editor.putLong(ListFragment.PREF_DB_MARKER, 0L);
+                    editor.apply();
+                    if (view != null) {
+                        final TextView tv = view.findViewById(R.id.reset_maxid_text);
+                        tv.setText(getString(R.string.setting_max_id) + " 0");
+                    }
+                } else {
+                    MainActivity.error("Null editor - unable to update DB marker");
                 }
                 break;
             }
             case MAX_OUT_DIALOG: {
-                final long maxDB = prefs.getLong( ListFragment.PREF_MAX_DB, 0L );
-                editor.putLong( ListFragment.PREF_DB_MARKER, maxDB );
-                editor.apply();
-                if (view != null) {
-                    // set the text on the other button
-                    final TextView tv = (TextView) view.findViewById(R.id.reset_maxid_text);
-                    tv.setText(getString(R.string.setting_max_id) + " " + maxDB);
+                if (prefs != null && editor != null) {
+                    final long maxDB = prefs.getLong( ListFragment.PREF_MAX_DB, 0L );
+                    editor.putLong( ListFragment.PREF_DB_MARKER, maxDB );
+                    editor.apply();
+                    if (view != null) {
+                        // set the text on the other button
+                        final TextView tv = view.findViewById(R.id.reset_maxid_text);
+                        tv.setText(getString(R.string.setting_max_id) + " " + maxDB);
+                    }
+                } else {
+                    MainActivity.error("Null prefs/editor - unable to update DB marker");
                 }
+
                 break;
             }
             case DELETE_DIALOG: {
                 //blow away the DB
                 ListFragment.lameStatic.dbHelper.clearDatabase();
                 //update markers
-                editor.putLong( ListFragment.PREF_DB_MARKER, 0L );
-                editor.putLong( ListFragment.PREF_DB_MARKER, 0L );
-                editor.apply();
-                if (view != null) {
-                    final TextView tv = (TextView) view.findViewById(R.id.reset_maxid_text);
-                    tv.setText(getString(R.string.setting_max_id) + " " + 0L);
-                }
-                try {
-                    ListFragment.lameStatic.dbHelper.getNetworkCountFromDB();
-                } catch (DBException dbe) {
-                    MainActivity.warn("Failed to update network count on DB clear: ", dbe);
+                if (null != editor) {
+                    editor.putLong(ListFragment.PREF_DB_MARKER, 0L);
+                    editor.putLong(ListFragment.PREF_DB_MARKER, 0L);
+                    editor.apply();
+                    if (view != null) {
+                        final TextView tv = view.findViewById(R.id.reset_maxid_text);
+                        tv.setText(getString(R.string.setting_max_id) + " " + 0L);
+                    }
+                    try {
+                        ListFragment.lameStatic.dbHelper.getNetworkCountFromDB();
+                    } catch (DBException dbe) {
+                        MainActivity.warn("Failed to update network count on DB clear: ", dbe);
+                    }
+                } else {
+                    MainActivity.error("Null editor - unable to update DB marker");
                 }
 
                 break;
@@ -469,7 +573,7 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
 
             final View view = fragment.getView();
             if (view != null) {
-                final TextView tv = (TextView) view.findViewById( R.id.backup_db_text );
+                final TextView tv = view.findViewById( R.id.backup_db_text );
                 if (tv != null) {
                     tv.setText( mainActivity.getString(R.string.backup_db_text) );
                 }
@@ -486,16 +590,22 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
                     intent.setType("application/xsqlite-3");
 
                     //TODO: verify local-only storage case/gpx_paths.xml
-                    final Uri fileUri = FileProvider.getUriForFile(getContext(),
-                            MainActivity.getMainActivity().getApplicationContext().getPackageName() +
-                                    ".sqliteprovider", new File(dbResult.getSecond()));
+                    final Context c = getContext();
+                    if (null == c) {
+                        MainActivity.error("null context in DB backup postExec");
+                    } else {
+                        final Uri fileUri = FileProvider.getUriForFile(c,
+                                MainActivity.getMainActivity().getApplicationContext().getPackageName() +
+                                        ".sqliteprovider", new File(dbResult.getSecond()));
 
-                    intent.putExtra(Intent.EXTRA_STREAM, fileUri);
-                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                    startActivity(Intent.createChooser(intent, getResources().getText(R.string.send_to)));
+                        intent.putExtra(Intent.EXTRA_STREAM, fileUri);
+                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                        startActivity(Intent.createChooser(intent, getResources().getText(R.string.send_to)));
+                    }
                 } else {
                     //TODO: show error
+                    MainActivity.error("null or empty DB result in DB backup postExec");
                 }
             }
 
@@ -591,7 +701,12 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
         MainActivity.info( "resume data." );
         super.onResume();
         try {
-            getActivity().setTitle(R.string.data_activity_name);
+            final FragmentActivity fa = getActivity();
+            if (null != fa) {
+                getActivity().setTitle(R.string.data_activity_name);
+            } else {
+                MainActivity.error("Failed to set title on null activity onResume");
+            }
         } catch (NullPointerException npe) {
             //Nothing to do here.
         }
@@ -647,7 +762,7 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
             // TODO: there's a real case for refusing to export on devices that don't have SD...
             // TODO: android R FS changes
 
-            final boolean hasSD = MainActivity.hasSD();
+            final boolean hasSD = FileUtility.hasSD();
 
             File m8bDestFile;
             final FileChannel out;
@@ -662,13 +777,13 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
                     if (!path.exists()) {
                         MainActivity.info("Got '!exists': " + path);
                     }
-                    String openString = basePath + M8B_FILE_PREFIX +  M8B_EXTENSION;
+                    String openString = basePath + M8B_FILE_PREFIX +  M8B_EXT;
                     //DEBUG: MainActivity.info("Opening file: " + openString);
                     m8bDestFile = new File( openString );
 
                 } else {
                     m8bDestFile = new File(getActivity().getApplication().getFilesDir(),
-                            M8B_FILE_PREFIX + M8B_EXTENSION);
+                            M8B_FILE_PREFIX + M8B_EXT);
                 }
                 //ALIBI: always start fresh
                 boolean append = false;
@@ -682,15 +797,15 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
             final File outputFile = m8bDestFile;
 
             final SipKey sipkey = new SipKey(new byte[16]);
-            final byte[] macbytes = new byte[6];
-            final Map<Integer,Set<mgrs>> mjg = new TreeMap<Integer,Set<mgrs>>();
+            final byte[] macBytes = new byte[6];
+            final Map<Integer,Set<mgrs>> mjg = new TreeMap<>();
 
             final long genStart = System.currentTimeMillis();
 
             // write intermediate file
             // ALIBI: redundant thread, but this gets us queue, progress
             final QueryThread.Request request = new QueryThread.Request(
-                    ListFragment.lameStatic.dbHelper.LOCATED_NETS_QUERY, new QueryThread.ResultHandler() {
+                    DatabaseHelper.LOCATED_NETS_QUERY, new QueryThread.ResultHandler() {
 
                 int non_utm=0;
                 int rows = 0;
@@ -706,11 +821,11 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
                     } else {
                         mgrs m = mgrs.fromUtm(utm.fromLatLon(lat,lon));
 
-                        Integer kslice2 = MagicEightUtil.extractKeyFrom(bssid,macbytes,sipkey,SLICE_BITS);
+                        Integer kslice2 = MagicEightUtil.extractKeyFrom(bssid, macBytes, sipkey, SLICE_BITS);
 
                         Set<mgrs> locs = mjg.get(kslice2);
                         if (locs==null){
-                            locs = new HashSet<mgrs>();
+                            locs = new HashSet<>();
                             mjg.put(kslice2,locs);
                         }
                         if(locs.add(m)){
@@ -805,14 +920,19 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
                     intent.setType("application/wigle.m8b");
 
                     //TODO: verify local-only storage case/m8b_paths.xml
-                    final Uri fileUri = FileProvider.getUriForFile(getContext(),
-                            MainActivity.getMainActivity().getApplicationContext().getPackageName() +
-                                    ".m8bprovider", outputFile);
+                    Context c = getContext();
+                    if (null != c) {
+                        final Uri fileUri = FileProvider.getUriForFile(c,
+                                MainActivity.getMainActivity().getApplicationContext().getPackageName() +
+                                        ".m8bprovider", outputFile);
 
                         intent.putExtra(Intent.EXTRA_STREAM, fileUri);
                         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
                         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
                         startActivity(Intent.createChooser(intent, getResources().getText(R.string.send_to)));
+                    } else {
+                        MainActivity.error("Unable to link m8b provider - null context");
+                    }
                 }
             });
             ListFragment.lameStatic.dbHelper.addToQueue( request );
@@ -872,7 +992,7 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
         protected String doInBackground(Long... routeLocs) {
             // TODO: AS ABOVE there's a real case for refusing to export on devices that don't have SD...
             // TODO: android R FS changes
-            final boolean hasSD = MainActivity.hasSD();
+            final boolean hasSD = FileUtility.hasSD();
 
             final DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
             final String name = df.format(new Date());
@@ -888,21 +1008,31 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
                     if (!path.exists()) {
                         MainActivity.info("Got '!exists': " + path);
                     }
-                    String openString = basePath + name +  GPX_EXTENSION;
+                    String openString = basePath + name +  GPX_EXT;
                     //DEBUG: MainActivity.info("Opening file: " + openString);
                     gpxDestFile = new File( openString );
 
                 } else {
-                    gpxDestFile = new File(getActivity().getApplication().getFilesDir(),
-                            name + GPX_EXTENSION);
+                    final Activity a = getActivity();
+                    if (null != a) {
+                        gpxDestFile = new File(getActivity().getApplication().getFilesDir(),
+                                name + GPX_EXT);
+                    } else {
+                        MainActivity.error("set destination file due to null Activity in GPX export");
+                    }
                 }
                 FileWriter writer = new FileWriter(gpxDestFile, false);
                 writer.append(GPX_HEADER_A);
                 String creator = "WiGLE WiFi ";
                 try {
-                    final PackageManager pm = getActivity().getApplicationContext().getPackageManager();
-                    final PackageInfo pi = pm.getPackageInfo(getActivity().getApplicationContext().getPackageName(), 0);
-                    creator += pi.versionName;
+                    final Activity a = getActivity();
+                    if (null != a) {
+                        final PackageManager pm = getActivity().getApplicationContext().getPackageManager();
+                        final PackageInfo pi = pm.getPackageInfo(getActivity().getApplicationContext().getPackageName(), 0);
+                        creator += pi.versionName;
+                    } else {
+                        MainActivity.error("unable to get packageManager due to null Activity in GPX export");
+                    }
                 } catch (Exception ex) {
                     creator += "(unknown)";
                 }
@@ -964,14 +1094,19 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
                 intent.setType("application/gpx");
 
                 //TODO: verify local-only storage case/gpx_paths.xml
-                final Uri fileUri = FileProvider.getUriForFile(getContext(),
-                        MainActivity.getMainActivity().getApplicationContext().getPackageName() +
-                                ".gpxprovider", gpxDestFile);
+                final Context c = getContext();
+                if (null != c) {
+                    final Uri fileUri = FileProvider.getUriForFile(getContext(),
+                            MainActivity.getMainActivity().getApplicationContext().getPackageName() +
+                                    ".gpxprovider", gpxDestFile);
 
-                intent.putExtra(Intent.EXTRA_STREAM, fileUri);
-                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                startActivity(Intent.createChooser(intent, getResources().getText(R.string.send_to)));
+                    intent.putExtra(Intent.EXTRA_STREAM, fileUri);
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                    startActivity(Intent.createChooser(intent, getResources().getText(R.string.send_to)));
+                } else {
+                    MainActivity.error("Unable to initiate GPX export - null context");
+                }
             }
         }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
@@ -30,7 +30,6 @@ import android.media.AudioManager;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
-import android.os.Environment;
 import androidx.fragment.app.Fragment;
 import androidx.core.content.FileProvider;
 import androidx.fragment.app.FragmentActivity;
@@ -230,8 +229,9 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
     private void setupBackupDbButton( final View view ) {
         final Button dbBackupButton = view.findViewById( R.id.backup_db_button );
 
-        //TODO: there's a question here: if the backupDb option shouldn't be used w/out SD
-        //  should we also disable the export to KML/CSV options, since they'll certainly be larger?
+        //TODO: experiments extending the provider to grant direct share access to the
+        //   databases/wiglewifi.sqlite file failing under Pie. If we can add a provider that can
+        //   reach ../databases/*, we could remove this limit
         if ( ! FileUtility.hasSD() ) {
             dbBackupButton.setEnabled(false);
         }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ErrorReportActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ErrorReportActivity.java
@@ -11,13 +11,14 @@ import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Environment;
 import android.os.Handler;
 import androidx.appcompat.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.WindowManager;
 import android.widget.TextView;
+
+import net.wigle.wigleandroid.util.FileUtility;
 
 /**
  * display latest error stack, if any.
@@ -126,7 +127,7 @@ public class ErrorReportActivity extends AppCompatActivity {
 
     private String getLatestStackfilePath() {
         try {
-            File fileDir = MainActivity.getErrorStackPath(getApplicationContext());
+            File fileDir = FileUtility.getErrorStackPath(getApplicationContext());
             if (!fileDir.canRead() || !fileDir.isDirectory()) {
                 MainActivity.error("file is not readable or not a directory. fileDir: " + fileDir);
             } else {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ErrorReportActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ErrorReportActivity.java
@@ -1,7 +1,6 @@
 package net.wigle.wigleandroid;
 
 import java.io.BufferedReader;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -45,7 +44,7 @@ public class ErrorReportActivity extends AppCompatActivity {
         setContentView( R.layout.error );
 
         // get stack from file
-        stackFilePath = getLatestStackfilePath();
+        stackFilePath = FileUtility.getLatestStackfilePath(getApplicationContext());
         if (stackFilePath == null || stackFilePath.isEmpty()) {
             //ALIBI: we have no record of what or why - no reason to hassle user
             finish();
@@ -53,7 +52,7 @@ public class ErrorReportActivity extends AppCompatActivity {
         stack = getLatestStack(stackFilePath);
 
         // set on view
-        TextView tv = (TextView) findViewById( R.id.errorreport );
+        TextView tv = findViewById( R.id.errorreport );
         tv.setText( stack );
 
         Intent intent = getIntent();
@@ -123,35 +122,6 @@ public class ErrorReportActivity extends AppCompatActivity {
         if ( SpeechActivity.speechActivity != null ) {
             SpeechActivity.speechActivity.finish();
         }
-    }
-
-    private String getLatestStackfilePath() {
-        try {
-            File fileDir = FileUtility.getErrorStackPath(getApplicationContext());
-            if (!fileDir.canRead() || !fileDir.isDirectory()) {
-                MainActivity.error("file is not readable or not a directory. fileDir: " + fileDir);
-            } else {
-                String[] files = fileDir.list();
-                if (files == null) {
-                    MainActivity.error("no files in dir: " + fileDir);
-                } else {
-                    String latestFilename = null;
-                    for (String filename : files) {
-                        if (filename.startsWith(MainActivity.ERROR_STACK_FILENAME)) {
-                            if (latestFilename == null || filename.compareTo(latestFilename) > 0) {
-                                latestFilename = filename;
-                            }
-                        }
-                    }
-                    MainActivity.info("latest filename: " + latestFilename);
-
-                    return MainActivity.safeFilePath(fileDir) + "/" + latestFilename;
-                }
-            }
-        } catch (Exception ex) {
-            MainActivity.error( "error finding stack file: " + ex, ex );
-        }
-        return null;
     }
 
     private String getLatestStack(final String filePath) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -113,6 +113,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static android.location.LocationManager.GPS_PROVIDER;
+import static net.wigle.wigleandroid.util.FileUtility.APP_SUB_DIR;
 
 public final class MainActivity extends AppCompatActivity {
     //*** state that is retained ***
@@ -1056,36 +1057,6 @@ public final class MainActivity extends AppCompatActivity {
         return retval;
     }
 
-    public static String getSDPath() {
-        return MainActivity.safeFilePath(Environment.getExternalStorageDirectory()) + "/wiglewifi/";
-    }
-
-    public static FileOutputStream createFile(final Context context, final String filename, final boolean isCache) throws IOException {
-        final String filepath = getSDPath();
-        final File path = new File(filepath);
-
-        final boolean hasSD = MainActivity.hasSD();
-        if (hasSD) {
-            //noinspection ResultOfMethodCallIgnored
-            path.mkdirs();
-            final String openString = filepath + filename;
-            MainActivity.info("openString: " + openString);
-            final File file = new File(openString);
-            if (!file.exists()) {
-                if (!file.createNewFile()) {
-                    throw new IOException("Could not create file: " + openString);
-                }
-            }
-
-            return new FileOutputStream(file);
-        } else if (isCache) {
-            File file = File.createTempFile(filename, null, context.getCacheDir());
-            return new FileOutputStream(file);
-        }
-
-        return context.openFileOutput(filename, Context.MODE_PRIVATE);
-    }
-
     @Override
     public void onDestroy() {
         MainActivity.info("MAIN: destroy.");
@@ -1308,9 +1279,9 @@ public final class MainActivity extends AppCompatActivity {
     private static Uri resToFile(final Context context, final int resid, final String name) throws IOException {
         // throw it in our bag of fun.
         String openString = name;
-        final boolean hasSD = hasSD();
+        final boolean hasSD = FileUtility.hasSD();
         if (hasSD) {
-            final String filepath = MainActivity.safeFilePath(Environment.getExternalStorageDirectory()) + "/wiglewifi/";
+            final String filepath = MainActivity.safeFilePath(Environment.getExternalStorageDirectory()) + APP_SUB_DIR;
             final File path = new File(filepath);
             //noinspection ResultOfMethodCallIgnored
             path.mkdirs();
@@ -1504,13 +1475,6 @@ public final class MainActivity extends AppCompatActivity {
         }
     }
 
-    public static File getErrorStackPath(final Context context) {
-        if (hasSD()) {
-            return new File(MainActivity.safeFilePath(Environment.getExternalStorageDirectory()) + "/wiglewifi/");
-        }
-        return context.getApplicationContext().getFilesDir();
-    }
-
     public static void writeError(final Thread thread, final Throwable throwable, final Context context) {
         writeError(thread, throwable, context, null);
     }
@@ -1519,7 +1483,7 @@ public final class MainActivity extends AppCompatActivity {
         try {
             final String error = "Thread: " + thread + " throwable: " + throwable;
             error(error, throwable);
-            final File stackPath = getErrorStackPath(context);
+            final File stackPath = FileUtility.getErrorStackPath(context);
             if (stackPath.exists() && stackPath.canWrite()) {
                 //noinspection ResultOfMethodCallIgnored
                 stackPath.mkdirs();
@@ -1664,15 +1628,6 @@ public final class MainActivity extends AppCompatActivity {
             return android.provider.Settings.Secure.getInt(context.getContentResolver(),
                     android.provider.Settings.Global.DEVELOPMENT_SETTINGS_ENABLED , 0) != 0;
         } else return false;
-    }
-
-    public static boolean hasSD() {
-        File sdCard = new File(MainActivity.safeFilePath(Environment.getExternalStorageDirectory()) + "/");
-        MainActivity.info("exists: " + sdCard.exists() + " dir: " + sdCard.isDirectory()
-                + " read: " + sdCard.canRead() + " write: " + sdCard.canWrite()
-                + " path: " + sdCard.getAbsolutePath());
-
-        return sdCard.exists() && sdCard.isDirectory() && sdCard.canRead() && sdCard.canWrite();
     }
 
     private void setupSound() {
@@ -2633,7 +2588,7 @@ public final class MainActivity extends AppCompatActivity {
 
     public boolean checkStorage() {
         boolean safe;
-        boolean external = hasSD();
+        boolean external = FileUtility.hasSD();
         if (external) {
             safe = FileUtility.checkExternalStorageDangerZone();
         } else {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
@@ -43,6 +43,7 @@ import net.wigle.wigleandroid.background.ApiDownloader;
 import net.wigle.wigleandroid.background.DownloadHandler;
 import net.wigle.wigleandroid.listener.GPSListener;
 import net.wigle.wigleandroid.listener.PrefCheckboxListener;
+import net.wigle.wigleandroid.util.FileUtility;
 import net.wigle.wigleandroid.util.SettingsUtil;
 
 import static net.wigle.wigleandroid.UserStatsFragment.MSG_USER_DONE;
@@ -590,7 +591,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
      * clear cache files (i.e. on creds change)
      */
     private void clearCachefiles() {
-        final File cacheDir = new File(MainActivity.getSDPath());
+        final File cacheDir = new File(FileUtility.getSDPath());
         final File[] cacheFiles = cacheDir.listFiles(new FilenameFilter() {
             @Override
             public boolean accept( final File dir,

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractApiRequest.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractApiRequest.java
@@ -10,6 +10,7 @@ import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.TokenAccess;
 import net.wigle.wigleandroid.WiGLEAuthException;
+import net.wigle.wigleandroid.util.FileUtility;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -161,8 +162,8 @@ public abstract class AbstractApiRequest extends AbstractBackgroundTask {
 
     public JSONObject getCached() {
         File file = null;
-        if (MainActivity.hasSD()) {
-            file = new File(MainActivity.getSDPath() + cacheFilename);
+        if (FileUtility.hasSD()) {
+            file = new File(FileUtility.getSDPath() + cacheFilename);
             if (!file.exists() || !file.canRead()) {
                 MainActivity.warn("External cache file doesn't exist or can't be read: " + file);
                 return null;
@@ -208,7 +209,7 @@ public abstract class AbstractApiRequest extends AbstractBackgroundTask {
 
         FileOutputStream fos = null;
         try {
-            fos = MainActivity.createFile(context, cacheFilename, true);
+            fos = FileUtility.createFile(context, cacheFilename, true);
             // header
             ObservationUploader.writeFos(fos, result);
         }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ApiDownloader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ApiDownloader.java
@@ -29,7 +29,7 @@ public class ApiDownloader extends AbstractApiRequest {
         String result = null;
         try {
             result = doDownload(this.connectionMethod);
-            if (cacheFilename != null) {
+            if (outputFileName != null) {
                 cacheResult(result);
             }
             final JSONObject json = new JSONObject(result);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlDownloader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlDownloader.java
@@ -16,7 +16,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 
-import static net.wigle.wigleandroid.util.FileUtility.KML_DIR;
 import static net.wigle.wigleandroid.util.FileUtility.KML_EXT;
 
 /**
@@ -42,9 +41,9 @@ public class KmlDownloader extends AbstractProgressApiRequest {
         String result = null;
         try {
             result = doDownload(this.connectionMethod);
-            writeSharefile(result, cacheFilename);
+            writeSharefile(result, outputFileName);
             final JSONObject json = new JSONObject("{success: " + true + ", file:\"" +
-                    (FileUtility.hasSD()? FileUtility.getSDPath() : context.getDir("kml", Context.MODE_PRIVATE).getAbsolutePath() + "/" ) + cacheFilename + "\"}");
+                    FileUtility.getKmlPath(context) + "/" + outputFileName + "\"}");
             sendBundledMessage( Status.SUCCESS.ordinal(), bundle );
             listener.requestComplete(json, false);
         } catch (final WiGLEAuthException waex) {
@@ -59,18 +58,18 @@ public class KmlDownloader extends AbstractProgressApiRequest {
 
     /**
      * write string data to a file accessible for Intent-based share or view
-     * @param result
-     * @param filename
-     * @throws IOException
+     * @param result the result of the operation
+     * @param filename the filename to write
+     * @throws IOException on failure to write
      */
     protected void writeSharefile(final String result, final String filename) throws IOException {
 
         if (FileUtility.hasSD()) {
-            if (cacheFilename != null) {
-                //DEBUG: KmlDownloader.printDirContents(new File(MainActivity.getSDPath()));
+            if (outputFileName != null) {
+                //DEBUG: FileUtility.printDirContents(new File(MainActivity.getSDPath()));
                 //ALIBI: for external-storage, our existing "cache" method is fine to write the file
                 cacheResult(result);
-                //DEBUG: KmlDownloader.printDirContents(new File(MainActivity.getSDPath()));
+                //DEBUG: FileUtility.printDirContents(new File(MainActivity.getSDPath()));
             }
         } else {
             //ALIBI: building a special directory for KML for intents
@@ -79,32 +78,19 @@ public class KmlDownloader extends AbstractProgressApiRequest {
             //see if KML dir exists
             MainActivity.info("local storage DL...");
 
-            //TODO: dedupe w/ MainActivity.createFile(..)
-            File kmlPath = new File(context.getFilesDir(), KML_DIR);
+            File kmlPath = new File(FileUtility.getKmlPath(context));
             if (!kmlPath.exists()) {
+                //noinspection ResultOfMethodCallIgnored
                 kmlPath.mkdir();
             }
-            //DEBUG: KmlDownloader.printDirContents(kmlPath);
+            //DEBUG: FileUtility.printDirContents(kmlPath);
             if (kmlPath.exists() && kmlPath.isDirectory()) {
                 //DEBUG: MainActivity.info("... file output directory found");
                 File kmlFile = new File(kmlPath, filename);
                 FileOutputStream out = new FileOutputStream(kmlFile);
                 ObservationUploader.writeFos(out, result);
-                //DEBUG: KmlDownloader.printDirContents(kmlPath);
+                //DEBUG: FileUtility.printDirContents(kmlPath);
             }
-        }
-    }
-
-    /**
-     * file inspection debugging method - probably should get moved into a utility class eventually
-     * @param directory
-     */
-    public static  void printDirContents(final File directory) {
-        System.out.println("\tListing for: "+directory.toString());
-        File[] files = directory.listFiles();
-        System.out.println("\tSize: "+ files.length);
-        for (int i = 0; i < files.length; i++) {
-            System.out.println("\t\t"+files[i].getName()+"\t"+files[i].getAbsoluteFile());
         }
     }
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlDownloader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlDownloader.java
@@ -7,6 +7,7 @@ import androidx.fragment.app.FragmentActivity;
 import net.wigle.wigleandroid.db.DatabaseHelper;
 import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.WiGLEAuthException;
+import net.wigle.wigleandroid.util.FileUtility;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -14,6 +15,9 @@ import org.json.JSONObject;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+
+import static net.wigle.wigleandroid.util.FileUtility.KML_DIR;
+import static net.wigle.wigleandroid.util.FileUtility.KML_EXT;
 
 /**
  * A KML-upload grabber intended for sharing/viewing via itents
@@ -25,7 +29,7 @@ public class KmlDownloader extends AbstractProgressApiRequest {
 
     public KmlDownloader(final FragmentActivity context, final DatabaseHelper dbHelper /*TODO: not needed?*/,
                                final String transid, final ApiListener listener) {
-        super(context, dbHelper, "KmlDL", transid+".kml", MainActivity.KML_TRANSID_URL_STEM+transid, false,
+        super(context, dbHelper, "KmlDL", transid+KML_EXT, MainActivity.KML_TRANSID_URL_STEM+transid, false,
                 true, true, false, AbstractApiRequest.REQUEST_GET, listener, true);
         }
 
@@ -40,7 +44,7 @@ public class KmlDownloader extends AbstractProgressApiRequest {
             result = doDownload(this.connectionMethod);
             writeSharefile(result, cacheFilename);
             final JSONObject json = new JSONObject("{success: " + true + ", file:\"" +
-                    (MainActivity.hasSD()? MainActivity.getSDPath() : context.getDir("kml", Context.MODE_PRIVATE).getAbsolutePath() + "/" ) + cacheFilename + "\"}");
+                    (FileUtility.hasSD()? FileUtility.getSDPath() : context.getDir("kml", Context.MODE_PRIVATE).getAbsolutePath() + "/" ) + cacheFilename + "\"}");
             sendBundledMessage( Status.SUCCESS.ordinal(), bundle );
             listener.requestComplete(json, false);
         } catch (final WiGLEAuthException waex) {
@@ -61,7 +65,7 @@ public class KmlDownloader extends AbstractProgressApiRequest {
      */
     protected void writeSharefile(final String result, final String filename) throws IOException {
 
-        if (MainActivity.hasSD()) {
+        if (FileUtility.hasSD()) {
             if (cacheFilename != null) {
                 //DEBUG: KmlDownloader.printDirContents(new File(MainActivity.getSDPath()));
                 //ALIBI: for external-storage, our existing "cache" method is fine to write the file
@@ -75,7 +79,8 @@ public class KmlDownloader extends AbstractProgressApiRequest {
             //see if KML dir exists
             MainActivity.info("local storage DL...");
 
-            File kmlPath = new File(context.getFilesDir(), "app_kml");
+            //TODO: dedupe w/ MainActivity.createFile(..)
+            File kmlPath = new File(context.getFilesDir(), KML_DIR);
             if (!kmlPath.exists()) {
                 kmlPath.mkdir();
             }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlWriter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlWriter.java
@@ -13,11 +13,14 @@ import net.wigle.wigleandroid.db.DBException;
 import net.wigle.wigleandroid.db.DatabaseHelper;
 import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.model.NetworkType;
+import net.wigle.wigleandroid.util.FileUtility;
 
 import android.annotation.SuppressLint;
 import android.database.Cursor;
 import android.os.Bundle;
 import androidx.fragment.app.FragmentActivity;
+
+import static net.wigle.wigleandroid.util.FileUtility.KML_EXT;
 
 public class KmlWriter extends AbstractBackgroundTask {
     private final Set<String> networks;
@@ -46,9 +49,9 @@ public class KmlWriter extends AbstractBackgroundTask {
 
         final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         final SimpleDateFormat fileDateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
-        final String filename = "WigleWifi_" + fileDateFormat.format(new Date()) + ".kml";
+        final String filename = "WigleWifi_" + fileDateFormat.format(new Date()) + KML_EXT;
 
-        final FileOutputStream fos = MainActivity.createFile(context, filename, false);
+        final FileOutputStream fos = FileUtility.createFile(context, filename, false);
         // header
         ObservationUploader.writeFos( fos, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                 + "<kml xmlns=\"http://www.opengis.net/kml/2.2\"><Document>"
@@ -162,7 +165,7 @@ public class KmlWriter extends AbstractBackgroundTask {
 
         fos.close();
 
-        bundle.putString( BackgroundGuiHandler.FILEPATH, MainActivity.getSDPath() + filename );
+        bundle.putString( BackgroundGuiHandler.FILEPATH, FileUtility.getSDPath() + filename );
         bundle.putString( BackgroundGuiHandler.FILENAME, filename );
         MainActivity.info( "done with kml export" );
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlWriter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlWriter.java
@@ -165,6 +165,7 @@ public class KmlWriter extends AbstractBackgroundTask {
 
         fos.close();
 
+        //WARNING: ignored if no SD, so this is ok, but misleading...
         bundle.putString( BackgroundGuiHandler.FILEPATH, FileUtility.getSDPath() + filename );
         bundle.putString( BackgroundGuiHandler.FILENAME, filename );
         MainActivity.info( "done with kml export" );

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
@@ -22,6 +22,7 @@ import net.wigle.wigleandroid.R;
 import net.wigle.wigleandroid.TokenAccess;
 import net.wigle.wigleandroid.WiGLEAuthException;
 import net.wigle.wigleandroid.model.Network;
+import net.wigle.wigleandroid.util.FileUtility;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -49,6 +50,10 @@ import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
 import javax.net.ssl.SSLException;
+
+import static net.wigle.wigleandroid.util.FileUtility.APP_SUB_DIR;
+import static net.wigle.wigleandroid.util.FileUtility.CSV_EXT;
+import static net.wigle.wigleandroid.util.FileUtility.GZ_EXT;
 
 /**
  * replacement file upload task
@@ -204,7 +209,7 @@ public class ObservationUploader extends AbstractProgressApiRequest {
             sendBundledMessage( Status.UPLOADING.ordinal(), bundle );
 
             // send file
-            final boolean hasSD = MainActivity.hasSD();
+            final boolean hasSD = FileUtility.hasSD();
 
             final String absolutePath = hasSD ? file.getAbsolutePath() : context.getFileStreamPath(filename).getAbsolutePath();
 
@@ -627,15 +632,15 @@ public class ObservationUploader extends AbstractProgressApiRequest {
                                                final Object[] fileFilename)
             throws IOException {
         final SimpleDateFormat fileDateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
-        final String filename = "WigleWifi_" + fileDateFormat.format(new Date()) + ".csv.gz";
+        final String filename = "WigleWifi_" + fileDateFormat.format(new Date()) + CSV_EXT + GZ_EXT;
 
 
-        final boolean hasSD = MainActivity.hasSD();
+        final boolean hasSD = FileUtility.hasSD();
         File file = null;
         bundle.putString( BackgroundGuiHandler.FILENAME, filename );
         if ( hasSD ) {
             final String filepath = MainActivity.safeFilePath(
-                    Environment.getExternalStorageDirectory() ) + "/wiglewifi/";
+                    Environment.getExternalStorageDirectory() ) + APP_SUB_DIR;
             final File path = new File( filepath );
             //noinspection ResultOfMethodCallIgnored
             path.mkdirs();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
@@ -1,6 +1,7 @@
 package net.wigle.wigleandroid.background;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
@@ -9,7 +10,6 @@ import android.database.Cursor;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Bundle;
-import android.os.Environment;
 import android.preference.PreferenceManager;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
@@ -51,7 +51,6 @@ import java.util.zip.GZIPOutputStream;
 
 import javax.net.ssl.SSLException;
 
-import static net.wigle.wigleandroid.util.FileUtility.APP_SUB_DIR;
 import static net.wigle.wigleandroid.util.FileUtility.CSV_EXT;
 import static net.wigle.wigleandroid.util.FileUtility.GZ_EXT;
 
@@ -133,9 +132,9 @@ public class ObservationUploader extends AbstractProgressApiRequest {
     }
 
     /**
-     * override base startDownload
+     * override base startDownload - but instead perform an upload
      * TODO: a misnomer, really
-     * @param fragment
+     * @param fragment the fragment from which the upload was started
      * @throws WiGLEAuthException
      */
     @Override
@@ -143,19 +142,25 @@ public class ObservationUploader extends AbstractProgressApiRequest {
         // download token if needed
         SharedPreferences prefs;
         if (null != fragment) {
-            prefs = fragment.getActivity().getSharedPreferences(
-                    ListFragment.SHARED_PREFS, 0);
+            Activity a = fragment.getActivity();
+            if (a != null) {
+                prefs = fragment.getActivity().getSharedPreferences(
+                        ListFragment.SHARED_PREFS, 0);
+            } else {
+                prefs = null;
+                MainActivity.error("Failed to get activity for non-null fragment - prefs access failed on upload.");
+            }
         } else {
             prefs = PreferenceManager.getDefaultSharedPreferences(MainActivity.getMainActivity().getApplicationContext());
         }
         if (prefs != null) {
             final boolean beAnonymous = prefs.getBoolean(ListFragment.PREF_BE_ANONYMOUS, false);
-            final String authname = prefs.getString(ListFragment.PREF_AUTHNAME, null);
+            final String authName = prefs.getString(ListFragment.PREF_AUTHNAME, null);
             final String userName = prefs.getString(ListFragment.PREF_USERNAME, null);
             final String userPass = prefs.getString(ListFragment.PREF_PASSWORD, null);
-            MainActivity.info("authname: " + authname);
-            if ((!beAnonymous) && (authname == null) && (userName != null) && (userPass != null)) {
-                MainActivity.info("No authname, going to request token");
+            MainActivity.info("authName: " + authName);
+            if ((!beAnonymous) && (authName == null) && (userName != null) && (userPass != null)) {
+                MainActivity.info("No authName, going to request token");
                 downloadTokenAndStart(fragment);
             } else {
                 start();
@@ -166,8 +171,8 @@ public class ObservationUploader extends AbstractProgressApiRequest {
     /**
      * upload guts. lifted from FileUploaderTask
      * @param bundle
-     * @return
-     * @throws InterruptedException
+     * @return the Status of the upload
+     * @throws InterruptedException if the upload is interrupted
      */
     private Status doUpload( final Bundle bundle )
             throws InterruptedException {
@@ -191,8 +196,8 @@ public class ObservationUploader extends AbstractProgressApiRequest {
                 params.put("donate","on");
             }
             final boolean beAnonymous = prefs.getBoolean(ListFragment.PREF_BE_ANONYMOUS, false);
-            final String authname = prefs.getString(ListFragment.PREF_AUTHNAME, null);
-            if (!beAnonymous && null == authname) {
+            final String authName = prefs.getString(ListFragment.PREF_AUTHNAME, null);
+            if (!beAnonymous && null == authName) {
                 return Status.BAD_LOGIN;
             }
             final String userName = prefs.getString(ListFragment.PREF_USERNAME, null);
@@ -213,13 +218,14 @@ public class ObservationUploader extends AbstractProgressApiRequest {
 
             final String absolutePath = hasSD ? file.getAbsolutePath() : context.getFileStreamPath(filename).getAbsolutePath();
 
-            MainActivity.info("authname: " + authname);
+            MainActivity.info("authName: " + authName);
 
             if (beAnonymous) {
                 MainActivity.info("anonymous upload");
             }
 
-            final String response = OkFileUploader.upload(MainActivity.FILE_POST_URL, absolutePath, "file", params, authname, token, getHandler());
+            final String response = OkFileUploader.upload(MainActivity.FILE_POST_URL, absolutePath,
+                    "file", params, authName, token, getHandler());
 
             if ( ! prefs.getBoolean(ListFragment.PREF_DONATE, false) ) {
                 if ( response != null && response.indexOf("donate=Y") > 0 ) {
@@ -286,6 +292,10 @@ public class ObservationUploader extends AbstractProgressApiRequest {
     public static boolean hasDataConnection(final Context context) {
         final ConnectivityManager connMgr =
                 (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (null == connMgr) {
+            MainActivity.error("null ConnectivityManager trying to determine connection info");
+            return false;
+        }
         final NetworkInfo wifi = connMgr.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
         final NetworkInfo mobile = connMgr.getNetworkInfo(ConnectivityManager.TYPE_MOBILE);
         //noinspection SimplifiableIfStatement
@@ -296,8 +306,9 @@ public class ObservationUploader extends AbstractProgressApiRequest {
     }
 
     /**
+     * Given a stream of observations, write a file.
      * (directly lifted from FileUploaderTask)
-     * @return
+     * @return the Status of the write operation
      */
     public Status justWriteFile() {
         Status status = null;
@@ -611,12 +622,13 @@ public class ObservationUploader extends AbstractProgressApiRequest {
     }
 
     /**
+     * Copy a date according to format into a position in a string
      * (lifted directly from FileUploaderTask)
-     * @param dateFormat
+     * @param dateFormat the DateFormat to use
      * @param stringBuffer
      * @param charBuffer
-     * @param fp
-     * @param date
+     * @param fp the position at which to insert
+     * @param date the date
      */
     private void singleCopyDateFormat(final DateFormat dateFormat, final StringBuffer stringBuffer,
                                       final CharBuffer charBuffer, final FieldPosition fp,
@@ -638,13 +650,13 @@ public class ObservationUploader extends AbstractProgressApiRequest {
         final boolean hasSD = FileUtility.hasSD();
         File file = null;
         bundle.putString( BackgroundGuiHandler.FILENAME, filename );
-        if ( hasSD ) {
-            final String filepath = MainActivity.safeFilePath(
-                    Environment.getExternalStorageDirectory() ) + APP_SUB_DIR;
-            final File path = new File( filepath );
+        final String filePath = FileUtility.getUploadFilePath();
+
+        if ( hasSD && filePath != null) {
+            final File path = new File( filePath );
             //noinspection ResultOfMethodCallIgnored
             path.mkdirs();
-            String openString = filepath + filename;
+            String openString = filePath + filename;
             MainActivity.info("Opening file: " + openString);
             file = new File( openString );
             if ( ! file.exists() ) {
@@ -652,11 +664,10 @@ public class ObservationUploader extends AbstractProgressApiRequest {
                     throw new IOException("Could not create file: " + openString);
                 }
             }
-            bundle.putString( BackgroundGuiHandler.FILEPATH, filepath );
-            bundle.putString( BackgroundGuiHandler.FILENAME, filename );
+            bundle.putString( BackgroundGuiHandler.FILEPATH, filePath );
         }
 
-        final FileOutputStream rawFos = hasSD ? new FileOutputStream( file )
+        final FileOutputStream rawFos = (hasSD && null != file) ? new FileOutputStream( file )
                     : context.openFileOutput( filename, Context.MODE_PRIVATE );
 
         final GZIPOutputStream fos = new GZIPOutputStream( rawFos );

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
@@ -8,7 +8,6 @@ import static net.wigle.wigleandroid.MainActivity.ERROR_REPORT_DIALOG;
 import static net.wigle.wigleandroid.listener.GPSListener.MIN_ROUTE_LOCATION_DIFF_METERS;
 import static net.wigle.wigleandroid.listener.GPSListener.MIN_ROUTE_LOCATION_DIFF_TIME;
 import static net.wigle.wigleandroid.listener.GPSListener.MIN_ROUTE_LOCATION_PRECISION_METERS;
-import static net.wigle.wigleandroid.util.FileUtility.APP_SUB_DIR;
 import static net.wigle.wigleandroid.util.FileUtility.SQL_EXT;
 
 import java.io.File;
@@ -68,7 +67,7 @@ public final class DatabaseHelper extends Thread {
     private static final double BIG_LATLON_CHANGE = 0.01D;
     private static final int LEVEL_CHANGE = 5;
     private static final String DATABASE_NAME = "wiglewifi"+SQL_EXT;
-    private static final String DATABASE_PATH = Environment.getExternalStorageDirectory() + APP_SUB_DIR;
+    private static final String EXTERNAL_DATABASE_PATH = FileUtility.getSDPath();
     private static final int DB_PRIORITY = Process.THREAD_PRIORITY_BACKGROUND;
     private static final Object TRANS_LOCK = new Object();
 
@@ -422,10 +421,10 @@ public final class DatabaseHelper extends Thread {
         String dbFilename = DATABASE_NAME;
         final boolean hasSD = FileUtility.hasSD();
         if ( hasSD ) {
-            File path = new File( DATABASE_PATH );
+            File path = new File( EXTERNAL_DATABASE_PATH );
             //noinspection ResultOfMethodCallIgnored
             path.mkdirs();
-            dbFilename = DATABASE_PATH + DATABASE_NAME;
+            dbFilename = EXTERNAL_DATABASE_PATH + DATABASE_NAME;
         }
         final File dbFile = new File( dbFilename );
         boolean doCreateNetwork = false;
@@ -1394,8 +1393,8 @@ public final class DatabaseHelper extends Thread {
 
 
     public Pair<Boolean,String> copyDatabase(final BackupTask task) {
-        final String dbFilename = DATABASE_PATH + DATABASE_NAME;
-        final String outputFilename = DATABASE_PATH + "backup-" + System.currentTimeMillis() + SQL_EXT;
+        final String dbFilename = EXTERNAL_DATABASE_PATH + DATABASE_NAME;
+        final String outputFilename = EXTERNAL_DATABASE_PATH + "backup-" + System.currentTimeMillis() + SQL_EXT;
         File file = new File(dbFilename);
         File outputFile = new File(outputFilename);
         Pair<Boolean,String> result;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
@@ -8,6 +8,8 @@ import static net.wigle.wigleandroid.MainActivity.ERROR_REPORT_DIALOG;
 import static net.wigle.wigleandroid.listener.GPSListener.MIN_ROUTE_LOCATION_DIFF_METERS;
 import static net.wigle.wigleandroid.listener.GPSListener.MIN_ROUTE_LOCATION_DIFF_TIME;
 import static net.wigle.wigleandroid.listener.GPSListener.MIN_ROUTE_LOCATION_PRECISION_METERS;
+import static net.wigle.wigleandroid.util.FileUtility.APP_SUB_DIR;
+import static net.wigle.wigleandroid.util.FileUtility.SQL_EXT;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -33,6 +35,7 @@ import net.wigle.wigleandroid.model.ConcurrentLinkedHashMap;
 import net.wigle.wigleandroid.model.Network;
 import net.wigle.wigleandroid.model.NetworkType;
 import net.wigle.wigleandroid.model.Pair;
+import net.wigle.wigleandroid.util.FileUtility;
 
 import android.content.Context;
 import android.content.Intent;
@@ -64,8 +67,8 @@ public final class DatabaseHelper extends Thread {
     private static final double MEDIUM_LATLON_CHANGE = 0.001D;
     private static final double BIG_LATLON_CHANGE = 0.01D;
     private static final int LEVEL_CHANGE = 5;
-    private static final String DATABASE_NAME = "wiglewifi.sqlite";
-    private static final String DATABASE_PATH = Environment.getExternalStorageDirectory() + "/wiglewifi/";
+    private static final String DATABASE_NAME = "wiglewifi"+SQL_EXT;
+    private static final String DATABASE_PATH = Environment.getExternalStorageDirectory() + APP_SUB_DIR;
     private static final int DB_PRIORITY = Process.THREAD_PRIORITY_BACKGROUND;
     private static final Object TRANS_LOCK = new Object();
 
@@ -417,7 +420,7 @@ public final class DatabaseHelper extends Thread {
         // if(true) throw new SQLiteException("meat puppets");
 
         String dbFilename = DATABASE_NAME;
-        final boolean hasSD = MainActivity.hasSD();
+        final boolean hasSD = FileUtility.hasSD();
         if ( hasSD ) {
             File path = new File( DATABASE_PATH );
             //noinspection ResultOfMethodCallIgnored
@@ -1392,7 +1395,7 @@ public final class DatabaseHelper extends Thread {
 
     public Pair<Boolean,String> copyDatabase(final BackupTask task) {
         final String dbFilename = DATABASE_PATH + DATABASE_NAME;
-        final String outputFilename = DATABASE_PATH + "backup-" + System.currentTimeMillis() + ".sqlite";
+        final String outputFilename = DATABASE_PATH + "backup-" + System.currentTimeMillis() + SQL_EXT;
         File file = new File(dbFilename);
         File outputFile = new File(outputFilename);
         Pair<Boolean,String> result;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/MxcDatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/MxcDatabaseHelper.java
@@ -7,7 +7,6 @@ import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteDatabaseCorruptException;
 import android.database.sqlite.SQLiteOpenHelper;
-import android.os.Environment;
 
 import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.MainActivity;
@@ -21,13 +20,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import static net.wigle.wigleandroid.util.FileUtility.APP_SUB_DIR;
 import static net.wigle.wigleandroid.util.FileUtility.EST_MXC_DB_SIZE;
 import static net.wigle.wigleandroid.util.FileUtility.SQL_EXT;
 
 public class MxcDatabaseHelper extends SQLiteOpenHelper {
     private static final String MXC_DB_NAME = "mmcmnc"+SQL_EXT;
-    private static final String DATABASE_PATH = Environment.getExternalStorageDirectory() + APP_SUB_DIR;
+    private static final String EXTERNAL_DATABASE_PATH = FileUtility.getSDPath();
     private static final int MXC_DATABASE_VERSION = 1;
     private static final int MAX_INSTALL_TRIES = 5;
 
@@ -52,7 +50,7 @@ public class MxcDatabaseHelper extends SQLiteOpenHelper {
     private File getMxcFile() {
         final File dbFile;
         if (hasSD) {
-            final String mxcPath = DATABASE_PATH + MXC_DB_NAME;
+            final String mxcPath = EXTERNAL_DATABASE_PATH + MXC_DB_NAME;
             dbFile = new File(mxcPath);
         }
         else {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/MxcDatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/MxcDatabaseHelper.java
@@ -21,11 +21,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import static net.wigle.wigleandroid.util.FileUtility.APP_SUB_DIR;
 import static net.wigle.wigleandroid.util.FileUtility.EST_MXC_DB_SIZE;
+import static net.wigle.wigleandroid.util.FileUtility.SQL_EXT;
 
 public class MxcDatabaseHelper extends SQLiteOpenHelper {
-    private static final String MXC_DB_NAME = "mmcmnc.sqlite";
-    private static final String DATABASE_PATH = Environment.getExternalStorageDirectory() + "/wiglewifi/";
+    private static final String MXC_DB_NAME = "mmcmnc"+SQL_EXT;
+    private static final String DATABASE_PATH = Environment.getExternalStorageDirectory() + APP_SUB_DIR;
     private static final int MXC_DATABASE_VERSION = 1;
     private static final int MAX_INSTALL_TRIES = 5;
 
@@ -43,7 +45,7 @@ public class MxcDatabaseHelper extends SQLiteOpenHelper {
     public MxcDatabaseHelper(Context context) {
         super(context, MXC_DB_NAME, null, MXC_DATABASE_VERSION);
         this.context = context;
-        hasSD = MainActivity.hasSD();
+        hasSD = FileUtility.hasSD();
         prefs = context.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
     }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/CsvGzFileProvider.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/CsvGzFileProvider.java
@@ -1,0 +1,6 @@
+package net.wigle.wigleandroid.util;
+
+import androidx.core.content.FileProvider;
+
+public class CsvGzFileProvider extends FileProvider {
+}

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/FileUtility.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/FileUtility.java
@@ -1,5 +1,6 @@
 package net.wigle.wigleandroid.util;
 
+import android.content.Context;
 import android.os.Build;
 import android.os.Environment;
 import android.os.StatFs;
@@ -7,11 +8,27 @@ import android.os.StatFs;
 import net.wigle.wigleandroid.MainActivity;
 
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 
 /**
- * Simple filespace check calls
+ * file space and name routines
  */
 public class FileUtility {
+
+    public final static String APP_DIR = "wiglewifi";
+    public final static String APP_SUB_DIR = "/"+APP_DIR+"/";
+    public final static String CSV_EXT = ".csv";
+    public static final String GPX_DIR = APP_SUB_DIR+"gpx/";
+    public static final String GPX_EXT = ".gpx";
+    public static final String GZ_EXT = ".gz";
+    public final static String KML_DIR = "app_kml";
+    public final static String KML_EXT = ".kml";
+    public static final String M8B_FILE_PREFIX = "export";
+    //public static final String M8B_SOURCE_EXTENSION = ".m8bs";
+    public static final String M8B_DIR = APP_SUB_DIR+"m8b/";
+    public static final String M8B_EXT = ".m8b";
+    public static final String SQL_EXT = ".sqlite";
 
     //ALIBI: can't actually read the size of compressed assets via the asset manager - has to be hardcoded
     //  this can be updated by checking the size of wiglewifiwardriving/src/main/assets/mmcmnc.sqlite on build
@@ -36,20 +53,113 @@ public class FileUtility {
         }
     }
 
+    /**
+     * check internal storage for near-fullness
+     * @return true if we're in the danger zone
+     */
     public static boolean checkInternalStorageDangerZone() {
         return getFreeInternalBytes() > WARNING_THRESHOLD_BYTES;
     }
 
+    /**
+     * check external storage for near-fullness
+     * @return true if we're in the danger zone
+     */
     public static boolean checkExternalStorageDangerZone() {
         return getFreeExternalBytes() > WARNING_THRESHOLD_BYTES;
     }
 
+    /**
+     * get the free bytes on external storage
+     * @return the number of bytes
+     */
     public static long getFreeExternalBytes() {
         return FileUtility.getFreeBytes(Environment.getExternalStorageDirectory());
     }
 
+    /**
+     * get the free bytes on internal storage
+     * @return the number of bytes
+     */
     public static long getFreeInternalBytes() {
         return FileUtility.getFreeBytes(Environment.getDataDirectory());
     }
+
+    /**
+     * Core check to determine whether this device has "external" storage the app can use
+     * @return true if we can find it and we have permission
+     */
+    public static boolean hasSD() {
+        File sdCard = new File(MainActivity.safeFilePath(Environment.getExternalStorageDirectory()) + "/");
+        MainActivity.info("exists: " + sdCard.exists() + " dir: " + sdCard.isDirectory()
+                + " read: " + sdCard.canRead() + " write: " + sdCard.canWrite()
+                + " path: " + sdCard.getAbsolutePath());
+
+        return sdCard.exists() && sdCard.isDirectory() && sdCard.canRead() && sdCard.canWrite();
+    }
+
+    /**
+     * determine the FS location on which the "external" storage is mounted
+     * @return the string file path
+     */
+    public static String getSDPath() {
+        return MainActivity.safeFilePath(Environment.getExternalStorageDirectory()) + APP_SUB_DIR;
+    }
+
+    /**
+     * Create an output file sensitive to the SD availability of the install - currently used for network temp files and KmlWriter output
+     * @param context Context of the application
+     * @param filename the filename to store
+     * @param isCache whether to locate this in the cache directory
+     * @return tje FileOutputStream of the new file
+     * @throws IOException if unable to create the file/directory.
+     */
+    public static FileOutputStream createFile(final Context context, final String filename, final boolean isCache) throws IOException {
+        final String filepath = getSDPath();
+        final File path = new File(filepath);
+
+        final boolean hasSD = hasSD();
+        if (hasSD) {
+            //noinspection ResultOfMethodCallIgnored
+            path.mkdirs();
+            final String openString = filepath + filename;
+            MainActivity.info("openString: " + openString);
+            final File file = new File(openString);
+            if (!file.exists()) {
+                if (!file.createNewFile()) {
+                    throw new IOException("Could not create file: " + openString);
+                }
+            }
+            return new FileOutputStream(file);
+        } else if (isCache) {
+            File file = File.createTempFile(filename, null, context.getCacheDir());
+            return new FileOutputStream(file);
+        }
+
+        //TODO: dedupe w/ KmlDownloader.writeSharefile()
+        if (filename.endsWith(KML_EXT)) {
+            File kmlPath = new File(context.getFilesDir(), KML_DIR);
+            if (!kmlPath.exists()) {
+                kmlPath.mkdir();
+            }
+            if (kmlPath.exists() && kmlPath.isDirectory()) {
+                //DEBUG: MainActivity.info("... file output directory found");
+                File kmlFile = new File(kmlPath, filename);
+                return new FileOutputStream(kmlFile);
+            }
+        }
+        MainActivity.info("saving as: "+filename);
+
+        return context.openFileOutput(filename, Context.MODE_PRIVATE);
+    }
+
+    public static File getErrorStackPath(final Context context) {
+        if (FileUtility.hasSD()) {
+            return new File(MainActivity.safeFilePath(Environment.getExternalStorageDirectory()) + APP_SUB_DIR);
+        }
+        return context.getApplicationContext().getFilesDir();
+    }
+
+    //TODO: get KML/M8B/GPX/CSV paths?
 
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/FileUtility.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/FileUtility.java
@@ -16,17 +16,21 @@ import java.io.IOException;
  */
 public class FileUtility {
 
-    public final static String APP_DIR = "wiglewifi";
-    public final static String APP_SUB_DIR = "/"+APP_DIR+"/";
+    //directory locations - centrally managed here, but must be in sync with fileprovider defs
+    private  final static String APP_DIR = "wiglewifi";
+    private final static String APP_SUB_DIR = "/"+APP_DIR+"/";
+    private static final String GPX_DIR = APP_SUB_DIR+"gpx/";
+    private final static String KML_DIR = "app_kml";
+    private final static String KML_DIR_BASE = "kml";
+    private static final String M8B_DIR = APP_SUB_DIR+"m8b/";
+
     public final static String CSV_EXT = ".csv";
-    public static final String GPX_DIR = APP_SUB_DIR+"gpx/";
+    public static final String ERROR_STACK_FILE_PREFIX = "errorstack";
     public static final String GPX_EXT = ".gpx";
     public static final String GZ_EXT = ".gz";
-    public final static String KML_DIR = "app_kml";
+    public final static String CSV_GZ_EXT = CSV_EXT+GZ_EXT;
     public final static String KML_EXT = ".kml";
     public static final String M8B_FILE_PREFIX = "export";
-    //public static final String M8B_SOURCE_EXTENSION = ".m8bs";
-    public static final String M8B_DIR = APP_SUB_DIR+"m8b/";
     public static final String M8B_EXT = ".m8b";
     public static final String SQL_EXT = ".sqlite";
 
@@ -90,7 +94,7 @@ public class FileUtility {
      * @return true if we can find it and we have permission
      */
     public static boolean hasSD() {
-        File sdCard = new File(MainActivity.safeFilePath(Environment.getExternalStorageDirectory()) + "/");
+        File sdCard = new File(safeFilePath(Environment.getExternalStorageDirectory()) + "/");
         MainActivity.info("exists: " + sdCard.exists() + " dir: " + sdCard.isDirectory()
                 + " read: " + sdCard.canRead() + " write: " + sdCard.canWrite()
                 + " path: " + sdCard.getAbsolutePath());
@@ -103,7 +107,7 @@ public class FileUtility {
      * @return the string file path
      */
     public static String getSDPath() {
-        return MainActivity.safeFilePath(Environment.getExternalStorageDirectory()) + APP_SUB_DIR;
+        return safeFilePath(Environment.getExternalStorageDirectory()) + APP_SUB_DIR;
     }
 
     /**
@@ -140,6 +144,7 @@ public class FileUtility {
         if (filename.endsWith(KML_EXT)) {
             File kmlPath = new File(context.getFilesDir(), KML_DIR);
             if (!kmlPath.exists()) {
+                //noinspection ResultOfMethodCallIgnored
                 kmlPath.mkdir();
             }
             if (kmlPath.exists() && kmlPath.isDirectory()) {
@@ -153,13 +158,166 @@ public class FileUtility {
         return context.openFileOutput(filename, Context.MODE_PRIVATE);
     }
 
+    /**
+     * return the uploads dir if we're using external storage
+     * @return external file location if we're using external/otherwise null
+     * //TODO: do we write uploads to context.getApplicationContext().getFilesDir() if !hasSD?
+     */
+    public static String getUploadFilePath() {
+        if ( hasSD() ) {
+            return getSDPath();
+        }
+        return null;
+    }
+
+    /**
+     * return the m8b dir if we're using external storage
+     * @return external file location if we're using external/otherwise null
+     * //TODO: useful to return the true path if !hasSD?
+     */
+    public static String getM8bPath() {
+        if ( hasSD() ) {
+            return safeFilePath(Environment.getExternalStorageDirectory()) + M8B_DIR;
+        }
+        return null;
+    }
+
+    /**
+     * return the GPX dir if we're using external storage
+     * @return external file location if we're using external/otherwise null
+     * //TODO: useful to return the true path if !hasSD?
+     */
+    public static String getGpxPath() {
+        if ( hasSD() ) {
+            return safeFilePath(Environment.getExternalStorageDirectory()) + GPX_DIR;
+        }
+        return null;
+    }
+
+    /**
+     * just get the KML location for internal purposes; should be compatible with the results of
+     * getKmlDownloadFile
+     * @param context the context of the application
+     * @return the string path suitable for intent construction
+     */
+    public static String getKmlPath(final Context context) {
+        if (hasSD()) {
+            //ALIBI: placing these right in the appdir external in storage for now.
+            return FileUtility.getSDPath();
+        }
+        File f = new File(context.getFilesDir(), KML_DIR);
+        return f.getAbsolutePath();
+    }
+
+    /**
+     * return the error stack dir
+     * @param context application context to locate output
+     * @return the File instance for the path
+     */
     public static File getErrorStackPath(final Context context) {
-        if (FileUtility.hasSD()) {
-            return new File(MainActivity.safeFilePath(Environment.getExternalStorageDirectory()) + APP_SUB_DIR);
+        if (hasSD()) {
+            return new File(getSDPath());
         }
         return context.getApplicationContext().getFilesDir();
     }
 
-    //TODO: get KML/M8B/GPX/CSV paths?
+    public static File getKmlDownloadFile(final Context context, final String fileName, final String localFilePath) {
+        if (hasSD()) {
+            return new File(localFilePath);
+        } else {
+            File dir = new File(context.getFilesDir(), KML_DIR);
+            File file = new File(dir, fileName + KML_EXT);
+            if (!file.exists()) {
+                MainActivity.error("file does not exist: " + file.getAbsolutePath());
+                return null;
+            } else {
+                //DEBUG: MainActivity.info(file.getAbsolutePath());
+                return file;
+            }
+        }
+    }
+
+    public static File getCsvGzFile(final Context context, final String fileName) {
+        File file;
+        if (hasSD()) {
+            file = new File(getSDPath(), fileName);
+        } else {
+            file = new File(context.getFilesDir(), fileName);
+        }
+        if (!file.exists()) {
+            MainActivity.error("file does not exist: " + file.getAbsolutePath());
+            return null;
+        } else {
+            //DEBUG: MainActivity.info(file.getAbsolutePath());
+            return file;
+        }
+
+    }
+
+    /**
+     * Get the latest stack file
+     * @param context context for the request
+     * @return the path string for the latest stack file
+     */
+    public static String getLatestStackfilePath(final Context context) {
+        try {
+            File fileDir = getErrorStackPath(context);
+            if (!fileDir.canRead() || !fileDir.isDirectory()) {
+                MainActivity.error("file is not readable or not a directory. fileDir: " + fileDir);
+            } else {
+                String[] files = fileDir.list();
+                if (files == null) {
+                    MainActivity.error("no files in dir: " + fileDir);
+                } else {
+                    String latestFilename = null;
+                    for (String filename : files) {
+                        if (filename.startsWith(ERROR_STACK_FILE_PREFIX)) {
+                            if (latestFilename == null || filename.compareTo(latestFilename) > 0) {
+                                latestFilename = filename;
+                            }
+                        }
+                    }
+                    MainActivity.info("latest filename: " + latestFilename);
+
+                    return safeFilePath(fileDir) + "/" + latestFilename;
+                }
+            }
+        } catch (Exception ex) {
+            MainActivity.error( "error finding stack file: " + ex, ex );
+        }
+        return null;
+    }
+
+    /**
+     *  safely get the canonical path, as this call throws exceptions on some devices
+     * @param file the file for which to retrieve the cannonical path
+     * @return the String path
+     */
+    private static String safeFilePath(final File file) {
+        String retval = null;
+        try {
+            retval = file.getCanonicalPath();
+        } catch (Exception ex) {
+            MainActivity.error("Failed to get filepath", ex);
+        }
+
+        if (retval == null) {
+            retval = file.getAbsolutePath();
+        }
+        return retval;
+    }
+
+    /**
+     * file inspection debugging method - probably should get moved into a utility class eventually
+     * @param directory the directory to enumerate
+     */
+    public static void printDirContents(final File directory) {
+        System.out.println("\tListing for: "+directory.toString());
+        File[] files = directory.listFiles();
+        System.out.println("\tSize: "+ files.length);
+        for (int i = 0; i < files.length; i++) {
+            System.out.println("\t\t"+files[i].getName()+"\t"+files[i].getAbsoluteFile());
+        }
+    }
 
 }

--- a/wiglewifiwardriving/src/main/res/xml/csvgz_paths.xml
+++ b/wiglewifiwardriving/src/main/res/xml/csvgz_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="csvgz" path="wiglewifi"/>
+    <files-path name="csvgz-internal" path="./"/>
+</paths>


### PR DESCRIPTION
All requests involving paths now moved into FileUtility.
DRY'd up SD pathing, error messaging.
Tested in local and external FS mode on Android Pie, for
  - Upload KML View
  - Database Run KML
  - Database DB KML
  - Database M8B
  - Database CSV RUN
  - Database CSV DB
  - Database GPX
This is a huge change, and deserves extensive testing.