### PR TITLE
[FIX] Min sdk updates

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* 2.68 (2022)
+minimum SDK update to satisfy Google's new requirements
+GNSSStatus LocationManager changes
+Fixes for start-on-boot in Android 10+ (requires manual pefs config update)
+
 * 2.65 - 2.67 (10/10/2022)
 German language fixes (thanks rumpelyann!)
 Various polish/log/toast improvements (thanks Krzysztofz01!)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@
 minimum SDK update to satisfy Google's new requirements
 GNSSStatus LocationManager changes
 Fixes for start-on-boot in Android 10+ (requires manual pefs config update)
+Adding stats badge to user stats view
 
 * 2.65 - 2.67 (10/10/2022)
 German language fixes (thanks rumpelyann!)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ As of December 2022, this application supports Android SDK versions 19 (KitKat) 
 - Accumulate a database of wireless signal observations
 - Search and export observed data
 - Integrate with a [WiGLE.net account](https://wigle.net) for competition, statistics, and online aggregation and visualization
-- See your standings and accomplisments per the WiGLE.net server
+- See your standings and accomplishments per the WiGLE.net server
 
 ## Data Export
 The client offers numerous data export formats including:

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # WiGLE Wireless Wardriving
 
-Nethugging client for Android, from [wigle.net](https://wigle.net).
+Nethugging client for Android, from [wigle.net](https://wigle.net). 
 
 This client provides geolocated detection and logging for WiFi, Bluetooth, and cellular signals using Android devices.
 
+As of December 2022, this application supports Android SDK versions 19 (KitKat) and up. For older versions, see the [2.67 release tag](https://github.com/wiglenet/wigle-wifi-wardriving/releases/tag/2.67) to build your own copy or side-load [the compiled artifact](https://github.com/wiglenet/wigle-wifi-wardriving/blob/2.67/dist/release/wiglewifiwardriving-release.apk). 
+
 ## Features
-- View and map local RF signals
+- View and map local RF signals including WiFi, Blueooth, and Cell
 - Accumulate a database of wireless signal observations
 - Search and export observed data
 - Integrate with a [WiGLE.net account](https://wigle.net) for competition, statistics, and online aggregation and visualization
+- See your standings and accomplisments per the WiGLE.net server
 
 ## Data Export
 The client offers numerous data export formats including:
@@ -30,7 +33,13 @@ Currently Android versions from KitKat (Android 4.4.3 / API 19) to Android 12 (A
 We receive various bug reports from forks/ports of Android to non-standard devices, but cannot address or test all possible variations. While we do our best to support the widest range of devices possible, the best way to get support for your device is to help us debug or to submit a pull request!
 
 ## Contributing
-You can submit fixes and changes for inclusion by forking this repository, working in a branch, and issuing a pull request.
+You can submit fixes and changes for inclusion by forking this repository, working in a branch, and issuing a pull request. Langauge help and translations are VERY welcome.
+
+We don't have a lot of contribution guidelines, but please:
+
+- Make sure to test your changes
+- Make sure that exporting data is the result of a direct, intentional user action, or via the Android Broadcast Intent system - don't send data off-device without user permission!
+- Please be mindful of the need for multi-language support if adding text to the UI. Google translate is enough to get people started, but please add an attempt!
 
 ## Where to get it
 Available on [Google Play](https://play.google.com/store/apps/details?id=net.wigle.wigleandroid&hl=en)

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:7.3.1'
         classpath 'de.undercouch:gradle-download-task:3.4.3'
     }
 }

--- a/wiglewifiwardriving/build.gradle
+++ b/wiglewifiwardriving/build.gradle
@@ -5,12 +5,26 @@ apply plugin: 'de.undercouch.download'
 
 android {
     namespace "net.wigle.wigleandroid"
-    compileSdkVersion 30
-
+    compileSdkVersion 31
+    flavorDimensions "version"
+    productFlavors {
+        legacy {
+            dimension "version"
+            minSdkVersion 14
+            versionCode 1401  // Min API level 14, v01
+            applicationIdSuffix ".legacy"
+            versionNameSuffix "-legacy"
+        }
+        current {
+            dimension "version"
+            minSdkVersion 19
+            versionCode 1901  // Min API level 19, v01
+        }
+    }
     defaultConfig {
         applicationId "net.wigle.wigleandroid"
-        minSdkVersion 14
-        targetSdkVersion 30
+        minSdkVersion 19
+        targetSdkVersion 31
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
         multiDexEnabled true
@@ -51,23 +65,28 @@ ext {
 
 dependencies {
     implementation project(':android-maps-utils')
-    implementation "androidx.core:core:1.3.2"
-    implementation "androidx.legacy:legacy-support-core-utils:1.0.0"
-    implementation "androidx.appcompat:appcompat:1.2.0"
-    implementation "com.google.android.material:material:1.3.0"
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
-    implementation "androidx.appcompat:appcompat:1.2.0"
-    implementation "com.google.android.gms:play-services-maps:17.0.1"
+    implementation "androidx.legacy:legacy-support-core-utils:1.0.0"
+    legacyImplementation "androidx.core:core:1.3.2"
+    legacyImplementation "androidx.appcompat:appcompat:1.2.0"
+    legacyImplementation "com.google.android.material:material:1.3.0"
+    legacyImplementation "androidx.appcompat:appcompat:1.2.0"
+    legacyImplementation "com.google.android.gms:play-services-maps:17.0.1"
+    currentImplementation "androidx.core:core:1.6.0"
+    currentImplementation "androidx.appcompat:appcompat:1.4.2"
+    currentImplementation "com.google.android.material:material:1.6.0"
+    currentImplementation "androidx.appcompat:appcompat:1.3.0"
+    currentImplementation "com.google.android.gms:play-services-maps:18.1.0"
     implementation 'com.google.android.gms:play-services-vision:20.1.3'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'org.slf4j:slf4j-android:1.7.19'
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.9.0.pr3'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.11.1'
     implementation 'com.fasterxml.jackson.core:jackson-annotations:2.11.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.10.8'
-    implementation 'com.squareup.okhttp3:okhttp:3.12.12'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.11.1'
+    implementation 'com.squareup.okhttp3:okhttp:3.14.9'
     implementation 'ru.egslava:MaskedEditText:1.0.5'
     implementation 'com.goebl:simplify:1.0.0'
-    //TODO: MinAPI issue: implementation 'com.babylon.certificatetransparency:certificatetransparency-android:0.2.0'
+    currentImplementation 'com.babylon.certificatetransparency:certificatetransparency-android:0.3.0'
     testImplementation 'junit:junit:4.13'
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/wiglewifiwardriving/build.gradle
+++ b/wiglewifiwardriving/build.gradle
@@ -6,21 +6,6 @@ apply plugin: 'de.undercouch.download'
 android {
     namespace "net.wigle.wigleandroid"
     compileSdkVersion 31
-    flavorDimensions "version"
-    productFlavors {
-        legacy {
-            dimension "version"
-            minSdkVersion 14
-            versionCode 1401  // Min API level 14, v01
-            applicationIdSuffix ".legacy"
-            versionNameSuffix "-legacy"
-        }
-        current {
-            dimension "version"
-            minSdkVersion 19
-            versionCode 1901  // Min API level 19, v01
-        }
-    }
     defaultConfig {
         applicationId "net.wigle.wigleandroid"
         minSdkVersion 19
@@ -67,16 +52,11 @@ dependencies {
     implementation project(':android-maps-utils')
     implementation "androidx.legacy:legacy-support-v4:1.0.0"
     implementation "androidx.legacy:legacy-support-core-utils:1.0.0"
-    legacyImplementation "androidx.core:core:1.3.2"
-    legacyImplementation "androidx.appcompat:appcompat:1.2.0"
-    legacyImplementation "com.google.android.material:material:1.3.0"
-    legacyImplementation "androidx.appcompat:appcompat:1.2.0"
-    legacyImplementation "com.google.android.gms:play-services-maps:17.0.1"
-    currentImplementation "androidx.core:core:1.6.0"
-    currentImplementation "androidx.appcompat:appcompat:1.4.2"
-    currentImplementation "com.google.android.material:material:1.6.0"
-    currentImplementation "androidx.appcompat:appcompat:1.3.0"
-    currentImplementation "com.google.android.gms:play-services-maps:18.1.0"
+    implementation "androidx.core:core:1.6.0"
+    implementation "androidx.appcompat:appcompat:1.4.2"
+    implementation "com.google.android.material:material:1.6.0"
+    implementation "androidx.appcompat:appcompat:1.3.0"
+    implementation "com.google.android.gms:play-services-maps:18.1.0"
     implementation 'com.google.android.gms:play-services-vision:20.1.3'
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'org.slf4j:slf4j-android:1.7.19'
@@ -86,7 +66,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.14.9'
     implementation 'ru.egslava:MaskedEditText:1.0.5'
     implementation 'com.goebl:simplify:1.0.0'
-    currentImplementation 'com.babylon.certificatetransparency:certificatetransparency-android:0.3.0'
+    implementation 'com.babylon.certificatetransparency:certificatetransparency-android:0.3.0'
     testImplementation 'junit:junit:4.13'
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/wiglewifiwardriving/src/main/AndroidManifest.xml
+++ b/wiglewifiwardriving/src/main/AndroidManifest.xml
@@ -12,6 +12,9 @@
         android:smallScreens="true"
         android:xlargeScreens="true" />
 
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
@@ -24,12 +27,13 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-    <uses-permission android:name="android.permission.WRITE_SETTINGS" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="net.wigle.wigleandroid.permission.MAPS_RECEIVE" />
     <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!-- permission for start-on-boot -->
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
     <!-- confine camera activation to Marshmallow and up. -->
     <!-- NB: this functionality exists as early as JellyBean (4.2.2), but not worth the thrash -->
@@ -283,6 +287,9 @@
             android:permission="android.permission.RECEIVE_BOOT_COMPLETED">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
+                <action android:name="android.intent.action.LOCKED_BOOT_COMPLETED" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </receiver>

--- a/wiglewifiwardriving/src/main/AndroidManifest.xml
+++ b/wiglewifiwardriving/src/main/AndroidManifest.xml
@@ -18,8 +18,8 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <!-- uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION"/ -->
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN, BLUETOOTH_ADVERTISE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/wiglewifiwardriving/src/main/AndroidManifest.xml
+++ b/wiglewifiwardriving/src/main/AndroidManifest.xml
@@ -18,8 +18,8 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <!-- uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION"/ -->
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN, BLUETOOTH_ADVERTISE" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"  />
+    <uses-permission android:name="BLUETOOTH_ADVERTISE"/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ActivateActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ActivateActivity.java
@@ -48,11 +48,6 @@ public class ActivateActivity extends Activity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_activate);
 
-        //TODO: figure out what checks (if any) make manual setup necessary with AppCompat theme
-        //if (Build.VERSION.SDK_INT >= 11) {
-        //    getActionBar().setDisplayHomeAsUpEnabled(true);
-        //}
-
         Uri data = getIntent().getData();
         //DEBUG Log.i(LOG_TAG, "intent data: "+data+" matches: "+
         //        ActivateActivity.barcodeIntent.equals(data.toString()));

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
@@ -21,7 +21,7 @@ import android.widget.ImageView;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
-import net.wigle.wigleandroid.listener.GPSListener;
+import net.wigle.wigleandroid.listener.GNSSListener;
 import net.wigle.wigleandroid.ui.UINumberFormat;
 import net.wigle.wigleandroid.util.Logging;
 
@@ -201,7 +201,7 @@ public class DashboardFragment extends Fragment {
                     String conKeyString = null;
                     String conValString = null;
                     if (MainActivity.getMainActivity() != null && MainActivity.getMainActivity().getGPSListener() != null) {
-                        final GPSListener listener = MainActivity.getMainActivity().getGPSListener();
+                        final GNSSListener listener = MainActivity.getMainActivity().getGPSListener();
                         satString = "("+listener.getSatCount()+")";
                         conKeyString = MainActivity.join("\n", listener.getConstellations().keySet());
                         conValString = MainActivity.join("\n", listener.getConstellations().values());

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
@@ -696,7 +696,7 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
 
     private void setLocationUI( final MainActivity main, final View view ) {
         final State state = main.getState();
-        if ( state.gpsListener == null ) {
+        if ( state.GNSSListener == null ) {
             return;
         }
         if ( view == null ) {
@@ -705,9 +705,9 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
 
         try {
             TextView tv = view.findViewById( R.id.LocationTextView06 );
-            tv.setText( getString(R.string.list_short_sats) + " " + state.gpsListener.getSatCount() );
+            tv.setText( getString(R.string.list_short_sats) + " " + state.GNSSListener.getSatCount() );
 
-            final Location location = state.gpsListener.getLocation();
+            final Location location = state.GNSSListener.getLocation();
 
             tv = view.findViewById( R.id.LocationTextView01 );
             String latText;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -2351,8 +2351,9 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                 if (gnssStatusCallback != null) {
                     locationManager.unregisterGnssStatusCallback(gnssStatusCallback);
                 }
+            } else {
+                locationManager.removeGpsStatusListener(state.GNSSListener);
             }
-            locationManager.removeGpsStatusListener(state.GNSSListener);
         }
 
         // create a new listener to try and get around the gps stopping bug

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -817,13 +817,11 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
     }
 
     public static boolean isHighDefinition() {
-        if (Build.VERSION.SDK_INT >= 19) {
-            DisplayMetrics metrics = new DisplayMetrics();
-            MainActivity.getMainActivity().getWindowManager().getDefaultDisplay().getRealMetrics(metrics);
-            int dpi = metrics.densityDpi;
-            if (dpi >= 240) {
-                return true;
-            }
+        DisplayMetrics metrics = new DisplayMetrics();
+        MainActivity.getMainActivity().getWindowManager().getDefaultDisplay().getRealMetrics(metrics);
+        int dpi = metrics.densityDpi;
+        if (dpi >= 240) {
+            return true;
         }
         return false;
     }
@@ -1702,10 +1700,8 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
     }
 
     public static boolean isDevMode(final Context context) {
-        if (Build.VERSION.SDK_INT >= 19) {
-            return android.provider.Settings.Secure.getInt(context.getContentResolver(),
-                    android.provider.Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, 0) != 0;
-        } else return false;
+        return android.provider.Settings.Secure.getInt(context.getContentResolver(),
+                android.provider.Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, 0) != 0;
     }
 
     private void setupSound() {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -37,10 +37,13 @@ import android.os.IBinder;
 import android.os.PowerManager;
 import android.preference.PreferenceManager;
 import android.provider.Settings;
+
 import androidx.annotation.NonNull;
+
 import com.google.android.material.navigation.NavigationView;
 
 import androidx.annotation.RequiresApi;
+import androidx.core.location.LocationManagerCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
@@ -79,7 +82,7 @@ import net.wigle.wigleandroid.db.DatabaseHelper;
 import net.wigle.wigleandroid.db.MxcDatabaseHelper;
 import net.wigle.wigleandroid.listener.BatteryLevelReceiver;
 import net.wigle.wigleandroid.listener.BluetoothReceiver;
-import net.wigle.wigleandroid.listener.GPSListener;
+import net.wigle.wigleandroid.listener.GNSSListener;
 import net.wigle.wigleandroid.listener.PhoneState;
 import net.wigle.wigleandroid.listener.PrefCheckboxListener;
 import net.wigle.wigleandroid.listener.WifiReceiver;
@@ -131,7 +134,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         MediaPlayer soundPop;
         MediaPlayer soundNewPop;
         WifiLock wifiLock;
-        GPSListener gpsListener;
+        GNSSListener GNSSListener;
         WifiReceiver wifiReceiver;
         BluetoothReceiver bluetoothReceiver;
         NumberFormat numberFormat0;
@@ -180,7 +183,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
     public static final String SEARCH_WIFI_URL = "https://api.wigle.net/api/v2/network/search";
     public static final String SEARCH_CELL_URL = "https://api.wigle.net/api/v2/cell/search";
 
-        // registration web view
+    // registration web view
     public static final String REG_URL = "https://wigle.net/register";
 
     public static final String ENCODING = "ISO-8859-1";
@@ -269,8 +272,8 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             state = stateFragment.getState();
 
             // tell those that need it that we have a new context
-            if (state.gpsListener != null) {
-                state.gpsListener.setMainActivity(this);
+            if (state.GNSSListener != null) {
+                state.GNSSListener.setMainActivity(this);
             }
             if (state.wifiReceiver != null) {
                 state.wifiReceiver.setMainActivity(this);
@@ -387,11 +390,11 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                     .setTitle(R.string.no_internal_space_title)
                     .setCancelable(true)
                     .setPositiveButton(R.string.ok, new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    dialog.dismiss();
-                }
-            });
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            dialog.dismiss();
+                        }
+                    });
 
             final Dialog dialog = iseDlgBuilder.create();
             if (!isFinishing()) {
@@ -420,8 +423,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             for (final String key : keys) {
                 pieScanSet(prefs, key);
             }
-        }
-        else if (Build.VERSION.SDK_INT == 29) {
+        } else if (Build.VERSION.SDK_INT == 29) {
             // see if all configs are at the P
             for (final String key : keys) {
                 if (prefs.getLong(key, -1) != SCAN_P_DEFAULT) {
@@ -449,8 +451,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                 } else {
                     Logging.error("unable to work around corrupted ZoomTables.data error");
                 }
-            }
-            else {
+            } else {
                 Logging.info("already worked around google maps bug 154855417");
             }
         } catch (Exception e) {
@@ -503,9 +504,10 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             if (!addPermission(permissionsList, Manifest.permission.ACCESS_COARSE_LOCATION)) {
                 permissionsNeeded.add(mainActivity.getString(R.string.cell_permission));
             }
-            addPermission(permissionsList, Manifest.permission.WRITE_EXTERNAL_STORAGE);
             addPermission(permissionsList, Manifest.permission.BLUETOOTH);
-
+            addPermission(permissionsList, Manifest.permission.READ_PHONE_STATE);
+            addPermission(permissionsList, Manifest.permission.BLUETOOTH_SCAN);
+            addPermission(permissionsList, Manifest.permission.BLUETOOTH_CONNECT);
             if (!permissionsList.isEmpty()) {
                 // The permission is NOT already granted.
                 // Check if the user has been asked about this permission already and denied
@@ -549,6 +551,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
     @Override
     public void onRequestPermissionsResult(final int requestCode, @NonNull final String permissions[],
                                            @NonNull final int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
         switch (requestCode) {
             case PERMISSIONS_REQUEST: {
                 Logging.info("location grant response permissions: " + Arrays.toString(permissions)
@@ -635,12 +638,12 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                         // close drawer when item is tapped
                         if (R.id.nav_stats == menuItem.getItemId()) {
                             Logging.info("Nav stats clicked");
-                            showSubmenu(navigationView.getMenu(), R.id.stats_group, menuItem.isChecked() );
+                            showSubmenu(navigationView.getMenu(), R.id.stats_group, menuItem.isChecked());
                         } else {
                             if (R.id.nav_site_stats != menuItem.getItemId() &&
                                     R.id.nav_user_stats != menuItem.getItemId() &&
-                                    R.id.nav_rank != menuItem.getItemId() )
-                            showSubmenu(navigationView.getMenu(), R.id.stats_group, false);
+                                    R.id.nav_rank != menuItem.getItemId())
+                                showSubmenu(navigationView.getMenu(), R.id.stats_group, false);
                             mDrawerLayout.closeDrawers();
                             selectFragment(menuItem.getItemId());
                         }
@@ -656,18 +659,18 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         //TODO:
         int menuSubColor = 0xE0777777;
         MenuItem uStats = navigationView.getMenu().findItem(R.id.nav_user_stats);
-        SpannableString spanString = new SpannableString("    "+uStats.getTitle().toString());
-        spanString.setSpan(new ForegroundColorSpan(menuSubColor), 0,     spanString.length(), 0);
+        SpannableString spanString = new SpannableString("    " + uStats.getTitle().toString());
+        spanString.setSpan(new ForegroundColorSpan(menuSubColor), 0, spanString.length(), 0);
         uStats.setTitle(spanString);
 
         MenuItem sStats = navigationView.getMenu().findItem(R.id.nav_site_stats);
-        spanString = new SpannableString("    "+sStats.getTitle().toString());
-        spanString.setSpan(new ForegroundColorSpan(menuSubColor), 0,     spanString.length(), 0);
+        spanString = new SpannableString("    " + sStats.getTitle().toString());
+        spanString.setSpan(new ForegroundColorSpan(menuSubColor), 0, spanString.length(), 0);
         sStats.setTitle(spanString);
 
         MenuItem rStats = navigationView.getMenu().findItem(R.id.nav_rank);
-        spanString = new SpannableString("    "+rStats.getTitle().toString());
-        spanString.setSpan(new ForegroundColorSpan(menuSubColor), 0,     spanString.length(), 0);
+        spanString = new SpannableString("    " + rStats.getTitle().toString());
+        spanString.setSpan(new ForegroundColorSpan(menuSubColor), 0, spanString.length(), 0);
         rStats.setTitle(spanString);
 
         navigationView.getMenu().getItem(0).setCheckable(true);
@@ -713,7 +716,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
 
             try {
                 fragmentManager.beginTransaction()
-                        .replace(R.id.tabcontent, frag, FRAGMENT_TAG_PREFIX+itemId)
+                        .replace(R.id.tabcontent, frag, FRAGMENT_TAG_PREFIX + itemId)
                         .commit();
             } catch (final NullPointerException | IllegalStateException ex) {
                 final String message = "exception in fragment switch: " + ex;
@@ -724,9 +727,9 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             state.currentTab = itemId;
             setTitle(fragmentTitles.get(itemId));
         } catch (IllegalAccessException ex) {
-            Logging.error("Unable to get fragment for id: "+itemId, ex);
+            Logging.error("Unable to get fragment for id: " + itemId, ex);
         } catch (InstantiationException ex) {
-            Logging.error("Unable to make fragment for id: "+itemId, ex);
+            Logging.error("Unable to make fragment for id: " + itemId, ex);
         }
     }
 
@@ -749,12 +752,12 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         Bundle bundle = new Bundle();
         listFragment.setArguments(bundle);
 
-        transaction.add(R.id.tabcontent, listFragment, FRAGMENT_TAG_PREFIX+R.id.nav_list);
+        transaction.add(R.id.tabcontent, listFragment, FRAGMENT_TAG_PREFIX + R.id.nav_list);
         transaction.commit();
     }
 
     private static Class classForFragmentNavId(final int navId) {
-        switch(navId) {
+        switch (navId) {
             case R.id.nav_list:
                 return ListFragment.class;
             case R.id.nav_dash:
@@ -814,7 +817,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
     }
 
     public static boolean isHighDefinition() {
-        if (Build.VERSION.SDK_INT >= 17) {
+        if (Build.VERSION.SDK_INT >= 19) {
             DisplayMetrics metrics = new DisplayMetrics();
             MainActivity.getMainActivity().getWindowManager().getDefaultDisplay().getRealMetrics(metrics);
             int dpi = metrics.densityDpi;
@@ -890,7 +893,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
             builder.setCancelable(true);
             builder.setTitle("Confirmation"); //TODO: literal string
-            final String checkboxLabel = getArguments().containsKey("checkboxLabel") ? getArguments().getString("checkboxLabel"): null;
+            final String checkboxLabel = getArguments().containsKey("checkboxLabel") ? getArguments().getString("checkboxLabel") : null;
             if (null != checkboxLabel) {
                 View checkBoxView = View.inflate(activity, R.layout.checkbox, null);
                 CheckBox checkBox = (CheckBox) checkBoxView.findViewById(R.id.checkbox);
@@ -898,16 +901,16 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                 builder.setView(checkBoxView);
             }
             final String persistPrefKey = getArguments().containsKey("persistPref") ?
-                    getArguments().getString("persistPref"): null;
+                    getArguments().getString("persistPref") : null;
             final String persistPrefAgreeValue = getArguments().containsKey("persistPrefAgreeValue") ?
-                    getArguments().getString("persistPrefAgreeValue"): null;
+                    getArguments().getString("persistPrefAgreeValue") : null;
             final String persistPrefDisagreeValue = getArguments().containsKey("persistPrefDisagreeValue") ?
-                    getArguments().getString("persistPrefDisagreeValue"): null;
+                    getArguments().getString("persistPrefDisagreeValue") : null;
 
             builder.setMessage(getArguments().getString("message"));
             final int tabPos = getArguments().getInt("tabPos");
             final int dialogId = getArguments().getInt("dialogId");
-            final SharedPreferences prefs = activity.getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
+            final SharedPreferences prefs = activity.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
 
 
             final AlertDialog ad = builder.create();
@@ -934,7 +937,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                                 final String maybeName = getResources().getResourceName(tabPos);
                                 //DEBUG: MainActivity.info("Attempting lookup for: " + String.format("0x%08X", tabPos) + " (" + maybeName + ")");
                                 FragmentManager fragmentManager = ((MainActivity) activity).getSupportFragmentManager();
-                                final Fragment fragment = fragmentManager.findFragmentByTag(FRAGMENT_TAG_PREFIX+tabPos);
+                                final Fragment fragment = fragmentManager.findFragmentByTag(FRAGMENT_TAG_PREFIX + tabPos);
                                 if (fragment == null) {
                                     Logging.error("null fragment for: " + String.format("0x%08X", tabPos) + " (" + maybeName + ")");
                                     //TODO: might behoove us to show an error here
@@ -978,7 +981,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
     }
 
     public static void createConfirmation(final FragmentActivity activity, final String message,
-                                   final int tabPos, final int dialogId) {
+                                          final int tabPos, final int dialogId) {
         try {
             final FragmentManager fm = activity.getSupportFragmentManager();
             final ConfirmationDialog dialog = ConfirmationDialog.newInstance(message, tabPos, dialogId);
@@ -997,7 +1000,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                                            final String checkboxLabel, final String persistPrefKey,
                                            final String persistPrefAgreeValue,
                                            final String persistPrefDisagreeValue,
-                                   final int tabPos, final int dialogId) {
+                                           final int tabPos, final int dialogId) {
         try {
             final FragmentManager fm = activity.getSupportFragmentManager();
             final ConfirmationDialog dialog = ConfirmationDialog.newInstance(message, checkboxLabel,
@@ -1114,13 +1117,16 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
 
             //TODO: redundant with endBluetooth?
             final BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
-            if (bluetoothAdapter != null && bluetoothAdapter.isDiscovering()) {
-                bluetoothAdapter.cancelDiscovery();
-            } try {
+            try {
+                if (bluetoothAdapter != null && bluetoothAdapter.isDiscovering()) {
+                    bluetoothAdapter.cancelDiscovery();
+                }
                 Logging.info("unregister bluetoothReceiver");
-                unregisterReceiver( state.bluetoothReceiver );
-            } catch ( final IllegalArgumentException ex ) {
-                Logging.info( "bluetoothReceiver not registered: " + ex );
+                unregisterReceiver(state.bluetoothReceiver);
+            } catch (final IllegalArgumentException ex) {
+                Logging.info("bluetoothReceiver not registered: " + ex);
+            } catch (final SecurityException ex) {
+                Logging.info("bluetoothReceiver access: " + ex);
             }
             if (state.bluetoothReceiver != null) {
                 state.bluetoothReceiver.stopScanning();
@@ -1192,7 +1198,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         mDrawerToggle.onConfigurationChanged(newConfig);
         if (Build.VERSION.SDK_INT > 28) {
             if (newConfig.uiMode != state.uiMode) {
-                Logging.info("uiMode change - "+state.uiMode+"->"+newConfig.uiMode);
+                Logging.info("uiMode change - " + state.uiMode + "->" + newConfig.uiMode);
                 state.uiMode = newConfig.uiMode;
                 //DEBUG:
                 finishSoon(0, false, true);
@@ -1209,7 +1215,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             prefs.edit().putBoolean(ListFragment.PREF_BLOWED_UP, false).commit();
             // activate the email intent
             final Intent intent = new Intent(this, ErrorReportActivity.class);
-            intent.putExtra( MainActivity.ERROR_REPORT_DO_EMAIL, true );
+            intent.putExtra(MainActivity.ERROR_REPORT_DO_EMAIL, true);
             startActivity(intent);
         }
 
@@ -1271,10 +1277,10 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         if (!lang.isEmpty() && !current.equals(lang)) {
             if (lang.contains("-r")) {
                 String[] parts = lang.split("-r");
-                Logging.info("\tlang: "+parts[0]+" country: "+parts[1]);
+                Logging.info("\tlang: " + parts[0] + " country: " + parts[1]);
                 newLocale = new Locale(parts[0], parts[1]);
             } else {
-                Logging.info("\tlang: "+lang + " current: "+current);
+                Logging.info("\tlang: " + lang + " current: " + current);
                 newLocale = new Locale(lang);
             }
         } else if (lang.isEmpty() && ORIG_LOCALE != null && !ORIG_LOCALE.getLanguage().isEmpty()
@@ -1329,10 +1335,10 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         Logging.info("current lang: " + current + " new lang: " + lang);
         if (lang.contains("-r")) {
             String[] parts = lang.split("-r");
-            Logging.info("\tlang: "+parts[0]+" country: "+parts[1]);
+            Logging.info("\tlang: " + parts[0] + " country: " + parts[1]);
             return new Locale(parts[0], parts[1]);
         } else {
-            Logging.info("\tlang: "+lang);
+            Logging.info("\tlang: " + lang);
             return new Locale(lang);
         }
     }
@@ -1523,7 +1529,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         final FragmentManager fragmentManager = MainActivity.mainActivity.getSupportFragmentManager();
         if (getStaticState().currentTab == R.id.nav_map) {
             // Map is visible, give it the new network
-            final MappingFragment f = (MappingFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG_PREFIX+R.id.nav_map);
+            final MappingFragment f = (MappingFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG_PREFIX + R.id.nav_map);
             if (f != null) {
                 f.addNetwork(network);
             }
@@ -1534,7 +1540,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         final FragmentManager fragmentManager = MainActivity.mainActivity.getSupportFragmentManager();
         if (getStaticState().currentTab == R.id.nav_map) {
             // Map is visible, give it the new network
-            final MappingFragment f = (MappingFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG_PREFIX+R.id.nav_map);
+            final MappingFragment f = (MappingFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG_PREFIX + R.id.nav_map);
             if (f != null) {
                 f.updateNetwork(network);
             }
@@ -1545,7 +1551,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         final FragmentManager fragmentManager = MainActivity.mainActivity.getSupportFragmentManager();
         if (getStaticState().currentTab == R.id.nav_map) {
             // Map is visible, give it the new network
-            final MappingFragment f = (MappingFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG_PREFIX+R.id.nav_map);
+            final MappingFragment f = (MappingFragment) fragmentManager.findFragmentByTag(FRAGMENT_TAG_PREFIX + R.id.nav_map);
             if (f != null) {
                 f.reCluster();
             }
@@ -1643,13 +1649,11 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                         // ohwell
                         Logging.error("error getting logs for error: " + er, er);
                     }
-                }
-                finally {
+                } finally {
                     // can't try-with-resources and support api 14
                     try {
                         if (fos != null) fos.close();
-                    }
-                    catch (final Exception ex) {
+                    } catch (final Exception ex) {
                         Logging.error("error closing fos: " + ex, ex);
                     }
                 }
@@ -1698,12 +1702,9 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
     }
 
     public static boolean isDevMode(final Context context) {
-        if(Build.VERSION.SDK_INT == 16) {
+        if (Build.VERSION.SDK_INT >= 19) {
             return android.provider.Settings.Secure.getInt(context.getContentResolver(),
-                    android.provider.Settings.Secure.DEVELOPMENT_SETTINGS_ENABLED , 0) != 0;
-        } else if (Build.VERSION.SDK_INT >= 17) {
-            return android.provider.Settings.Secure.getInt(context.getContentResolver(),
-                    android.provider.Settings.Global.DEVELOPMENT_SETTINGS_ENABLED , 0) != 0;
+                    android.provider.Settings.Global.DEVELOPMENT_SETTINGS_ENABLED, 0) != 0;
         } else return false;
     }
 
@@ -1786,14 +1787,14 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
      * @param addressKey the preferences key of the matching settings for which to build the matcher
      * @return a Matcher instance corresponding to the current user settings from preferences
      */
-    private Matcher generateBssidFilterMatcher( final SharedPreferences prefs,  final String addressKey) {
+    private Matcher generateBssidFilterMatcher(final SharedPreferences prefs, final String addressKey) {
         Gson gson = new Gson();
         Matcher matcher = null;
         String[] values = gson.fromJson(prefs.getString(addressKey, "[]"), String[].class);
-        if(values.length>0) {
+        if (values.length > 0) {
             StringBuilder sb = new StringBuilder("^(");
             boolean first = true;
-            for (String value: values) {
+            for (String value : values) {
 
                 if (first) {
                     first = false;
@@ -1807,9 +1808,9 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             }
             sb.append(")");
             //TODO: debug
-            Logging.info("building regex from: "+sb.toString());
-            Pattern pattern = Pattern.compile( sb.toString(), Pattern.CASE_INSENSITIVE );
-            matcher = pattern.matcher( "" );
+            Logging.info("building regex from: " + sb.toString());
+            Pattern pattern = Pattern.compile(sb.toString(), Pattern.CASE_INSENSITIVE);
+            matcher = pattern.matcher("");
         }
 
         return matcher;
@@ -1823,8 +1824,8 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         return batteryLevelReceiver;
     }
 
-    public GPSListener getGPSListener() {
-        return state.gpsListener;
+    public GNSSListener getGPSListener() {
+        return state.GNSSListener;
     }
 
     public PhoneState getPhoneState() {
@@ -1880,7 +1881,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
     private void setupActivationDialog() {
         final boolean willActivateBt = canBtBeActivated();
         final boolean willActivateWifi = canWifiBeActivated();
-        final SharedPreferences prefs = getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
+        final SharedPreferences prefs = getSharedPreferences(ListFragment.SHARED_PREFS, 0);
         final boolean useBt = prefs.getBoolean(ListFragment.PREF_SCAN_BT, true);
         final boolean alertVersions = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P;
         int pieBadCount = prefs.getInt(ListFragment.PREF_PIE_BAD_TOAST_COUNT, 0);
@@ -1895,8 +1896,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                 if (pieBadCount < 5) activationMessages = getString(R.string.pie_bad);
                 editor.putInt(ListFragment.PREF_PIE_BAD_TOAST_COUNT, pieBadCount + 1);
 
-            }
-            else if (Build.VERSION.SDK_INT == 29) {
+            } else if (Build.VERSION.SDK_INT == 29) {
                 if (qBadCount < 5) activationMessages = getString(R.string.q_bad);
                 editor.putInt(ListFragment.PREF_Q_BAD_TOAST_COUNT, qBadCount + 1);
             }
@@ -1950,8 +1950,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             if (Build.VERSION.SDK_INT >= 29) {
                 final Intent panelIntent = new Intent(Settings.Panel.ACTION_WIFI);
                 startActivityForResult(panelIntent, ACTION_WIFI_CODE);
-            }
-            else {
+            } else {
                 // open wifi setting pages after a few seconds
                 new Handler().postDelayed(new Runnable() {
                     @Override
@@ -1992,8 +1991,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             // Make sure the request was successful
             if (resultCode == RESULT_OK) {
                 Logging.info("wifi turned on");
-            }
-            else {
+            } else {
                 Logging.info("wifi NOT turned on, resultCode: " + resultCode);
             }
         } else if (requestCode == ACTION_TTS_CODE) {
@@ -2004,15 +2002,15 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                     PackageManager pm = getPackageManager();
                     Intent installTTSIntent = new Intent();
                     installTTSIntent.setAction(TextToSpeech.Engine.ACTION_INSTALL_TTS_DATA);
-                    ResolveInfo resolveInfo = pm.resolveActivity( installTTSIntent, PackageManager.MATCH_DEFAULT_ONLY );
+                    ResolveInfo resolveInfo = pm.resolveActivity(installTTSIntent, PackageManager.MATCH_DEFAULT_ONLY);
 
-                    if( resolveInfo == null ) {
+                    if (resolveInfo == null) {
                         Logging.error("ACTION_TTS_CALLBACK: resolve ACTION_INSTALL_TTS_DATA via package mgr.");
                     } else {
                         startActivity(installTTSIntent);
                     }
                 } catch (Exception e) {
-                    Logging.error("ACTION_TTS_CALLBACK: failed to issue ACTION_INSTALL_TTS_DATA",e);
+                    Logging.error("ACTION_TTS_CALLBACK: failed to issue ACTION_INSTALL_TTS_DATA", e);
                 }
             }
         } else {
@@ -2085,12 +2083,12 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                 intentFilter.addAction(BluetoothAdapter.ACTION_DISCOVERY_FINISHED);
                 registerReceiver(state.bluetoothReceiver, intentFilter);
             }
-        } catch (SecurityException se) {
-            Logging.info("Security exception attempting to access bluetooth adapter", se);
+        } catch (SecurityException e) {
+            Logging.error("exception initializing bluetooth: ", e);
         } catch (Exception e) {
             //ALIBI: there's a lot of wonkiness in real-world BT adapters
             //  seeing them go null during this block after null check passes,
-            Logging.error("failure initializing bluetooth: ",e);
+            Logging.error("failure initializing bluetooth: ", e);
         }
     }
 
@@ -2101,27 +2099,31 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
 
         final BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
         if (bluetoothAdapter != null) {
+            try {
             if (bluetoothAdapter.isDiscovering()) {
                 bluetoothAdapter.cancelDiscovery();
+            }
+            } catch (final SecurityException ex) {
+                Logging.info("bluetoothReceiver access: " + ex);
             }
         }
         try {
             Logging.info("unregister bluetoothReceiver");
-            unregisterReceiver( state.bluetoothReceiver );
+            unregisterReceiver(state.bluetoothReceiver);
             state.bluetoothReceiver = null;
-        } catch ( final IllegalArgumentException ex ) {
+        } catch (final IllegalArgumentException ex) {
             //ALIBI: it's fine to call and fail here.
-            Logging.info( "bluetoothReceiver not registered: " + ex );
+            Logging.info("bluetoothReceiver not registered: " + ex);
         }
 
-        final boolean btWasOff = prefs.getBoolean( ListFragment.PREF_BT_WAS_OFF, false );
+        final boolean btWasOff = prefs.getBoolean(ListFragment.PREF_BT_WAS_OFF, false);
         //ALIBI: this pref seems to be persisting across runs, shutting down BT on exit when it was active on start.
         Editor removeBtPref = prefs.edit();
         removeBtPref.remove(ListFragment.PREF_BT_WAS_OFF);
         removeBtPref.apply();
 
         // don't call on emulator, it crashes it
-        if ( btWasOff && ! state.inEmulator ) {
+        if (btWasOff && !state.inEmulator) {
             // ALIBI: we disabled this for WiFi since we had weird errors with root window disposal. Uncomment if we get that resolved?
             //WiGLEToast.showOverActivity(this, R.string.app_name, getString(R.string.turning_bt_off));
 
@@ -2135,6 +2137,8 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                     Logging.info("Disable bluetooth");
                     bt.disable();
                 }
+            } catch (final SecurityException ex) {
+                Logging.info("bluetoothReceiver access: " + ex);
             } catch (Exception ex) {
                 Logging.error("exception turning bluetooth back off: " + ex, ex);
             }
@@ -2211,6 +2215,8 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
 
         try {
             // check if there is a gps
+            LocationManagerCompat.hasProvider(locationManager, GPS_PROVIDER);
+            Logging.info("GNSS HW: "+LocationManagerCompat.getGnssHardwareModelName(locationManager)+" year: "+LocationManagerCompat.getGnssYearOfHardware(locationManager)+ " enabled: "+ LocationManagerCompat.isLocationEnabled(locationManager));
             final LocationProvider locProvider = locationManager.getProvider(GPS_PROVIDER);
 
             if (locProvider == null) {
@@ -2231,7 +2237,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             return;
         }
 
-        if (state.gpsListener == null) {
+        if (state.GNSSListener == null) {
             // force a listener to be created
             final SharedPreferences prefs = getSharedPreferences(ListFragment.SHARED_PREFS, 0);
             boolean logRoutes = prefs.getBoolean(ListFragment.PREF_LOG_ROUTES, false);
@@ -2307,7 +2313,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             }
             // turn off location updates
             this.setLocationUpdates(0L, 0f);
-            state.gpsListener.handleScanStop();
+            state.GNSSListener.handleScanStop();
             if (state.wifiLock.isHeld()) {
                 try {
                     state.wifiLock.release();
@@ -2338,25 +2344,20 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             throws SecurityException {
         final LocationManager locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
 
-        if (state.gpsListener != null) {
+        if (state.GNSSListener != null) {
             // remove any old requests
-            locationManager.removeUpdates(state.gpsListener);
+            locationManager.removeUpdates(state.GNSSListener);
             if (Build.VERSION.SDK_INT >= 24) {
                 if (gnssStatusCallback != null) {
                     locationManager.unregisterGnssStatusCallback(gnssStatusCallback);
                 }
             }
-            locationManager.removeGpsStatusListener(state.gpsListener);
+            locationManager.removeGpsStatusListener(state.GNSSListener);
         }
 
         // create a new listener to try and get around the gps stopping bug
-        state.gpsListener = new GPSListener(this, state.dbHelper);
-        state.gpsListener.setMapListener(MappingFragment.STATIC_LOCATION_LISTENER);
-        try {
-            locationManager.addGpsStatusListener(state.gpsListener);
-        } catch (final SecurityException ex) {
-            Logging.info("Security exception adding status listener: " + ex, ex);
-        }
+        state.GNSSListener = new GNSSListener(this, state.dbHelper);
+        state.GNSSListener.setMapListener(MappingFragment.STATIC_LOCATION_LISTENER);
 
         if (Build.VERSION.SDK_INT >= 24) {
             try {
@@ -2367,6 +2368,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
 
                     @Override
                     public void onStopped() {
+                        state.GNSSListener.handleScanStop();
                     }
 
                     @Override
@@ -2375,14 +2377,22 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
 
                     @Override
                     public void onSatelliteStatusChanged(GnssStatus status) {
-                        state.gpsListener.onGnssStatusChanged(status);
+                        state.GNSSListener.onGnssStatusChanged(status);
                     }
                 };
                 locationManager.registerGnssStatusCallback(gnssStatusCallback);
-            }
-            catch (final Exception ex) {
+            } catch (final Exception ex) {
                 Logging.error("Error registering for gnss: " + ex, ex);
             }
+        }
+        try {
+            if (Build.VERSION.SDK_INT >= 24) {
+                locationManager.registerGnssStatusCallback(gnssStatusCallback);
+            } else {
+                //addGpsStatusListener(state.gpsListener);
+            }
+        } catch (final SecurityException ex) {
+            Logging.info("Security exception adding status listener: " + ex, ex);
         }
 
         final SharedPreferences prefs = getSharedPreferences(ListFragment.SHARED_PREFS, 0);
@@ -2399,7 +2409,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                 if (!"passive".equals(provider) && updateIntervalMillis > 0L) {
                     Logging.info("using provider: " + provider);
                     try {
-                        locationManager.requestLocationUpdates(provider, updateIntervalMillis, updateMeters, state.gpsListener);
+                        locationManager.requestLocationUpdates(provider, updateIntervalMillis, updateMeters, state.GNSSListener);
                     } catch (final SecurityException ex) {
                         Logging.info("Security exception adding status listener: " + ex, ex);
                     }
@@ -2407,9 +2417,9 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             }
 
             if (updateIntervalMillis <= 0L) {
-                Logging.info("removing location listener: " + state.gpsListener);
+                Logging.info("removing location listener: " + state.GNSSListener);
                 try {
-                    locationManager.removeUpdates(state.gpsListener);
+                    locationManager.removeUpdates(state.GNSSListener);
                     if (Build.VERSION.SDK_INT >= 24) {
                         if (gnssStatusCallback != null) {
                             locationManager.unregisterGnssStatusCallback(gnssStatusCallback);
@@ -2584,20 +2594,21 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                 observationUploader.setInterrupted();
             }
 
-            if (state.gpsListener != null) {
+            if (state.GNSSListener != null) {
                 // save our location for later runs
-                state.gpsListener.saveLocation();
+                state.GNSSListener.saveLocation();
             }
 
             // close the db. not in destroy, because it'll still write after that.
             if (state.dbHelper != null) state.dbHelper.close();
 
             final LocationManager locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
-            if (state.gpsListener != null && locationManager != null) {
+            if (state.GNSSListener != null && locationManager != null) {
                 try {
-                    locationManager.removeGpsStatusListener(state.gpsListener);
-                    locationManager.removeUpdates(state.gpsListener);
-                    if (Build.VERSION.SDK_INT >= 24) {
+                    if (Build.VERSION.SDK_INT < 24) {
+                        locationManager.removeGpsStatusListener(state.GNSSListener);
+                        locationManager.removeUpdates(state.GNSSListener);
+                    }else if (Build.VERSION.SDK_INT >= 24) {
                         if (gnssStatusCallback != null) {
                             locationManager.unregisterGnssStatusCallback(gnssStatusCallback);
                         }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
@@ -80,9 +80,9 @@ import net.wigle.wigleandroid.ui.UINumberFormat;
 import net.wigle.wigleandroid.ui.WiGLEToast;
 import net.wigle.wigleandroid.util.Logging;
 
-import static net.wigle.wigleandroid.listener.GPSListener.MIN_ROUTE_LOCATION_DIFF_METERS;
-import static net.wigle.wigleandroid.listener.GPSListener.MIN_ROUTE_LOCATION_DIFF_TIME;
-import static net.wigle.wigleandroid.listener.GPSListener.MIN_ROUTE_LOCATION_PRECISION_METERS;
+import static net.wigle.wigleandroid.listener.GNSSListener.MIN_ROUTE_LOCATION_DIFF_METERS;
+import static net.wigle.wigleandroid.listener.GNSSListener.MIN_ROUTE_LOCATION_DIFF_TIME;
+import static net.wigle.wigleandroid.listener.GNSSListener.MIN_ROUTE_LOCATION_PRECISION_METERS;
 
 /**
  * show a map depicting current position and configurable stumbling progress information.

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/WigleService.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/WigleService.java
@@ -26,7 +26,10 @@ import java.text.NumberFormat;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static android.app.PendingIntent.FLAG_IMMUTABLE;
+import static android.app.PendingIntent.FLAG_UPDATE_CURRENT;
 import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_NONE;
+import static android.os.Build.VERSION.SDK_INT;
 
 public final class WigleService extends Service {
     private static final int NOTIFICATION_ID = 1;
@@ -173,7 +176,8 @@ public final class WigleService extends Service {
                 final String title = context.getString(R.string.wigle_service);
 
                 final Intent notificationIntent = new Intent(this, MainActivity.class);
-                final PendingIntent contentIntent = PendingIntent.getActivity(this, 0, notificationIntent, 0);
+                final int flags = SDK_INT >= Build.VERSION_CODES.S?(FLAG_UPDATE_CURRENT | FLAG_IMMUTABLE): FLAG_UPDATE_CURRENT;
+                final PendingIntent contentIntent = PendingIntent.getActivity(this, 0, notificationIntent, flags);
                 final long dbNets = ListFragment.lameStatic.dbNets;
                 String text = context.getString(R.string.list_waiting_gps);
 
@@ -217,18 +221,18 @@ public final class WigleService extends Service {
                 Notification notification = null;
 
                 if (null != ma) {
-                    final PendingIntent pauseIntent = PendingIntent.getBroadcast(MainActivity.getMainActivity(), 0, pauseSharedIntent, PendingIntent.FLAG_CANCEL_CURRENT);
+                    final PendingIntent pauseIntent = PendingIntent.getBroadcast(MainActivity.getMainActivity(), 0, pauseSharedIntent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_CANCEL_CURRENT);
                     final Intent scanSharedIntent = new Intent();
                     scanSharedIntent.setAction("net.wigle.wigleandroid.SCAN");
                     scanSharedIntent.setClass(getApplicationContext(), net.wigle.wigleandroid.listener.ScanControlReceiver.class);
-                    final PendingIntent scanIntent = PendingIntent.getBroadcast(MainActivity.getMainActivity(), 0, scanSharedIntent, PendingIntent.FLAG_CANCEL_CURRENT);
+                    final PendingIntent scanIntent = PendingIntent.getBroadcast(MainActivity.getMainActivity(), 0, scanSharedIntent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_CANCEL_CURRENT);
 
                     final Intent uploadSharedIntent = new Intent();
                     uploadSharedIntent.setAction("net.wigle.wigleandroid.UPLOAD");
                     uploadSharedIntent.setClass(getApplicationContext(), net.wigle.wigleandroid.listener.UploadReceiver.class);
-                    final PendingIntent uploadIntent = PendingIntent.getBroadcast(MainActivity.getMainActivity(), 0, uploadSharedIntent, PendingIntent.FLAG_CANCEL_CURRENT);
+                    final PendingIntent uploadIntent = PendingIntent.getBroadcast(MainActivity.getMainActivity(), 0, uploadSharedIntent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_CANCEL_CURRENT);
 
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    if (SDK_INT >= Build.VERSION_CODES.O) {
                         notification = getNotification26(title, context, text, when, contentIntent, pauseIntent, scanIntent, uploadIntent);
                     } else {
                         notification = getNotification16(title, context, text, when, contentIntent, pauseIntent, scanIntent, uploadIntent);
@@ -259,7 +263,7 @@ public final class WigleService extends Service {
     }
 
     private boolean isServiceForeground() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+        if (SDK_INT < Build.VERSION_CODES.Q) {
             // no such thing as foreground back then
             return false;
         }
@@ -282,7 +286,7 @@ public final class WigleService extends Service {
         builder.setContentText(text);
         builder.setWhen(when);
         builder.setLargeIcon(largeIcon);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             builder.setSmallIcon(R.drawable.wiglewifi_small_white);
         } else {
             builder.setSmallIcon(R.drawable.wiglewifi_small);
@@ -311,7 +315,7 @@ public final class WigleService extends Service {
                                            final PendingIntent pauseIntent, final PendingIntent scanIntent,
                                            final PendingIntent uploadIntent) {
         // new notification channel
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (SDK_INT >= Build.VERSION_CODES.O) {
             final NotificationManager notificationManager =
                     (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
             if (notificationManager == null) return null;
@@ -337,7 +341,7 @@ public final class WigleService extends Service {
             builder.setColorized(true);
             //builder.setCustomBigContentView(new RemoteViews(getPackageName(), R.layout.expanded_notification_layout));
             // WiGLE Blue: builder.setColor(6005486);
-            if (Build.VERSION.SDK_INT < 29) {
+            if (SDK_INT < 29) {
                 //Classic charcoal:
                 builder.setColor(1973790);
             }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
@@ -6,9 +6,9 @@ package net.wigle.wigleandroid.db;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static net.wigle.wigleandroid.MainActivity.ERROR_REPORT_DIALOG;
 import static net.wigle.wigleandroid.util.Logging.info;
-import static net.wigle.wigleandroid.listener.GPSListener.MIN_ROUTE_LOCATION_DIFF_METERS;
-import static net.wigle.wigleandroid.listener.GPSListener.MIN_ROUTE_LOCATION_DIFF_TIME;
-import static net.wigle.wigleandroid.listener.GPSListener.MIN_ROUTE_LOCATION_PRECISION_METERS;
+import static net.wigle.wigleandroid.listener.GNSSListener.MIN_ROUTE_LOCATION_DIFF_METERS;
+import static net.wigle.wigleandroid.listener.GNSSListener.MIN_ROUTE_LOCATION_DIFF_TIME;
+import static net.wigle.wigleandroid.listener.GNSSListener.MIN_ROUTE_LOCATION_PRECISION_METERS;
 import static net.wigle.wigleandroid.util.FileUtility.SQL_EXT;
 import static net.wigle.wigleandroid.util.FileUtility.hasSD;
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
@@ -170,7 +170,7 @@ public class WifiReceiver extends BroadcastReceiver {
         }
 
         // have the gps listener to a self-check, in case it isn't getting updates anymore
-        final GPSListener gpsListener = mainActivity.getGPSListener();
+        final GNSSListener gpsListener = mainActivity.getGPSListener();
         Location location = null;
         if (gpsListener != null) {
             location = gpsListener.checkGetLocation(prefs);
@@ -835,7 +835,7 @@ public class WifiReceiver extends BroadcastReceiver {
         long defaultRate = MainActivity.SCAN_DEFAULT;
         // if over 5 mph
         Location location = null;
-        final GPSListener gpsListener = mainActivity.getGPSListener();
+        final GNSSListener gpsListener = mainActivity.getGPSListener();
         if (gpsListener != null) {
             location = gpsListener.getLocation();
         }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/WiGLEToast.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/WiGLEToast.java
@@ -45,6 +45,7 @@ public class WiGLEToast {
                 text.setText(messageString);
 
                 Toast toast = new Toast(context.getApplicationContext());
+                //ALIBI: logs errors in Toast, but works
                 toast.setGravity(Gravity.CENTER_VERTICAL, 0, 0);
                 toast.setDuration(toastLength);
                 toast.setView(layout);


### PR DESCRIPTION
We bid a fond farewell to SDK versions below 19 with this update.
- targets SDK 31, as required for new play store submission
- splits GPSStatus/GNSSStatus for maximum compat (remains big cleanup target)
- rectifies permission issues for new deployment target (try blocks in BT receiver also a cleanup target)
- fixes start-on-boot Android 10+ (per https://github.com/wiglenet/wigle-wifi-wardriving/issues/435 )