### PR TITLE
[FIX] removing vulnerable lib version

### DIFF
--- a/wiglewifiwardriving/build.gradle
+++ b/wiglewifiwardriving/build.gradle
@@ -70,7 +70,6 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.12.12'
     implementation 'ru.egslava:MaskedEditText:1.0.5'
     implementation 'com.goebl:simplify:1.0.0'
-    implementation 'commons-io:commons-io:2.6'
     //TODO: MinAPI issue: implementation 'com.babylon.certificatetransparency:certificatetransparency-android:0.2.0'
     testImplementation 'junit:junit:4.13'
     testImplementation 'androidx.test:core:1.3.0'

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/BackgroundGuiHandler.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/BackgroundGuiHandler.java
@@ -22,8 +22,6 @@ import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 
-import org.apache.commons.io.FilenameUtils;
-
 import java.io.File;
 
 import static net.wigle.wigleandroid.util.FileUtility.CSV_EXT;
@@ -156,7 +154,7 @@ public class BackgroundGuiHandler extends Handler {
                                 final String filePath = msg.peekData().getString(FILEPATH);
                                 //MainActivity.debug("File: "+filePath+" ("+fileName+")");
                                 if (null != filePath) {
-                                    File file = FileUtility.getKmlDownloadFile(this.context, FilenameUtils.removeExtension(fileName), filePath);
+                                    File file = FileUtility.getKmlDownloadFile(this.context, removeFileExtension(fileName), filePath);
                                     if (file == null || !file.exists()) {
                                         showError(fm, msg, status);
                                         MainActivity.error("UNABLE to export file - no access to " + filePath + " - " + fileName);
@@ -310,5 +308,21 @@ public class BackgroundGuiHandler extends Handler {
 
             return ad;
         }
+    }
+
+    /**
+     * ALIBI: simple filename ext. remover for Android. commons.io versions without security vulns (2.7 and up) break out backward compat.
+     * @param fileName the input filename
+     * @return the fileName minus the extension
+     * @throws IllegalArgumentException
+     */
+    private static String removeFileExtension(final String fileName) throws IllegalArgumentException {
+        if (fileName == null || fileName.indexOf(0) >= 0) {
+            throw new IllegalArgumentException("Invalid file name.");
+        }
+        final int extensionPos = fileName.lastIndexOf('.');
+        final int lastSeparator = fileName.lastIndexOf('/');
+        int index =  lastSeparator > extensionPos ? -1 : extensionPos;
+        return fileName.substring(0, index);
     }
 }


### PR DESCRIPTION
weeps: can't upgrade commons.io without breaking backwards compat < API 24.