### PR TITLE
[FIX] OUI availability check implementation

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
@@ -240,14 +240,16 @@ public final class Network implements ClusterItem {
     }
 
     public String getOui(final OUI oui) {
-        String retval = "";
+        if (oui == null || !oui.isOuiAvailable()) return "";
+
         final String lookup = getBssid().replace(":", "").toUpperCase();
-        if (oui != null && lookup.length() >= 9) {
-            retval = oui.getOui(lookup.substring(0, 9));
-            if (retval == null) retval = oui.getOui(lookup.substring(0, 7));
-            if (retval == null) retval = oui.getOui(lookup.substring(0, 6));
-        }
-        return retval == null ? "" : retval;
+        if (lookup.length() < 9) return "";
+
+        String brandName = oui.getOui(lookup.substring(0, 9));
+        if (brandName == null) brandName = oui.getOui(lookup.substring(0, 7));
+        if (brandName == null) brandName = oui.getOui(lookup.substring(0, 6));
+
+        return brandName == null ? "" : brandName;
     }
 
     @Override

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/OUI.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/OUI.java
@@ -9,7 +9,7 @@ import java.util.Properties;
 
 public final class OUI {
     private final Properties properties = new Properties();
-    private final boolean propertiesAvailable = false;
+    private boolean propertiesAvailable = false;
 
     public OUI(final AssetManager assetManager) {
         try {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/OUI.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/OUI.java
@@ -14,11 +14,11 @@ public final class OUI {
     public OUI(final AssetManager assetManager) {
         try {
             final InputStream ouiStream = assetManager.open("oui.properties");
-            Logging.info("Oui stream: " + stream);
+            Logging.info("Oui stream: " + ouiStream);
 
             InputStreamReader ouiStreamReader = new InputStreamReader(ouiStream, "UTF-8");
             properties.load(ouiStreamReader);
-            Logging.info("Oui properites loaded successful");
+            Logging.info("Oui properties loaded successful");
 
             propertiesAvailable = true;
         

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/OUI.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/OUI.java
@@ -1,9 +1,7 @@
 package net.wigle.wigleandroid.model;
 
 import android.content.res.AssetManager;
-
 import net.wigle.wigleandroid.util.Logging;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -11,21 +9,38 @@ import java.util.Properties;
 
 public final class OUI {
     private final Properties properties = new Properties();
+    private final boolean propertiesAvailable = false;
+
     public OUI(final AssetManager assetManager) {
         try {
-            final InputStream stream = assetManager.open("oui.properties");
-            Logging.info("oui stream: " + stream);
+            final InputStream ouiStream = assetManager.open("oui.properties");
+            Logging.info("Oui stream: " + stream);
 
-            InputStreamReader isr = new InputStreamReader(stream, "UTF-8");
-            properties.load(isr);
-            Logging.info("oui load complete");
-        }
-        catch (final IOException ex) {
-            Logging.error("exception loading oui: " + ex, ex);
+            InputStreamReader ouiStreamReader = new InputStreamReader(ouiStream, "UTF-8");
+            properties.load(ouiStreamReader);
+            Logging.info("Oui properites loaded successful");
+
+            propertiesAvailable = true;
+        
+        } catch (final IOException ex) {
+            Logging.error("Oui properties loading failed: " + ex, ex);
+            propertiesAvailable = false;
         }
     }
 
+    /**
+    * Returns the name of the manufacturer assigned to a given OUI or null value when the OUI does not exist or the data is not available.
+    */
     public String getOui(final String partial) {
+        if (!propertiesAvailable) return null;
+        
         return properties.getProperty(partial);
+    }
+
+    /**
+    * Returns a boolean value informing whether the OUI data was successfully loaded and whether it is available.
+    */
+    public boolean isOuiAvailable() {
+        return propertiesAvailable;
     }
 }


### PR DESCRIPTION
Minor change to the OUI class, which now includes an additional boolean value to indicate if *Properties* initialization was successful. Although *Properties* is initialized, it is partially protected against ["Partially initialized instances"](https://www.oracle.com/java/technologies/javase/seccodeguide.html#7-3). Moreover, I added a method that can check if OUI data is available. When *Properties* does not contain a given key, the return value is null, but keeping the information about data availability we do not have to rely on this mechanic.

