### PR TITLE
[ENH] Debug logging implementation

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -218,6 +218,8 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
     public static final boolean DEBUG_CELL_DATA = false;
     public static final boolean DEBUG_BLUETOOTH_DATA = false;
 
+    public static final boolean ENABLE_DEBUG_LOGGING = false;
+
     private static MainActivity mainActivity;
     private BatteryLevelReceiver batteryLevelReceiver;
     private boolean playServiceShown = false;
@@ -231,6 +233,12 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (ENABLE_DEBUG_LOGGING) {
+            Logging.enableDebugLogging();
+            Logging.info("Debug log-level is enabled.");
+        }
+
         Logging.info("MAIN onCreate. state:  " + state);
         workAroundGoogleMapsBug();
         final SharedPreferences prefs = getSharedPreferences(ListFragment.SHARED_PREFS, 0);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/Logging.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/Logging.java
@@ -9,6 +9,7 @@ import net.wigle.wigleandroid.MainActivity;
  */
 public class Logging {
     private static final String LOG_TAG = "wigle";
+    private static Boolean debugLogging = false;
 
     public static void info(final String value) {
         Log.i(LOG_TAG, Thread.currentThread().getName() + "] " + value);
@@ -38,5 +39,23 @@ public class Logging {
     public static void error(final String value, final Throwable t) {
         Log.e(LOG_TAG, Thread.currentThread().getName() + "] " + value, t);
         MainActivity.saveLog(value);
+    }
+
+    public static void debug(final String value) {
+        if (!debugLogging) return;
+        
+        Log.d(LOG_TAG, Thread.currentThread().getName() + "] " + value);
+        MainActivity.saveLog(value);
+    }
+
+    public static void debug(final String value, final Throwable t) {
+        if (!debugLogging) return;
+        
+        Log.d(LOG_TAG, Thread.currentThread().getName() + "] " + value, t);
+        MainActivity.saveLog(value);
+    }
+
+    private static void enableDebugLogging() {
+        debugLogging = true;
     }
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/Logging.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/Logging.java
@@ -55,7 +55,10 @@ public class Logging {
         MainActivity.saveLog(value);
     }
 
-    private static void enableDebugLogging() {
+    /**
+     * Enable debug-log-level logging via the Logging class
+     */
+    public static void enableDebugLogging() {
         debugLogging = true;
     }
 }


### PR DESCRIPTION
There is a information in the [TODO ](https://github.com/wiglenet/wigle-wifi-wardriving/blob/master/TODO) file to implement logging methods with debug log-level. There are no other implementation details so I interpreted it as follows. I have added two methods which are adapters for ``Android.util.Log`` debug-log methods, just like other methods in the ``Logging`` class. There is also a static field that decides if we will log in debug mode and a ``enableDebugLogging()`` method which can be used to activate debug logging (this method can be called in the application's entrypoint).