### PR TITLE
[ENH] making export GPX filenames clearer. 

### DIFF
--- a/wiglewifiwardriving/build.gradle
+++ b/wiglewifiwardriving/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation 'org.slf4j:slf4j-android:1.7.19'
     implementation 'com.fasterxml.jackson.core:jackson-core:2.9.0.pr3'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.10'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.10.8'
     implementation 'com.squareup.okhttp3:okhttp:3.12.12'
     implementation 'ru.egslava:MaskedEditText:1.0.5'
     implementation 'com.goebl:simplify:1.0.0'

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/AsyncGpxExportTask.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/AsyncGpxExportTask.java
@@ -161,7 +161,8 @@ public class AsyncGpxExportTask extends AsyncTask<Long, Integer, String> {
             }
             // fire share intent?
             Intent intent = new Intent(Intent.ACTION_SEND);
-            intent.putExtra(Intent.EXTRA_SUBJECT, "WiGLE.gpx");
+            final String fileName = (gpxDestFile != null && !gpxDestFile.getName().isEmpty()) ? gpxDestFile.getName() : "WiGLE.gpx";
+            intent.putExtra(Intent.EXTRA_SUBJECT, fileName);
             intent.setType("application/gpx");
 
             //TODO: verify local-only storage case/gpx_paths.xml


### PR DESCRIPTION
using datestamp
also a jackson version bump for security