### PR TITLE
altering WPA3 test to include SAE, OWE, EAP_SUITE_B_192

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.3'
+        classpath 'com.android.tools.build:gradle:3.6.3'
         classpath 'de.undercouch:gradle-download-task:3.4.3'
         classpath 'org.codehaus.groovy:groovy-android-gradle-plugin:2.0.1'
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Aug 25 16:44:01 EDT 2019
+#Wed Jun 03 17:11:28 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
@@ -33,6 +33,10 @@ public final class Network implements ClusterItem {
     private static final String BAR_STRING = " | ";
     private static final String DASH_STRING = " - ";
     private static final String WPA3_CAP = "[WPA3";
+    private static final String SAE_CAP = "SAE";
+    private static final String SUITE_B_192_CAP = "EAP_SUITE_B_192";
+    private static final String OWE_CAP = "OWE";    //ALIBI: handles both OWE and OWE_TRANSITION
+    //TODO: how we do distinguish between RSN-EAP-CCMP WPA2 and WPA3 implementations?
     private static final String WPA2_CAP = "[WPA2";
     private static final String RSN_CAP = "[RSN";
     private static final String WPA_CAP = "[WPA";
@@ -143,7 +147,7 @@ public final class Network implements ClusterItem {
             this.showCapabilities = null;
         }
 
-        if (this.capabilities.contains(WPA3_CAP)) {
+        if (this.capabilities.contains(WPA3_CAP) || this.capabilities.contains(SUITE_B_192_CAP) || this.capabilities.contains(OWE_CAP) || this.capabilities.contains(SAE_CAP)) {
             crypto = CRYPTO_WPA3;
         } else if (this.capabilities.contains(WPA2_CAP) || this.capabilities.contains(RSN_CAP)) {
             crypto = CRYPTO_WPA2;


### PR DESCRIPTION
these don't really address RSN-EAP-CCMP yet, but this will be closer.
new paths not exercised yet due to lack of wpa3 nets in test areas.