### PR TITLE
[FIX] should prevent another unicode-based filename upload crash.

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
@@ -55,6 +55,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -1006,7 +1007,7 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
             // TODO: android R FS changes
             final boolean hasSD = FileUtility.hasSD();
 
-            final DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+            final DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US);
             final String name = df.format(new Date());
             final String nameStr = "<name>" + name + "</name><trkseg>\n";
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlWriter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlWriter.java
@@ -42,14 +42,13 @@ public class KmlWriter extends AbstractBackgroundTask {
         this.btNetworks = (btNetworks == null) ? null : new HashSet<String>(btNetworks);
     }
 
-    @SuppressLint("SimpleDateFormat")
     @Override
     protected void subRun() throws IOException {
         final Bundle bundle = new Bundle();
 
 
-        final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        final SimpleDateFormat fileDateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+        final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
+        final SimpleDateFormat fileDateFormat = new SimpleDateFormat("yyyyMMddHHmmss", Locale.US);
         final String filename = WIWI_PREFIX + fileDateFormat.format(new Date()) + KML_EXT;
 
         final FileOutputStream fos = FileUtility.createFile(context, filename, false);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
@@ -403,7 +403,6 @@ public class ObservationUploader extends AbstractProgressApiRequest {
      * @throws PackageManager.NameNotFoundException
      * @throws InterruptedException
      */
-    @SuppressLint("SimpleDateFormat")
     private long writeFileWithCursor( final OutputStream fos, final Bundle bundle,
                                       final ObservationUploader.CountStats countStats,
                                       final Cursor cursor ) throws IOException,
@@ -413,7 +412,7 @@ public class ObservationUploader extends AbstractProgressApiRequest {
         long maxId = prefs.getLong( ListFragment.PREF_DB_MARKER, 0L );
 
         final long start = System.currentTimeMillis();
-        final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
         countStats.lineCount = 0;
         final int total = cursor.getCount();
         long fileWriteMillis = 0;
@@ -643,11 +642,10 @@ public class ObservationUploader extends AbstractProgressApiRequest {
         charBuffer.position( charBuffer.position() + stringBuffer.length() );
     }
 
-    @SuppressLint("SimpleDateFormat")
     public static OutputStream getOutputStream(final Context context, final Bundle bundle,
                                                final Object[] fileFilename)
             throws IOException {
-        final SimpleDateFormat fileDateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+        final SimpleDateFormat fileDateFormat = new SimpleDateFormat("yyyyMMddHHmmss", Locale.US);
         final String filename = WIWI_PREFIX + fileDateFormat.format(new Date()) + CSV_EXT + GZ_EXT;
 
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/CsvUtil.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/CsvUtil.java
@@ -8,6 +8,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Quick and dirty line-based CSV to string array mapper.
@@ -18,8 +19,7 @@ public class CsvUtil {
     public static final char CR = '\r';
     public static final char LF = '\n';
 
-    @SuppressLint("SimpleDateFormat")
-    private static final SimpleDateFormat CSV_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    private static final SimpleDateFormat CSV_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
 
     public static String[] lineToArray(final String line) {
         List<String> a = new ArrayList<>();


### PR DESCRIPTION
kinda amazed we didn't receive a report of this sooner.
forcing US ascii dates in files and filenames.