### PR TITLE
[FIX] proposed fix for play console exception - needs review

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
@@ -402,8 +402,10 @@ public final class DatabaseHelper extends Thread {
             }
         }
         catch ( final Throwable throwable ) {
-            MainActivity.writeError( Thread.currentThread(), throwable, context );
-            throw new RuntimeException( "DatabaseHelper throwable: " + throwable, throwable );
+            if ( ! done.get() ) { // ALIBI: no need to crash / error if this was a query post-terminate.
+                MainActivity.writeError(Thread.currentThread(), throwable, context);
+                throw new RuntimeException("DatabaseHelper throwable: " + throwable, throwable);
+            }
         }
 
         MainActivity.info("db worker thread shutting down");

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
@@ -405,6 +405,8 @@ public final class DatabaseHelper extends Thread {
             if ( ! done.get() ) { // ALIBI: no need to crash / error if this was a query post-terminate.
                 MainActivity.writeError(Thread.currentThread(), throwable, context);
                 throw new RuntimeException("DatabaseHelper throwable: " + throwable, throwable);
+            } else {
+                MainActivity.warn("DB error during shutdown - ignoring: ", throwable);
             }
         }
 


### PR DESCRIPTION
there's a narrow window in the run loop for DatabaseHelper where a request gets issued, but blows up because we've terminated the app - we can choose not to freak out if the error happened because of asynchrony during shutdown, but I'm not positive that this is a wholly harmless change, would appreciate insight into the original design.