### PR TITLE
[FIX] fixing up hash keys for m8b export

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
@@ -804,7 +804,7 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
 
             final SipKey sipkey = new SipKey(new byte[16]);
             final byte[] macBytes = new byte[6];
-            final Map<Integer,Set<mgrs>> mjg = new TreeMap<>();
+            final Map<Long,Set<mgrs>> mjg = new TreeMap<>();
 
             final long genStart = System.currentTimeMillis();
 
@@ -828,12 +828,13 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
                         } else {
                             mgrs m = mgrs.fromUtm(utm.fromLatLon(lat, lon));
 
-                            Integer kslice2 = MagicEightUtil.extractKeyFrom(bssid, macBytes, sipkey, SLICE_BITS);
+                            Long kslice2 = MagicEightUtil.extractKeyFrom(bssid, macBytes, sipkey, SLICE_BITS);
+
                             if (null != kslice2) {
                                 Set<mgrs> locs = mjg.get(kslice2);
                                 if (locs == null) {
                                     locs = new HashSet<>();
-                                    mjg.put(kslice2, locs);
+                                    mjg.put((long)kslice2, locs);
                                 }
                                 if (locs.add(m)) {
                                     records++;
@@ -888,8 +889,8 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
                             bb.clear();
                             byte[] mstr = new byte[9];
                             int outElements = 0;
-                            for ( Map.Entry<Integer,Set<mgrs>> me : mjg.entrySet()) {
-                                int key = me.getKey().intValue();
+                            for ( Map.Entry<Long,Set<mgrs>> me : mjg.entrySet()) {
+                                long key = me.getKey();
                                 for ( mgrs m : me.getValue() ) {
                                     if (bb.remaining() < recordsize ) {
                                         bb.flip();
@@ -899,7 +900,7 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
                                         bb.clear();
                                     }
                                     m.populateBytes(mstr);
-                                    bb.putInt(key).put(mstr);
+                                    bb.putLong(key).put(mstr);
                                 }
                                 outElements++;
                                 if (outElements % 100 == 0) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/MagicEightUtil.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/MagicEightUtil.java
@@ -10,14 +10,14 @@ public class MagicEightUtil {
      * read mac from text string into macbytes. run siphahsh(skipkeky,macbytes) and mask
      * the low-n bits (n=10 would only produce integer less than 1024)
      */
-    public static Integer extractKeyFrom(String mac, byte[] macbytes, SipKey sipkey, int n) {
+    public static Long extractKeyFrom(String mac, byte[] macbytes, SipKey sipkey, int n) {
 
         if (mac.length() != 17) {
             //ALIBI: invalid MAC
             return null;
         }
 
-        Integer kslice2 = Integer.valueOf( extractIntKeyFrom(mac,macbytes,sipkey,n) );
+        Long kslice2 = Long.valueOf( extractLongKeyFrom(mac,macbytes,sipkey,n) );
         if (kslice2 == -1) {
             return null;
         }
@@ -28,8 +28,7 @@ public class MagicEightUtil {
      * read mac from text string into macbytes. run siphahsh(skipkeky,macbytes) and mask
      * the low-n bits (n=10 would only produce integer less than 1024)
      */
-    public static int extractIntKeyFrom(String mac, byte[] macbytes, SipKey sipkey, int n) {
-
+    public static long extractLongKeyFrom(String mac, byte[] macbytes, SipKey sipkey, int n) {
         for ( int i = 0; i < macbytes.length; i++ ) {
             char hi = mac.charAt(i*3);
             char lo = mac.charAt(i*3+1);
@@ -37,12 +36,9 @@ public class MagicEightUtil {
             byte lob = nybbleFrom(lo);
             macbytes[i] = (byte)( hib | lob);
         }
-
         long siph = SipHash.digest(sipkey, macbytes);
-
         long mask = (1L << n ) - 1;
-
-        return (int)(siph & mask);
+        return (siph & mask);
     }
 
     /**


### PR DESCRIPTION
converting sipkey hashables to long (avoiding negative ints inherent in signed int32)
Doing this right would involve a test suite.