### PR TITLE
[ENH] Original SSID with commas valid CSV format fix

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
@@ -479,8 +479,9 @@ public class ObservationUploader extends AbstractProgressApiRequest {
                 countStats.lineCount++;
                 String ssid = network.getSsid();
                 if (ssid.contains(COMMA)) {
-                    // comma isn't a legal ssid character, but just in case
-                    ssid = ssid.replaceAll( COMMA, "_" );
+                    // When the ssid is containing a comma, we must wrap the ssid with
+                    // quotes to ensure the output CSV format is valid
+                    ssid = String.format("\"%s\"", ssid);
                 }
                 // ListActivity.debug("writing network: " + ssid );
 


### PR DESCRIPTION
I do not know if this pull request will be approved because I assume that the compatibility with the WiGLE backend is key and it probably handles SSIDs in its own way (in which the commas have been replaced with underscores). Recently, while researching networks, I came across a large number of networks with SSIDs containing commas. The names looked something like this:
```
Hotspot 2,4Ghz
Hotspot 5,0Ghz
```
In one of my projects, I dealt with the appropriate SSID formatting on the backend, but here this problem can be solved during the object-CSV serialization stage. The solution is to put the SSID in quotation marks according to the [RFC4180](https://datatracker.ietf.org/doc/html/rfc4180#section-1):

_6.  Fields containing line breaks (CRLF), double quotes, and commas should be enclosed in double-quotes._

Thanks to this, the CSV format will be valid and we will maintain the highest level of compliance with the actual parameters of a given access point.