### PR TITLE
[ENH] making the map observation markers zoom-proof

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/NetworkActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/NetworkActivity.java
@@ -44,6 +44,7 @@ import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.MapView;
 import com.google.android.gms.maps.MapsInitializer;
 import com.google.android.gms.maps.OnMapReadyCallback;
+import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.CameraPosition;
 import com.google.android.gms.maps.model.CircleOptions;
 import com.google.android.gms.maps.model.LatLng;
@@ -303,12 +304,11 @@ public class NetworkActivity extends AppCompatActivity implements DialogListener
                                     googleMap.moveCamera(CameraUpdateFactory.newCameraPosition(cameraPosition));
                                 }
 
-                                googleMap.addCircle(new CircleOptions()
-                                        .center(latLon)
-                                        .radius(4)
-                                        .fillColor(NetworkListUtil.getSignalColor(level, true))
-                                        .strokeWidth(0)
-                                        .zIndex(level));
+                                BitmapDescriptor obsIcon = NetworkListUtil.getSignalBitmap(
+                                        getApplicationContext(), level);
+
+                                googleMap.addMarker(new MarkerOptions().icon(obsIcon)
+                                        .position(latLon).zIndex(level));
                                 count++;
                             }
                             // if we got a good centroid, display it and center on it

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/NetworkListUtil.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/NetworkListUtil.java
@@ -2,9 +2,22 @@ package net.wigle.wigleandroid.ui;
 
 import android.bluetooth.BluetoothClass;
 import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
 import android.graphics.Color;
+import android.graphics.drawable.Drawable;
 import android.provider.Settings;
 
+import androidx.annotation.ColorInt;
+import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
+import androidx.core.content.res.ResourcesCompat;
+import androidx.core.graphics.drawable.DrawableCompat;
+
+import com.google.android.gms.maps.model.BitmapDescriptor;
+import com.google.android.gms.maps.model.BitmapDescriptorFactory;
+
+import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.R;
 import net.wigle.wigleandroid.model.Network;
 import net.wigle.wigleandroid.model.NetworkType;
@@ -70,6 +83,29 @@ public class NetworkListUtil {
             color = alpha ? COLOR_2A : COLOR_2;
         }
         return color;
+    }
+
+    public static BitmapDescriptor getSignalBitmap(@NonNull Context context, final int level) {
+        int color = getSignalColor(level, true);
+        return getBitmapFromVector(context, R.drawable.observation, color);
+    }
+
+    public static BitmapDescriptor getBitmapFromVector(@NonNull Context context,
+                                                       @DrawableRes int vectorResourceId,
+                                                       @ColorInt int tintColor) {
+        Drawable vectorDrawable = ResourcesCompat.getDrawable(
+                context.getResources(), vectorResourceId, null);
+        if (vectorDrawable == null) {
+            MainActivity.error("Requested vector resource was not found");
+            return BitmapDescriptorFactory.defaultMarker();
+        }
+        Bitmap bitmap = Bitmap.createBitmap(vectorDrawable.getIntrinsicWidth(),
+                vectorDrawable.getIntrinsicHeight(), Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        vectorDrawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        DrawableCompat.setTint(vectorDrawable, tintColor);
+        vectorDrawable.draw(canvas);
+        return BitmapDescriptorFactory.fromBitmap(bitmap);
     }
 
     public static int getImage(final Network network) {

--- a/wiglewifiwardriving/src/main/res/drawable/observation.xml
+++ b/wiglewifiwardriving/src/main/res/drawable/observation.xml
@@ -1,0 +1,12 @@
+<vector android:autoMirrored="true" android:height="22dp"
+    android:viewportHeight="76.63928" android:viewportWidth="76.63928"
+    android:width="22dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillAlpha="0.032258" android:fillColor="#ff0000"
+        android:pathData="M38.3196,38.3196m-37.4196,0a37.4196,37.4196 0,1 1,74.8393 0a37.4196,37.4196 0,1 1,-74.8393 0"
+        android:strokeColor="#ffffff" android:strokeLineCap="round"
+        android:strokeLineJoin="round" android:strokeWidth="1.8"/>
+    <path android:fillColor="#ffffff"
+        android:pathData="M38.3196,38.3196m-32.128,0a32.128,32.128 0,1 1,64.2559 0a32.128,32.128 0,1 1,-64.2559 0"
+        android:strokeColor="#00000000" android:strokeLineCap="round"
+        android:strokeLineJoin="round" android:strokeWidth="0.5"/>
+</vector>

--- a/wiglewifiwardriving/src/main/res/layout/search.xml
+++ b/wiglewifiwardriving/src/main/res/layout/search.xml
@@ -47,5 +47,4 @@
         android:hint="CA1E234FECABE"
         android:layout_weight="1"
         />
-
 </LinearLayout>

--- a/wiglewifiwardriving/src/main/res/layout/search_nets.xml
+++ b/wiglewifiwardriving/src/main/res/layout/search_nets.xml
@@ -48,5 +48,4 @@
                 android:text="@string/reset_button"/>
         </LinearLayout>
     </LinearLayout>
-
 </ScrollView>


### PR DESCRIPTION
using geo-shape circles in the map network detail created circumstances where zooming in and out would render the observations too small to see or large enough to interfere with the map. (https://github.com/wiglenet/wigle-wifi-wardriving/pull/436 was highlighting this by dynamically zooming in/out) Using markers derived from a vector asset remedies this problem, as well as giving us "click targets" if we want to provide detail of individual observation properties in future releases.