### PR TITLE
[FIX] day/night on SDK28+

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/GPSListener.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/GPSListener.java
@@ -316,8 +316,9 @@ public class GPSListener implements Listener, LocationListener {
             final boolean speechGPS = prefs.getBoolean( ListFragment.PREF_SPEECH_GPS, true );
             if ( speechGPS ) {
                 // no quotes or the voice pauses
-                final String speakAnnounce = location == null ? "Lost Location"
-                        : "Now have location from " + location.getProvider() + ".";
+
+                final String speakAnnounce = location == null ? mainActivity.getString(R.string.lost_location)
+                        : mainActivity.getString(R.string.have_location) + " " + location.getProvider() + ".";
                 mainActivity.speak( speakAnnounce );
             }
 


### PR DESCRIPTION
this is an attempt to get a clean UI restart on theme change without breaking everything. some of this is just de-crufting.

- TTS setup was launching on each UI re-instantiation because it was part of setup sound; does the setLocale call above it in onCreate handle this?
- setLocal was being called twice in onCreate (?!)
- adding an atomicBoolean to prevent service termination on a simple UI start; feels like the elaboration of a bad idea, but the alternative is to completely unwire our service management stuff from MainActivity which seems equally fraught
- some linting just because MainActivity is a file that's been through tons of changes over the course of a decade, wanted to see what the real warnings were.