### PR TITLE
[ENH] Determining the coverage area of a given access point

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
@@ -237,10 +237,27 @@ public class WifiReceiver extends BroadcastReceiver {
                 }
                 somethingAdded |= added;
 
-                if ( location != null && (added || network.getLatLng() == null) ) {
-                    // set the LatLng for mapping
-                    final LatLng LatLng = new LatLng( location.getLatitude(), location.getLongitude() );
-                    network.setLatLng( LatLng );
+                if (location != null) {
+                    final LatLng currentLocation = new LatLng(location.getLatitude(), location.getLongitude());
+                    
+                    // Set the current location if the current network location value is null
+                    if (added || network.getLatLng() == null || network.getLowLatLng() == null) {
+                        network.setLatLng(currentLocation);
+                        network.setLatLng(currentLocation);
+                    } 
+                    
+                    // If the current signal level is lower, update the network low level and low geopoint
+                    if (result.level < network.getLowLevel()) {
+                        network.setLowLevel(result.level);
+                        network.setLowLatLng(currentLocation);
+                    }
+                    
+                    // If the current signal level is higher, update the network level and geopoint
+                    if (result.level > network.getLevel()) {
+                        network.setLevel(result.level);
+                        network.setLatLng(currentLocation);
+                    }
+
                     MainActivity.addNetworkToMap(network);
                 }
 
@@ -422,6 +439,11 @@ public class WifiReceiver extends BroadcastReceiver {
         if ( speechPeriod != 0 && now - previousTalkTime > speechPeriod * 1000L ) {
             doAnnouncement( preQueueSize, newWifiCount, newCellCount, now );
         }
+    }
+
+    private void setNetworkLocationInfo()
+    {
+
     }
 
     /**

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
@@ -38,10 +38,14 @@ public final class Network implements ClusterItem {
     private NetworkType type;
 
     private int frequency;
-    private int level;
     private Integer channel;
-    private LatLng geoPoint;
     private boolean isNew;
+    
+    private int level;
+    private LatLng geoPoint;
+    
+    private int lowLevel;
+    private LatLng lowGeoPoint;
 
     private String detail;
     private final long constructionTime = System.currentTimeMillis(); // again
@@ -85,6 +89,7 @@ public final class Network implements ClusterItem {
         this.frequency = frequency;
         this.capabilities = ( capabilities == null ) ? "" : capabilities;
         this.level = level;
+        this.lowLevel = level;
         this.type = type;
         if (this.type.equals(NetworkType.typeForCode("W"))) {
             this.channel = channelForWiFiFrequencyMhz(frequency);
@@ -162,6 +167,10 @@ public final class Network implements ClusterItem {
         return level;
     }
 
+    public int getLowLevel() {
+        return lowLevel;
+    }
+
     public NetworkType getType() {
         return type;
     }
@@ -172,6 +181,10 @@ public final class Network implements ClusterItem {
 
     public void setLevel( final int level ) {
         this.level = level;
+    }
+
+    public void setLowLevel(final int level) {
+        this.lowLevel = lowLevel;
     }
 
     // Overloading for *FCN in GSM-derived networks for now. a subclass is probably more correct.
@@ -235,8 +248,16 @@ public final class Network implements ClusterItem {
         this.geoPoint = geoPoint;
     }
 
+    public void setLowLatLng(LatLng geoPoint) {
+        this.lowGeoPoint = geoPoint;
+    }
+
     public LatLng getLatLng() {
         return geoPoint;
+    }
+
+    public LatLng getLowLatLng() {
+        return lowGeoPoint;
     }
 
     public String getOui(final OUI oui) {


### PR DESCRIPTION
The functionality that I would like to implement is the ability to save information in which location a given network has the lowest signal level and to overwrite the default location, if the signal turned out to be stronger. Having these two pieces of information will allow to estimate the area in which a given network is available. One of my projects is able to properly parse data from the wigle scanner and adding such functionality would be very useful both for the wigle platform itself and for other independent projects.

My branch currently does not have the support for network CSV export implemented, also the new functionality has no unit test coverage yet.