### PR TITLE
[FIX] check the db before using it. like every other method

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
@@ -1362,6 +1362,7 @@ public final class DatabaseHelper extends Thread {
     }
 
     public void clearDefaultRoute() throws DBException {
+        checkDB();
         db.execSQL(CLEAR_DEFAULT_ROUTE);
     }
 


### PR DESCRIPTION
a few NPEs recorded trying to access routes in DB on startup.