### PR TITLE
[ENH] Settable display theme in SDK 28+

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
@@ -100,16 +100,18 @@ public class DashboardFragment extends Fragment {
     public void run() {
         // make sure the app isn't trying to finish
         if ( ! finishing.get() ) {
-          final View view = getView();
-          if (view != null) {
-            updateUI( view );
-          }
-
-          final long period = 1000L;
-          // info("wifitimer: " + period );
-          timer.postDelayed( this, period );
-        }
-        else {
+            try {
+                final View view = getView();
+                if (view != null) {
+                    updateUI(view);
+                }
+            } catch (Exception e) {
+                MainActivity.error("failed to update dash UI: ",e);
+            }
+            final long period = 1000L;
+            // info("wifitimer: " + period );
+            timer.postDelayed( this, period );
+        } else {
           MainActivity.info( "finishing mapping timer" );
         }
     }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -119,7 +119,6 @@ import java.util.regex.Pattern;
 import static android.location.LocationManager.GPS_PROVIDER;
 
 public final class MainActivity extends AppCompatActivity implements TextToSpeech.OnInitListener {
-
     //*** state that is retained ***
     public static class State {
         public MxcDatabaseHelper mxcDbHelper;
@@ -2722,6 +2721,14 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             dialog.show();
         }
         return safe;
+    }
+
+    public static void setTheme(final SharedPreferences prefs) {
+        if (Build.VERSION.SDK_INT > 28) {
+            final int displayMode = prefs.getInt(ListFragment.PREF_DAYNIGHT_MODE, AppCompatDelegate.MODE_NIGHT_YES);
+            info("set theme called: "+displayMode);
+            AppCompatDelegate.setDefaultNightMode(displayMode);
+        }
     }
 
     /**

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
@@ -17,6 +17,8 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+
+import androidx.appcompat.app.AppCompatDelegate;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import android.text.Editable;
@@ -505,6 +507,14 @@ public final class SettingsFragment extends Fragment implements DialogListener {
                 getString(R.string.language_zh_tw), getString(R.string.language_zh_hk),
         };
         SettingsUtil.doSpinner( R.id.language_spinner, view, ListFragment.PREF_LANGUAGE, "", languages, languageName, getContext() );
+
+        if (Build.VERSION.SDK_INT > 28) {
+            View theme = view.findViewById(R.id.theme_section);
+            theme.setVisibility(View.VISIBLE);
+            final Integer[] themes = new Integer[] {AppCompatDelegate.MODE_NIGHT_YES, AppCompatDelegate.MODE_NIGHT_NO, AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM};
+            final String[] themeName = new String[]{getString(R.string.theme_dark_label), getString(R.string.theme_light_label), getString(R.string.theme_follow_label)};
+            SettingsUtil.doSpinner(R.id.theme_spinner, view, ListFragment.PREF_DAYNIGHT_MODE, AppCompatDelegate.MODE_NIGHT_YES, themes, themeName, getContext());
+        }
 
         final String off = getString(R.string.off);
         final String sec = " " + getString(R.string.sec);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/SettingsUtil.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/SettingsUtil.java
@@ -77,11 +77,11 @@ public class SettingsUtil {
         Object period = null;
         if ( periods instanceof Long[] ) {
             period = prefs.getLong( pref, (Long) spinDefault );
-        }
-        else if ( periods instanceof String[] ) {
+        } else if ( periods instanceof String[] ) {
             period = prefs.getString( pref, (String) spinDefault );
-        }
-        else {
+        } else if (periods instanceof Integer[] ) {
+            period = prefs.getInt( pref, (Integer) spinDefault);
+        } else {
             MainActivity.error("unhandled object type array: " + Arrays.toString(periods) + " class: " + periods.getClass());
         }
 
@@ -107,19 +107,21 @@ public class SettingsUtil {
                 // MainActivity.info( pref + " setting period: " + period );
                 if ( period instanceof Long ) {
                     editor.putLong( pref, (Long) period );
-                }
-                else if ( period instanceof String ) {
+                } else if ( period instanceof String ) {
                     editor.putString( pref, (String) period );
-                }
-                else {
+                } else if (period instanceof Integer) {
+                    editor.putInt(pref, (Integer)period);
+                } else {
                     MainActivity.error("unhandled object type: " + period + " class: " + period.getClass());
                 }
                 editor.apply();
 
-                if ( period instanceof String ) {
+                if ( pref.equals(ListFragment.PREF_LANGUAGE) ) {
                     MainActivity.setLocale( context, context.getResources().getConfiguration() );
                 }
-
+                if ( pref.equals(ListFragment.PREF_DAYNIGHT_MODE) ) {
+                    MainActivity.setTheme(prefs);
+                }
             }
             @Override
             public void onNothingSelected( final AdapterView<?> arg0 ) {}

--- a/wiglewifiwardriving/src/main/res/layout/settings.xml
+++ b/wiglewifiwardriving/src/main/res/layout/settings.xml
@@ -192,7 +192,31 @@
             android:layout_gravity="left"
             />
     </LinearLayout>
-
+    <LinearLayout
+        android:id="@+id/theme_section"
+        android:orientation="horizontal"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dip"
+        android:layout_marginBottom="2dip"
+        android:visibility="gone"
+        >
+        <Spinner android:id="@+id/theme_spinner"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:drawSelectorOnTop="true"
+            android:layout_weight="0"
+            android:prompt="@string/theme_settings_label"
+            />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:text="@string/theme_settings_label"
+            android:layout_weight="1"
+            android:layout_marginRight="6dip"
+            android:layout_gravity="left"
+            />
+    </LinearLayout>
     <TextView
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"

--- a/wiglewifiwardriving/src/main/res/values-ar/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ar/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">أخفق التنزيل: لم يتم حفظ النتيجة.</string>
     <string name="not_proc">لم تتم معالجتها.&#160;</string>
+    <string name="theme_settings_label">عرض الموضوع</string>
+    <string name="theme_light_label">الضوء</string>
+    <string name="theme_dark_label">المظلم</string>
+    <string name="theme_follow_label">اتبع النظام</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-cs-rCZ/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-cs-rCZ/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">Stahování se nezdařilo: výsledek nebyl uložen.</string>
     <string name="not_proc">&#160;nezpracováno.</string>
+    <string name="theme_settings_label">Zobrazit téma</string>
+    <string name="theme_light_label">světelný</string>
+    <string name="theme_dark_label">tmavý</string>
+    <string name="theme_follow_label">Sledujte systém</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-da/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-da/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">Download mislykkedes: resultatet blev ikke gemt.</string>
     <string name="not_proc">&#160;ikke behandlet.</string>
+    <string name="theme_settings_label">Vis tema</string>
+    <string name="theme_light_label">Lys</string>
+    <string name="theme_dark_label">Mørk</string>
+    <string name="theme_follow_label">Følg systemet</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-de/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-de/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">Download fehlgeschlagen.</string>
     <string name="not_proc">&#160;nicht verarbeitet.</string>
+    <string name="theme_settings_label">Thema anzeigen</string>
+    <string name="theme_light_label">Licht</string>
+    <string name="theme_dark_label">Dunkler</string>
+    <string name="theme_follow_label">System folgen</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-es-rES/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-es-rES/strings.xml
@@ -424,4 +424,8 @@
     <string name="plus_gps">+GPS: </string>
     <string name="dl_failed">Error de descarga: el resultado no se ha guardado.</string>
     <string name="not_proc"> no procesado.</string>
+    <string name="theme_settings_label">Tema de visualización</string>
+    <string name="theme_light_label">Luz</string>
+    <string name="theme_dark_label">Oscuro</string>
+    <string name="theme_follow_label">Seguir el sistema</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fi/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">Lataus epäonnistui: tulosta ei tallennettu.</string>
     <string name="not_proc">&#160;käsittelemätön.</string>
+    <string name="theme_settings_label">Näytä teema</string>
+    <string name="theme_light_label">Kevyt</string>
+    <string name="theme_dark_label">Tumma</string>
+    <string name="theme_follow_label">Seuraa järjestelmää</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fr/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">Échec du téléchargement: le résultat n\'a pas été enregistré.</string>
     <string name="not_proc">&#160;non traité.</string>
+    <string name="theme_settings_label">Thème d\'affichage</string>
+    <string name="theme_light_label">Lumière</string>
+    <string name="theme_dark_label">Sombre</string>
+    <string name="theme_follow_label">Suivez système</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fy/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fy/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">Downloaden mislukt: resultaat is niet opgeslagen.</string>
     <string name="not_proc">&#160;niet verwerkt.</string>
+    <string name="theme_settings_label">Thema weergeven</string>
+    <string name="theme_light_label">Lichte</string>
+    <string name="theme_dark_label">Donkere</string>
+    <string name="theme_follow_label">Volg systeem</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-he/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-he/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">ההורדה נכשלה: התוצאה לא נשמרה.</string>
     <string name="not_proc">לא מעובד.&#160;</string>
+    <string name="theme_settings_label">נושא תצוגה</string>
+    <string name="theme_light_label">אור</string>
+    <string name="theme_dark_label">כהה</string>
+    <string name="theme_follow_label">עקוב אחר המערכת</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hi-rIN/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hi-rIN/strings.xml
@@ -424,4 +424,8 @@
     <string name="plus_gps">+GPS:</string>
     <string name="dl_failed">डाउनलोड विफल हुआ: परिणाम सहेजा नहीं गया था.</string>
     <string name="not_proc">संसाधित नहीं किया गया.</string>
+    <string name="theme_settings_label">विषय प्रदर्शित करें</string>
+    <string name="theme_light_label">प्रकाश</string>
+    <string name="theme_dark_label">डार्क</string>
+    <string name="theme_follow_label">सिस्टम का पालन करें</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hu-rHU/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hu-rHU/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">A letöltés sikertelen: az eredmény nem lett mentve.</string>
     <string name="not_proc">&#160;nem feldolgozott.</string>
+    <string name="theme_settings_label">Téma megjelenítése</string>
+    <string name="theme_light_label">Fény</string>
+    <string name="theme_dark_label">Sötét</string>
+    <string name="theme_follow_label">Kövesse a rendszert</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-it-rIT/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-it-rIT/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">Download non riuscito: il risultato non è stato salvato.</string>
     <string name="not_proc">&#160;non processato.</string>
+    <string name="theme_settings_label">Visualizza il tema</string>
+    <string name="theme_light_label">Luce</string>
+    <string name="theme_dark_label">Scura</string>
+    <string name="theme_follow_label">Segui il sistema</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ja-rJP/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ja-rJP/strings.xml
@@ -424,4 +424,8 @@
     <string name="plus_gps">+ GPS： </string>
     <string name="dl_failed">ダウンロードに失敗しました：結果は保存されませんでした。</string>
     <string name="not_proc"> 処理されていません。</string>
+    <string name="theme_settings_label">テーマを表示</string>
+    <string name="theme_light_label">ライト</string>
+    <string name="theme_dark_label">ダーク</string>
+    <string name="theme_follow_label">フォローシステム</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ko/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ko/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">다운로드 실패 : 결과가 저장되지 않았습니다.</string>
     <string name="not_proc">&#160;진행되지 않았다.</string>
+    <string name="theme_settings_label">디스플레이 테마</string>
+    <string name="theme_light_label">라이트</string>
+    <string name="theme_dark_label">다크</string>
+    <string name="theme_follow_label">팔로우 시스템</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-nl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nl/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">Downloaden mislukt: resultaat is niet opgeslagen.</string>
     <string name="not_proc">&#160;niet verwerkt.</string>
+    <string name="theme_settings_label">Thema weergeven</string>
+    <string name="theme_light_label">Lichte</string>
+    <string name="theme_dark_label">Donkere</string>
+    <string name="theme_follow_label">Volg systeem</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-nn/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nn/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">Nedlastingen mislyktes: resultatet ble ikke lagret.</string>
     <string name="not_proc">&#160;ikke behandlet.</string>
+    <string name="theme_settings_label">Vis tema</string>
+    <string name="theme_light_label">Lys</string>
+    <string name="theme_dark_label">Mørk</string>
+    <string name="theme_follow_label">Følg System</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-no/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-no/strings.xml
@@ -427,4 +427,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">Nedlastingen mislyktes: resultatet ble ikke lagret.</string>
     <string name="not_proc">&#160;ikke behandlet.</string>
+    <string name="theme_settings_label">Vis tema</string>
+    <string name="theme_light_label">Lys</string>
+    <string name="theme_dark_label">Mørk</string>
+    <string name="theme_follow_label">Følg System</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pl-rPL/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pl-rPL/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">Pobieranie nie powiodło się: wynik nie został zapisany.</string>
     <string name="not_proc">&#160;nieprzetworzony.</string>
+    <string name="theme_settings_label">Motyw wyświetlacza</string>
+    <string name="theme_light_label">światła</string>
+    <string name="theme_dark_label">ciemny</string>
+    <string name="theme_follow_label">śledzić system</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">Falha no download: o resultado não foi salvo.</string>
     <string name="not_proc">&#160;não processado.</string>
+    <string name="theme_settings_label">Tema de exibição</string>
+    <string name="theme_light_label">Luz</string>
+    <string name="theme_dark_label">Escuro</string>
+    <string name="theme_follow_label">Seguir sistema</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt-rPT/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rPT/strings.xml
@@ -424,4 +424,8 @@
     <string name="plus_gps">+GPS: </string>
     <string name="dl_failed">O download falhou: o resultado não foi guardado.</string>
     <string name="not_proc">não processado.</string>
+    <string name="theme_settings_label">Tema de exibição</string>
+    <string name="theme_light_label">Luz</string>
+    <string name="theme_dark_label">Escuro</string>
+    <string name="theme_follow_label">Seguir sistema</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ru/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ru/strings.xml
@@ -425,4 +425,8 @@
     <string name="prevmonthrank_title">Месячный рейтинг за последний месяц</string>
     <string name="prevrank_title">Рейтинг пользователя за последний месяц</string>
     <string name="calculating_m8b">Вычисление оракула</string>
+    <string name="theme_settings_label">Тема отображения</string>
+    <string name="theme_light_label">Легкий</string>
+    <string name="theme_dark_label">Темный</string>
+    <string name="theme_follow_label">Следить за системой</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-sv-rSE/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-sv-rSE/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">Nedladdningen misslyckades: resultatet sparades inte.</string>
     <string name="not_proc">&#160;inte bearbetad.</string>
+    <string name="theme_settings_label">Visa tema</string>
+    <string name="theme_light_label">Ljus</string>
+    <string name="theme_dark_label">Mörkt</string>
+    <string name="theme_follow_label">Följ systemet</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-sw/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-sw/strings.xml
@@ -424,4 +424,8 @@
     <string name="plus_gps">+GPS: </string>
     <string name="dl_failed">Imeshindwa kupakua: matokeo hayajahifadhiwa.</string>
     <string name="not_proc"> haijachakatwa.</string>
+    <string name="theme_settings_label">Onyesha mandhari</string>
+    <string name="theme_light_label">Nyepesi</string>
+    <string name="theme_dark_label">Meusi</string>
+    <string name="theme_follow_label">Fuata mfumo</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-tr-rTR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-tr-rTR/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">İndirme başarısız oldu: sonuç kaydedilmedi.</string>
     <string name="not_proc">&#160;işlenmemiş.</string>
+    <string name="theme_settings_label">Ekran teması</string>
+    <string name="theme_light_label">Açık</string>
+    <string name="theme_dark_label">Koyu</string>
+    <string name="theme_follow_label">Sistemi takip et</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rCN/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rCN/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">下载失败：未保存结果。</string>
     <string name="not_proc">&#160;未处理。</string>
+    <string name="theme_settings_label">显示主题</string>
+    <string name="theme_light_label">灯光模式</string>
+    <string name="theme_dark_label">暗模式</string>
+    <string name="theme_follow_label">追踪系统</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rHK/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rHK/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">下載失敗：未保存結果。</string>
     <string name="not_proc">&#160;未處理。</string>
+    <string name="theme_settings_label">顯示主題</string>
+    <string name="theme_light_label">燈光模式</string>
+    <string name="theme_dark_label">暗模式</string>
+    <string name="theme_follow_label">追踪系統</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rTW/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rTW/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">下載失敗：未保存結果。</string>
     <string name="not_proc">&#160;未處理。</string>
+    <string name="theme_settings_label">顯示主題</string>
+    <string name="theme_light_label">燈光模式</string>
+    <string name="theme_dark_label">暗模式</string>
+    <string name="theme_follow_label">追踪系統</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">下载失败：未保存结果。</string>
     <string name="not_proc">&#160;未处理。</string>
+    <string name="theme_settings_label">显示主题</string>
+    <string name="theme_light_label">灯光模式</string>
+    <string name="theme_dark_label">暗模式</string>
+    <string name="theme_follow_label">追踪系统</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values/strings.xml
@@ -425,4 +425,8 @@
     <string name="plus_gps">+GPS:&#160;</string>
     <string name="dl_failed">Download failed: result was not saved.</string>
     <string name="not_proc">&#160;not processed.</string>
+    <string name="theme_settings_label">Display theme</string>
+    <string name="theme_light_label">Light</string>
+    <string name="theme_dark_label">Dark</string>
+    <string name="theme_follow_label">Follow System</string>
 </resources>


### PR DESCRIPTION
- adding preferences for dark/light/follow display theme mode in SDK 28-and-up devices.
- google-translated labels for the preference that everyone will certainly hate.
- renaming some language file values directories to include rXX country codes, improving IDE support and opening the door to finer-grained localization in the future.
- small stability enhancement in dash from email bug report