### PR TITLE
[ENH] Dashboard scan toggle support

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
@@ -37,6 +37,7 @@ import net.wigle.wigleandroid.util.Logging;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class DashboardFragment extends Fragment {
@@ -356,7 +357,7 @@ public class DashboardFragment extends Fragment {
                 PREF_QUICK_PAUSE,
                 QUICK_SCAN_PAUSE,
                 QUICK_SCAN_DO_NOTHING,
-                R.id.nav_list,
+                R.id.nav_dash,
                 QUICK_PAUSE_DIALOG);
     }
 
@@ -452,15 +453,13 @@ public class DashboardFragment extends Fragment {
   }
 
   private String timeString(final long duration) {
-    //TODO: better to just use TimeUnit?
-    int seconds = (int) (duration / 1000) % 60 ;
-    int minutes = (int) ((duration / (1000*60)) % 60);
-    int hours   = (int) ((duration / (1000*60*60)) % 24);
-    String durString = String.format("%02d", minutes)+":"+String.format("%02d", seconds);
-    if (hours > 0) {
-      durString = String.format("%d", hours) + ":" + durString;
-    }
-    return " " +durString;
+    int seconds = (int)TimeUnit.MILLISECONDS.toSeconds(duration);
+    int minutes = (int)TimeUnit.MILLISECONDS.toMinutes(duration);
+    int hours = (int)TimeUnit.MILLISECONDS.toHours(duration);
+
+    return hours > 0
+            ? String.format(" %d:%02d:%02d", hours, minutes, seconds)
+            : String.format(" %02d:%02d", minutes, seconds);
   }
 
 }

--- a/wiglewifiwardriving/src/main/res/layout/dashtop.xml
+++ b/wiglewifiwardriving/src/main/res/layout/dashtop.xml
@@ -6,23 +6,35 @@
     android:layout_height="fill_parent"
     android:keepScreenOn="true" >
 
+<!--    <RelativeLayout-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        android:orientation="horizontal"-->
+<!--        android:id="@+id/dash_status_bar"-->
+
+<!--        android:visibility="gone">-->
+<!--        <TextView-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:id="@+id/dash_scanstatus"-->
+<!--            android:textSize="16sp"-->
+<!--            android:textColor="#FFFFFF"-->
+<!--            android:background="#A0FF0000"-->
+<!--            android:paddingTop="2dp"-->
+<!--            android:paddingBottom="4dp"-->
+<!--            android:gravity="center"-->
+<!--            />-->
+<!--    </RelativeLayout>-->
+
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:id="@+id/dash_status_bar"
+        android:layout_height="wrap_content">
 
-        android:visibility="gone">
-        <TextView
+        <Button android:id="@+id/dashboard_scan_toggle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:id="@+id/dash_scanstatus"
-            android:textSize="16sp"
-            android:textColor="#FFFFFF"
-            android:background="#A0FF0000"
-            android:paddingTop="2dp"
-            android:paddingBottom="4dp"
-            android:gravity="center"
+            android:text="SCAN"
+            android:layout_weight="1"
             />
     </RelativeLayout>
 


### PR DESCRIPTION
The goal of this pull request is to implement the functionality proposed by users. Information about the scanning status from the dashboard will be replaced with a button that allows you to pause/resume the scanning process. I have refactored, also a function that formats the run and scan duration as suggested by _TODO_. I ran into a problem implementing `ConfirmationDialog`. I was guided by the code from `MainActivity`, but despite calling `ConfirmationDialog`, the `SharedPreference` does not change and such exception appears:
```
I/wigle: main] exception handling fragment alert dialog: java.lang.ClassCastException: net.wigle.wigleandroid.DashboardFragment cannot be cast to net.wigle.wigleandroid.DialogListener
    java.lang.ClassCastException: net.wigle.wigleandroid.DashboardFragment cannot be cast to net.wigle.wigleandroid.DialogListener
        at net.wigle.wigleandroid.MainActivity$ConfirmationDialog$1.onClick(MainActivity.java:942)
        at com.android.internal.app.AlertController$ButtonHandler.handleMessage(AlertController.java:172)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6669)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
```
I would be very grateful for suggestions on how to deal with this problem and get this pull request to be mergeable.