### PR TITLE
ENH: Dashboard TimeUnit based timeString()

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
@@ -28,6 +28,7 @@ import net.wigle.wigleandroid.util.Logging;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class DashboardFragment extends Fragment {
@@ -352,15 +353,15 @@ public class DashboardFragment extends Fragment {
   }
 
   private String timeString(final long duration) {
-    //TODO: better to just use TimeUnit?
-    int seconds = (int) (duration / 1000) % 60 ;
-    int minutes = (int) ((duration / (1000*60)) % 60);
-    int hours   = (int) ((duration / (1000*60*60)) % 24);
-    String durString = String.format("%02d", minutes)+":"+String.format("%02d", seconds);
-    if (hours > 0) {
-      durString = String.format("%d", hours) + ":" + durString;
-    }
-    return " " +durString;
+    long seconds = TimeUnit.MILLISECONDS.toSeconds(duration);
+    long minutes = TimeUnit.MILLISECONDS.toMinutes(duration);
+    long hours = TimeUnit.MILLISECONDS.toHours(duration);
+    
+    Locale defaultLocale = Locale.getDefault();
+    
+    return hours > 0
+      ? String.format(defaultLocale," %d:%02d:%02d", hours, minutes, seconds)
+      : String.format(defaultLocale, " %02d:%02d", minutes, seconds);
   }
 
 }


### PR DESCRIPTION
This small pull request contains one of the changes that appeared in a different [closed pull request](https://github.com/wiglenet/wigle-wifi-wardriving/pull/531). The ```timeString()``` method used for formatting the scan related time duration has been refactored in such a way that it uses ```TimeUnit``` and that the formatted string has an explicit locale (good practices).