### PR TITLE
[ENH] adding run distance info to notification badge

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
@@ -1,7 +1,6 @@
 package net.wigle.wigleandroid;
 
 import android.app.Activity;
-import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.location.Location;
@@ -23,6 +22,7 @@ import android.widget.ScrollView;
 import android.widget.TextView;
 
 import net.wigle.wigleandroid.listener.GPSListener;
+import net.wigle.wigleandroid.ui.UINumberFormat;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
@@ -273,7 +273,7 @@ public class DashboardFragment extends Fragment {
 
   private void updateDist(final View view, final SharedPreferences prefs, final int id, final String pref, final String title ) {
       float dist = prefs.getFloat(pref, 0f);
-      final String distString = metersToString(prefs, numberFormat, getActivity(), dist, false);
+      final String distString = UINumberFormat.metersToString(prefs, numberFormat, getActivity(), dist, false);
       final TextView tv = view.findViewById(id);
       tv.setText( title + " " + distString );
   }
@@ -295,26 +295,6 @@ public class DashboardFragment extends Fragment {
       final String durString = timeString(cumulative);
       final TextView tv = view.findViewById( id );
       tv.setText(durString );
-  }
-
-  public static String metersToString(final SharedPreferences prefs, final NumberFormat numberFormat, final Context context, final float meters,
-      final boolean useShort ) {
-      final boolean metric = prefs.getBoolean( ListFragment.PREF_METRIC, false );
-      String retval;
-      if ( meters > 3000f ) {
-          if ( metric ) {
-              retval = numberFormat.format( meters / 1000f ) + " " + context.getString(R.string.km_short);
-          } else {
-              retval = numberFormat.format( meters / 1609.344f ) + " " +
-                      (useShort ? context.getString(R.string.mi_short) : context.getString(R.string.miles));
-          }
-      } else if (metric) {
-          retval = numberFormat.format( meters ) + " " + (useShort ? context.getString(R.string.m_short) : context.getString(R.string.meters));
-      } else {
-          retval = numberFormat.format( meters * 3.2808399f  ) + " " +
-              (useShort ? context.getString(R.string.ft_short) : context.getString(R.string.feet));
-      }
-      return retval;
   }
 
   @Override

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
@@ -3,7 +3,6 @@
 
 package net.wigle.wigleandroid;
 
-import android.animation.Animator;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;
@@ -735,10 +734,10 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
             } else {
                 if (main != null) {
                     final SharedPreferences prefs = main.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
-                    final String distString = DashboardFragment.metersToString(prefs,
+                    final String distString = UINumberFormat.metersToString(prefs,
                             state.numberFormat0, main, location.getAccuracy(), true);
                     tv4.setText("+/- " + distString);
-                    final String accString = DashboardFragment.metersToString(prefs,
+                    final String accString = UINumberFormat.metersToString(prefs,
                             state.numberFormat0, main, (float) location.getAltitude(), true);
                     tv5.setText(getString(R.string.list_short_alt) + " " + accString);
                 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
@@ -614,7 +614,7 @@ public final class MappingFragment extends Fragment {
                     tv.setText(UINumberFormat.counterFormat(ListFragment.lameStatic.dbNets));
                     if (prefs != null) {
                         float dist = prefs.getFloat(ListFragment.PREF_DISTANCE_RUN, 0f);
-                        final String distString = DashboardFragment.metersToString(prefs,
+                        final String distString = UINumberFormat.metersToString(prefs,
                                 numberFormat, getActivity(), dist, true);
                         tv = view.findViewById(R.id.rundistance);
                         tv.setText(distString);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/WigleService.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/WigleService.java
@@ -7,17 +7,22 @@ import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
+import android.content.res.Configuration;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.drawable.Icon;
 import android.os.Binder;
 import android.os.Build;
 import android.os.IBinder;
-import android.widget.RemoteViews;
 
 import androidx.annotation.RequiresApi;
 import androidx.core.app.NotificationCompat;
 
+import net.wigle.wigleandroid.ui.UINumberFormat;
+
+import java.text.NumberFormat;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public final class WigleService extends Service {
@@ -168,12 +173,31 @@ public final class WigleService extends Service {
                 final PendingIntent contentIntent = PendingIntent.getActivity(this, 0, notificationIntent, 0);
                 final long dbNets = ListFragment.lameStatic.dbNets;
                 String text = context.getString(R.string.list_waiting_gps);
+
+                String distString = "";
+                SharedPreferences prefs = getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+                if (prefs != null) {
+                    Locale locale = null;
+                    Configuration sysConfig = getResources().getConfiguration();
+                    if (null != sysConfig) {
+                        locale = sysConfig.locale;
+                    }
+                    if (null == locale) {
+                        locale = Locale.US;
+                    }
+                    NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
+                    numberFormat.setMaximumFractionDigits(1);
+
+                    final float dist = prefs.getFloat(ListFragment.PREF_DISTANCE_RUN, 0f);
+                    distString = " ("+UINumberFormat.metersToString(prefs, numberFormat, this, dist, true) + ")";
+                }
                 if (dbNets > 0) {
                     long runNets = ListFragment.lameStatic.runNets + ListFragment.lameStatic.runBt;
                     long newNets = ListFragment.lameStatic.newNets;
                     text = context.getString(R.string.run) + ": " + runNets
                             + "  " + context.getString(R.string.new_word) + ": " + newNets
-                            + "  " + context.getString(R.string.db) + ": " + dbNets;
+                            + "  " + context.getString(R.string.db) + ": " + dbNets
+                            + distString;
                 }
                 if (!MainActivity.isScanning(context)) {
                     text = context.getString(R.string.list_scanning_off) + " " + text;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
@@ -1,7 +1,5 @@
 package net.wigle.wigleandroid.listener;
 
-import static android.location.LocationManager.GPS_PROVIDER;
-
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
@@ -15,7 +13,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 
 import net.wigle.wigleandroid.model.ConcurrentLinkedHashMap;
-import net.wigle.wigleandroid.DashboardFragment;
 import net.wigle.wigleandroid.db.DatabaseHelper;
 import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.MainActivity;
@@ -27,6 +24,7 @@ import net.wigle.wigleandroid.model.NetworkType;
 import net.wigle.wigleandroid.FilterMatcher;
 import net.wigle.wigleandroid.R;
 import net.wigle.wigleandroid.ui.NetworkListSorter;
+import net.wigle.wigleandroid.ui.UINumberFormat;
 import net.wigle.wigleandroid.util.CellNetworkLegend;
 import net.wigle.wigleandroid.ui.WiGLEToast;
 
@@ -35,7 +33,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.content.SharedPreferences.Editor;
 import android.database.SQLException;
 import android.location.Location;
 import android.net.wifi.ScanResult;
@@ -755,7 +752,7 @@ public class WifiReceiver extends BroadcastReceiver {
         }
         if ( prefs.getBoolean( ListFragment.PREF_SPEAK_MILES, true ) ) {
             final float dist = prefs.getFloat( ListFragment.PREF_DISTANCE_RUN, 0f );
-            final String distString = DashboardFragment.metersToString(prefs, numberFormat1, mainActivity, dist, false );
+            final String distString = UINumberFormat.metersToString(prefs, numberFormat1, mainActivity, dist, false );
             builder.append(mainActivity.getString(R.string.tts_from)).append(" ")
                     .append(distString).append( ", " );
         }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/UINumberFormat.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/UINumberFormat.java
@@ -1,5 +1,13 @@
 package net.wigle.wigleandroid.ui;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import net.wigle.wigleandroid.ListFragment;
+import net.wigle.wigleandroid.R;
+
+import java.text.NumberFormat;
+
 public class UINumberFormat {
     /**
      * format the topbar counters
@@ -20,4 +28,23 @@ public class UINumberFormat {
         }
     }
 
+    public static String metersToString(final SharedPreferences prefs, final NumberFormat numberFormat, final Context context, final float meters,
+                                        final boolean useShort ) {
+        final boolean metric = prefs.getBoolean( ListFragment.PREF_METRIC, false );
+        String retval;
+        if ( meters > 3000f ) {
+            if ( metric ) {
+                retval = numberFormat.format( meters / 1000f ) + " " + context.getString(R.string.km_short);
+            } else {
+                retval = numberFormat.format( meters / 1609.344f ) + " " +
+                        (useShort ? context.getString(R.string.mi_short) : context.getString(R.string.miles));
+            }
+        } else if (metric) {
+            retval = numberFormat.format( meters ) + " " + (useShort ? context.getString(R.string.m_short) : context.getString(R.string.meters));
+        } else {
+            retval = numberFormat.format( meters * 3.2808399f  ) + " " +
+                (useShort ? context.getString(R.string.ft_short) : context.getString(R.string.feet));
+        }
+        return retval;
+    }
 }


### PR DESCRIPTION
Adding distance travelled (in prefs units) to notification element. Allows user to see distance for current program execution without unlocking device.