### PR TITLE
[FIX] preventing crash on data fragment detatched

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
@@ -619,20 +619,24 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
             if (pd != null) {
                 if (values.length == 1) {
                     MainActivity.info("progress: " + values[0]);
-                    if (values[0] > 0) {
-                        pd.setIndeterminate(false);
-                        if (100 == values[0]) {
-                            if (pd.isShowing()) {
-                                pd.dismiss();
+                    try {
+                        if (values[0] > 0) {
+                            pd.setIndeterminate(false);
+                            if (100 == values[0]) {
+                                if (pd.isShowing()) {
+                                    pd.dismiss();
+                                }
+                                return;
                             }
-                            return;
+                            pd.setMessage(getString(R.string.backup_in_progress));
+                            pd.setProgress(values[0]);
+                        } else {
+                            pd.setIndeterminate(false);
+                            pd.setMessage(getString(R.string.backup_preparing));
+                            pd.setProgress(values[0]);
                         }
-                        pd.setMessage(getString(R.string.backup_in_progress));
-                        pd.setProgress(values[0]);
-                    } else {
-                        pd.setIndeterminate(false);
-                        pd.setMessage(getString(R.string.backup_preparing));
-                        pd.setProgress(values[0]);
+                    } catch (IllegalStateException iex) {
+                        MainActivity.error("lost ability to update progress dialog - detatched fragment?", iex);
                     }
                 } else {
                     MainActivity.warn("too many values for DB Backup progress update");


### PR DESCRIPTION
crash from reporting on `2.51`
```
java.lang.IllegalStateException: Fragment DataFragment{4339e188 (99ef820b-7ce2-4e39-a7fd-9b8ba67fc079)} not attached to a context.
at androidx.fragment.app.Fragment.requireContext(Fragment.java:774)
at androidx.fragment.app.Fragment.getResources(Fragment.java:838)
at androidx.fragment.app.Fragment.getString(Fragment.java:860)
at net.wigle.wigleandroid.DataFragment$BackupTask.onProgressUpdate(DataFragment.java:630)
at net.wigle.wigleandroid.DataFragment$BackupTask.onProgressUpdate(DataFragment.java:542)
```

we COULD try and re-attach to the running activity, but I suspect this is happening when someone shuts the app down or a crash in mid-backup