### PR TITLE
[FIX] Refactor and cleanup

### DIFF
--- a/wiglewifiwardriving/build.gradle
+++ b/wiglewifiwardriving/build.gradle
@@ -55,7 +55,6 @@ dependencies {
     implementation "androidx.core:core:1.6.0"
     implementation "androidx.appcompat:appcompat:1.4.2"
     implementation "com.google.android.material:material:1.6.0"
-    implementation "androidx.appcompat:appcompat:1.3.0"
     implementation "com.google.android.gms:play-services-maps:18.1.0"
     implementation 'com.google.android.gms:play-services-vision:20.1.3'
     implementation 'com.google.code.gson:gson:2.8.9'
@@ -67,6 +66,7 @@ dependencies {
     implementation 'ru.egslava:MaskedEditText:1.0.5'
     implementation 'com.goebl:simplify:1.0.0'
     implementation 'com.babylon.certificatetransparency:certificatetransparency-android:0.3.0'
+    //debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.10'
     testImplementation 'junit:junit:4.13'
     testImplementation 'androidx.test:core:1.3.0'
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ActivateActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ActivateActivity.java
@@ -21,13 +21,14 @@ import com.google.android.gms.vision.barcode.Barcode;
 import com.google.android.gms.vision.barcode.BarcodeDetector;
 
 import net.wigle.wigleandroid.ui.WiGLEToast;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 import java.io.IOException;
 import java.util.Arrays;
 
 /**
  * fetch wigle authentication tokens by scanning a barcode
- * @Author: rksh
+ * @author rksh
  */
 public class ActivateActivity extends Activity {
 
@@ -123,7 +124,7 @@ public class ActivateActivity extends Activity {
                     }
 
                     @Override
-                    public void receiveDetections(Detector.Detections<Barcode> detections) {
+                    public void receiveDetections(@NonNull Detector.Detections<Barcode> detections) {
                         final SparseArray<Barcode> barcodes = detections.getDetectedItems();
                         if (barcodes.size() > 0) {
                             Log.i(LOG_TAG, "CAMERA received detections");
@@ -132,11 +133,11 @@ public class ActivateActivity extends Activity {
                                 Log.i(LOG_TAG, item.displayValue + " matched.");
                                 String[] tokens = item.displayValue.split(":");
                                 final SharedPreferences prefs = MainActivity.getMainActivity().
-                                        getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+                                        getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
                                 final SharedPreferences.Editor editor = prefs.edit();
-                                editor.putString(ListFragment.PREF_USERNAME, tokens[0]);
-                                editor.putString(ListFragment.PREF_AUTHNAME, tokens[1]);
-                                editor.putBoolean(ListFragment.PREF_BE_ANONYMOUS, false);
+                                editor.putString(PreferenceKeys.PREF_USERNAME, tokens[0]);
+                                editor.putString(PreferenceKeys.PREF_AUTHNAME, tokens[1]);
+                                editor.putBoolean(PreferenceKeys.PREF_BE_ANONYMOUS, false);
                                 editor.apply();
                                 TokenAccess.setApiToken(prefs, tokens[2]);
                                 finish();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/AddressFilterAdapter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/AddressFilterAdapter.java
@@ -15,6 +15,7 @@ import com.google.gson.Gson;
 import net.wigle.wigleandroid.util.Logging;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * It seems obvious that you'd want to implement all this junk in every mobile phone app that has a list.
@@ -24,14 +25,14 @@ import java.util.ArrayList;
 public class AddressFilterAdapter extends BaseAdapter implements ListAdapter {
 
     //enough to make a list and update prefs from it.
-    private ArrayList<String> list = new ArrayList<String>();
+    private List<String> list = new ArrayList<String>();
     private Context context;
     private final SharedPreferences prefs;
     private final String filterKey;
 
 
 
-    public AddressFilterAdapter(ArrayList<String> list, Context context, final SharedPreferences prefs, final String filterKey) {
+    public AddressFilterAdapter(List<String> list, Context context, final SharedPreferences prefs, final String filterKey) {
         this.list = list;
         this.context = context;
         this.prefs = prefs;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DBResultActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DBResultActivity.java
@@ -48,6 +48,7 @@ import net.wigle.wigleandroid.model.QueryArgs;
 import net.wigle.wigleandroid.ui.SetNetworkListAdapter;
 import net.wigle.wigleandroid.ui.WiGLEToast;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.UrlConfig;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -354,7 +355,7 @@ public class DBResultActivity extends AppCompatActivity {
                 this);
 
         final ApiDownloader task = new ApiDownloader(activity, ListFragment.lameStatic.dbHelper,
-                "search-cache-"+queryParams+".json", MainActivity.SEARCH_WIFI_URL+"?"+queryParams,
+                "search-cache-"+queryParams+".json", UrlConfig.SEARCH_WIFI_URL+"?"+queryParams,
                 false, true, true,
                 ApiDownloader.REQUEST_GET,
                 new ApiListener() {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
@@ -9,6 +9,7 @@ import android.media.AudioManager;
 import android.os.Bundle;
 import android.os.Handler;
 
+import androidx.annotation.NonNull;
 import androidx.core.content.res.ResourcesCompat;
 import androidx.fragment.app.Fragment;
 import android.view.LayoutInflater;
@@ -24,6 +25,7 @@ import android.widget.TextView;
 import net.wigle.wigleandroid.listener.GNSSListener;
 import net.wigle.wigleandroid.ui.UINumberFormat;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
@@ -155,16 +157,16 @@ public class DashboardFragment extends Fragment {
         tv.setText( ListFragment.lameStatic.newCells + " ");
 
         if (null != currentActivity) {
-            final SharedPreferences prefs = currentActivity.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+            final SharedPreferences prefs = currentActivity.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
             tv = view.findViewById( R.id.newNetsSinceUpload );
             tv.setText( getString(R.string.dash_new_upload) + " " + newNetsSinceUpload(prefs) );
 
-            updateDist(view, prefs, R.id.rundist, ListFragment.PREF_DISTANCE_RUN, getString(R.string.dash_dist_run));
-            updateTime(view, prefs, R.id.run_dur, ListFragment.PREF_STARTTIME_RUN);
-            updateTimeTare(view, prefs, R.id.scan_dur, ListFragment.PREF_CUMULATIVE_SCANTIME_RUN,
-                    ListFragment.PREF_STARTTIME_RUN, MainActivity.isScanning(getActivity()));
-            updateDist(view, prefs, R.id.totaldist, ListFragment.PREF_DISTANCE_TOTAL, getString(R.string.dash_dist_total));
-            updateDist(view, prefs, R.id.prevrundist, ListFragment.PREF_DISTANCE_PREV_RUN, getString(R.string.dash_dist_prev));
+            updateDist(view, prefs, R.id.rundist, PreferenceKeys.PREF_DISTANCE_RUN, getString(R.string.dash_dist_run));
+            updateTime(view, prefs, R.id.run_dur, PreferenceKeys.PREF_STARTTIME_RUN);
+            updateTimeTare(view, prefs, R.id.scan_dur, PreferenceKeys.PREF_CUMULATIVE_SCANTIME_RUN,
+                    PreferenceKeys.PREF_STARTTIME_RUN, MainActivity.isScanning(getActivity()));
+            updateDist(view, prefs, R.id.totaldist, PreferenceKeys.PREF_DISTANCE_TOTAL, getString(R.string.dash_dist_total));
+            updateDist(view, prefs, R.id.prevrundist, PreferenceKeys.PREF_DISTANCE_PREV_RUN, getString(R.string.dash_dist_prev));
         }
         tv = view.findViewById( R.id.queuesize );
         tv.setText( getString(R.string.dash_db_queue) + " " + wholeNumberFormat.format(ListFragment.lameStatic.preQueueSize) );
@@ -260,8 +262,8 @@ public class DashboardFragment extends Fragment {
 
   private String newNetsSinceUpload(final SharedPreferences prefs) {
       long newSinceUpload = 0;
-      final long marker = prefs.getLong( ListFragment.PREF_DB_MARKER, 0L );
-      final long uploaded = prefs.getLong( ListFragment.PREF_NETS_UPLOADED, 0L );
+      final long marker = prefs.getLong( PreferenceKeys.PREF_DB_MARKER, 0L );
+      final long uploaded = prefs.getLong( PreferenceKeys.PREF_NETS_UPLOADED, 0L );
       // marker is set but no uploaded, a migration situation, so return zero
       if (marker == 0 || uploaded != 0) {
           newSinceUpload = ListFragment.lameStatic.dbNets - uploaded;
@@ -289,9 +291,9 @@ public class DashboardFragment extends Fragment {
 
   private void updateTimeTare(final View view, final SharedPreferences prefs, final int id, final String prefCumulative,
                               final String prefCurrent, final boolean isScanning) {
-      long cumulative = prefs.getLong(ListFragment.PREF_CUMULATIVE_SCANTIME_RUN, 0L);
+      long cumulative = prefs.getLong(PreferenceKeys.PREF_CUMULATIVE_SCANTIME_RUN, 0L);
       if (isScanning) {
-        cumulative += System.currentTimeMillis() - prefs.getLong(ListFragment.PREF_STARTTIME_CURRENT_SCAN, System.currentTimeMillis());
+        cumulative += System.currentTimeMillis() - prefs.getLong(PreferenceKeys.PREF_STARTTIME_CURRENT_SCAN, System.currentTimeMillis());
       }
       final String durString = timeString(cumulative);
       final TextView tv = view.findViewById( id );
@@ -333,7 +335,7 @@ public class DashboardFragment extends Fragment {
   }
 
   @Override
-  public void onConfigurationChanged( final Configuration newConfig ) {
+  public void onConfigurationChanged(@NonNull final Configuration newConfig ) {
     Logging.info( "DASH: config changed" );
     switchView();
     super.onConfigurationChanged( newConfig );
@@ -341,13 +343,13 @@ public class DashboardFragment extends Fragment {
 
   /* Creates the menu items */
   @Override
-  public void onCreateOptionsMenu (final Menu menu, final MenuInflater inflater) {
+  public void onCreateOptionsMenu (@NonNull final Menu menu, @NonNull final MenuInflater inflater) {
     super.onCreateOptionsMenu(menu, inflater);
   }
 
   /* Handles item selections */
   @Override
-  public boolean onOptionsItemSelected( final MenuItem item ) {
+  public boolean onOptionsItemSelected(@NonNull final MenuItem item ) {
       return false;
   }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
@@ -12,11 +12,13 @@ import net.wigle.wigleandroid.background.KmlWriter;
 import net.wigle.wigleandroid.db.DBException;
 import net.wigle.wigleandroid.db.DatabaseHelper;
 import net.wigle.wigleandroid.model.Pair;
+import net.wigle.wigleandroid.ui.WiGLEConfirmationDialog;
 import net.wigle.wigleandroid.ui.WiGLEToast;
 import net.wigle.wigleandroid.util.AsyncGpxExportTask;
 import net.wigle.wigleandroid.util.FileUtility;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.MagicEightUtil;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 import net.wigle.wigleandroid.util.SearchUtil;
 
 import android.annotation.SuppressLint;
@@ -50,12 +52,12 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import static net.wigle.wigleandroid.ListFragment.PREF_LOG_ROUTES;
 import static net.wigle.wigleandroid.MainActivity.ACTION_GPX_MGMT;
 import static net.wigle.wigleandroid.util.AsyncGpxExportTask.EXPORT_GPX_DIALOG;
 import static net.wigle.wigleandroid.util.FileUtility.M8B_EXT;
@@ -111,31 +113,23 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
 
     private void setupQueryButtons( final View view ) {
         Button button = view.findViewById( R.id.search_button );
-        button.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(final View buttonView) {
+        button.setOnClickListener(buttonView -> {
 
-                final String fail = SearchUtil.setupQuery(view, getActivity(), true);
-                if (null != ListFragment.lameStatic.queryArgs) {
-                    ListFragment.lameStatic.queryArgs.setSearchWiGLE(false);
-                }
-                if (fail != null) {
-                    WiGLEToast.showOverFragment(getActivity(), R.string.error_general, fail);
-                } else {
-                    // start db result activity
-                    final Intent settingsIntent = new Intent(getActivity(), DBResultActivity.class);
-                    startActivity(settingsIntent);
-                }
+            final String fail = SearchUtil.setupQuery(view, getActivity(), true);
+            if (null != ListFragment.lameStatic.queryArgs) {
+                ListFragment.lameStatic.queryArgs.setSearchWiGLE(false);
+            }
+            if (fail != null) {
+                WiGLEToast.showOverFragment(getActivity(), R.string.error_general, fail);
+            } else {
+                // start db result activity
+                final Intent settingsIntent = new Intent(getActivity(), DBResultActivity.class);
+                startActivity(settingsIntent);
             }
         });
 
         button = view.findViewById( R.id.reset_button );
-        button.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(final View buttonView) {
-                SearchUtil.clearWiFiBtFields(view);
-            }
-        });
+        button.setOnClickListener(buttonView -> SearchUtil.clearWiFiBtFields(view));
 
     }
 
@@ -157,30 +151,24 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
         // actually need this Activity context, for dialogs
 
         final Button csvRunExportButton = view.findViewById( R.id.csv_run_export_button );
-        csvRunExportButton.setOnClickListener( new OnClickListener() {
-            @Override
-            public void onClick( final View buttonView ) {
-                final FragmentActivity fa = getActivity();
-                if (fa != null) {
-                    MainActivity.createConfirmation(fa,
-                            DataFragment.this.getString(R.string.data_export_csv), R.id.nav_data, CSV_RUN_DIALOG);
-                } else {
-                    Logging.error("Null FragmentActivity setting up CSV run export button");
-                }
+        csvRunExportButton.setOnClickListener(buttonView -> {
+            final FragmentActivity fa = getActivity();
+            if (fa != null) {
+                WiGLEConfirmationDialog.createConfirmation(fa,
+                        DataFragment.this.getString(R.string.data_export_csv), R.id.nav_data, CSV_RUN_DIALOG);
+            } else {
+                Logging.error("Null FragmentActivity setting up CSV run export button");
             }
         });
 
         final Button csvExportButton = view.findViewById( R.id.csv_export_button );
-        csvExportButton.setOnClickListener( new OnClickListener() {
-            @Override
-            public void onClick( final View buttonView ) {
-                final FragmentActivity fa = getActivity();
-                if (fa != null) {
-                    MainActivity.createConfirmation( fa,
-                        DataFragment.this.getString(R.string.data_export_csv_db), R.id.nav_data, CSV_DB_DIALOG);
-                } else {
-                    Logging.error("Null FragmentActivity setting up CSV export button");
-                }
+        csvExportButton.setOnClickListener(buttonView -> {
+            final FragmentActivity fa = getActivity();
+            if (fa != null) {
+                WiGLEConfirmationDialog.createConfirmation( fa,
+                    DataFragment.this.getString(R.string.data_export_csv_db), R.id.nav_data, CSV_DB_DIALOG);
+            } else {
+                Logging.error("Null FragmentActivity setting up CSV export button");
             }
         });
     }
@@ -192,7 +180,7 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
             public void onClick( final View buttonView ) {
                 final FragmentActivity fa = getActivity();
                 if (fa != null) {
-                    MainActivity.createConfirmation( fa,
+                    WiGLEConfirmationDialog.createConfirmation( fa,
                         DataFragment.this.getString(R.string.data_export_kml_run), R.id.nav_data, KML_RUN_DIALOG);
                 } else {
                     Logging.error("Null FragmentActivity setting up KML run export button");
@@ -202,32 +190,26 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
 
 
         final Button kmlExportButton = view.findViewById( R.id.kml_export_button );
-        kmlExportButton.setOnClickListener( new OnClickListener() {
-            @Override
-            public void onClick( final View buttonView ) {
-                final FragmentActivity fa = getActivity();
-                if (fa != null) {
-                    MainActivity.createConfirmation( fa,
-                        DataFragment.this.getString(R.string.data_export_kml_db), R.id.nav_data, KML_DB_DIALOG);
-                } else {
-                    Logging.error("Null FragmentActivity setting up KML export button");
-                }
+        kmlExportButton.setOnClickListener(buttonView -> {
+            final FragmentActivity fa = getActivity();
+            if (fa != null) {
+                WiGLEConfirmationDialog.createConfirmation( fa,
+                    DataFragment.this.getString(R.string.data_export_kml_db), R.id.nav_data, KML_DB_DIALOG);
+            } else {
+                Logging.error("Null FragmentActivity setting up KML export button");
             }
         });
     }
 
     private void setupBackupDbButton( final View view ) {
         final Button dbBackupButton = view.findViewById( R.id.backup_db_button );
-        dbBackupButton.setOnClickListener( new OnClickListener() {
-            @Override
-            public void onClick( final View buttonView ) {
-                final FragmentActivity fa = getActivity();
-                if (fa != null) {
-                    MainActivity.createConfirmation( fa,
-                        DataFragment.this.getString(R.string.data_backup_db), R.id.nav_data, BACKUP_DIALOG);
-                } else {
-                    Logging.error("Null FragmentActivity setting up backup confirmation");
-                }
+        dbBackupButton.setOnClickListener(buttonView -> {
+            final FragmentActivity fa = getActivity();
+            if (fa != null) {
+                WiGLEConfirmationDialog.createConfirmation( fa,
+                    DataFragment.this.getString(R.string.data_backup_db), R.id.nav_data, BACKUP_DIALOG);
+            } else {
+                Logging.error("Null FragmentActivity setting up backup confirmation");
             }
         });
     }
@@ -237,11 +219,11 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
         SharedPreferences prefs = null;
         Activity a = getActivity();
         if (null != a) {
-            prefs = a.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+            prefs = a.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
         }
         String authname = null;
         if (prefs != null) {
-            authname = prefs.getString(ListFragment.PREF_AUTHNAME, null);
+            authname = prefs.getString(PreferenceKeys.PREF_AUTHNAME, null);
         }
 
         if (null == authname) {
@@ -249,17 +231,14 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
         } else if (MainActivity.getMainActivity().isTransferring()) {
                 importObservedButton.setEnabled(false);
         }
-        importObservedButton.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(final View buttonView) {
-                final FragmentActivity fa = getActivity();
-                if (null != fa) {
-                    MainActivity.createConfirmation(fa,
-                            DataFragment.this.getString(R.string.data_import_observed),
-                            R.id.nav_data, IMPORT_DIALOG);
-                } else {
-                    Logging.error("unable to get fragment activity");
-                }
+        importObservedButton.setOnClickListener(buttonView -> {
+            final FragmentActivity fa = getActivity();
+            if (null != fa) {
+                WiGLEConfirmationDialog.createConfirmation(fa,
+                        DataFragment.this.getString(R.string.data_import_observed),
+                        R.id.nav_data, IMPORT_DIALOG);
+            } else {
+                Logging.error("unable to get fragment activity");
             }
         });
     }
@@ -274,17 +253,14 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
 
         final ObservationImporter task = new ObservationImporter(getActivity(),
                 ListFragment.lameStatic.dbHelper,
-                new ApiListener() {
-                    @Override
-                    public void requestComplete(JSONObject object, boolean cached) {
-                        if (mainActivity != null) {
-                            try {
-                                mainActivity.getState().dbHelper.getNetworkCountFromDB();
-                            } catch (DBException dbe) {
-                                Logging.warn("failed DB count update on import-observations", dbe);
-                            }
-                            mainActivity.transferComplete();
+                (object, cached) -> {
+                    if (mainActivity != null) {
+                        try {
+                            mainActivity.getState().dbHelper.getNetworkCountFromDB();
+                        } catch (DBException dbe) {
+                            Logging.warn("failed DB count update on import-observations", dbe);
                         }
+                        mainActivity.transferComplete();
                     }
                 });
         try {
@@ -299,95 +275,80 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
         SharedPreferences prefs = null;
         final Activity a = getActivity();
         if (null != a) {
-            prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+            prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
         }
 
         // db marker reset button and text
         final TextView tv = view.findViewById(R.id.reset_maxid_text);
         if (null != prefs) {
-            tv.setText(getString(R.string.setting_high_up) + " " + prefs.getLong(ListFragment.PREF_DB_MARKER, 0L));
+            tv.setText(getString(R.string.setting_high_up) + " " + prefs.getLong(PreferenceKeys.PREF_DB_MARKER, 0L));
         }
 
         final Button resetMaxidButton = view.findViewById(R.id.reset_maxid_button);
-        resetMaxidButton.setOnClickListener( new OnClickListener() {
-            @Override
-            public void onClick( final View buttonView ) {
-                final FragmentActivity fa = getActivity();
-                if (null != fa) {
-                    MainActivity.createConfirmation(fa, getString(R.string.setting_zero_out),
-                            R.id.nav_data, ZERO_OUT_DIALOG);
-                } else {
-                    Logging.error("unable to get fragment activity");
-                }
+        resetMaxidButton.setOnClickListener(buttonView -> {
+            final FragmentActivity fa = getActivity();
+            if (null != fa) {
+                WiGLEConfirmationDialog.createConfirmation(fa, getString(R.string.setting_zero_out),
+                        R.id.nav_data, ZERO_OUT_DIALOG);
+            } else {
+                Logging.error("unable to get fragment activity");
             }
         });
 
         // db marker maxout button and text
         if (null != prefs) {
             final TextView maxtv = view.findViewById(R.id.maxout_maxid_text);
-            final long maxDB = prefs.getLong(ListFragment.PREF_MAX_DB, 0L);
+            final long maxDB = prefs.getLong(PreferenceKeys.PREF_MAX_DB, 0L);
             maxtv.setText(getString(R.string.setting_max_start) + " " + maxDB);
         }
 
         final Button maxoutMaxidButton = view.findViewById(R.id.maxout_maxid_button);
-        maxoutMaxidButton.setOnClickListener( new OnClickListener() {
-            @Override
-            public void onClick( final View buttonView ) {
-                final FragmentActivity fa = getActivity();
-                if (null != fa) {
-                    MainActivity.createConfirmation(fa, getString(R.string.setting_max_out),
-                            R.id.nav_data, MAX_OUT_DIALOG);
-                } else {
-                    Logging.error("unable to get fragment activity");
-                }
+        maxoutMaxidButton.setOnClickListener(buttonView -> {
+            final FragmentActivity fa = getActivity();
+            if (null != fa) {
+                WiGLEConfirmationDialog.createConfirmation(fa, getString(R.string.setting_max_out),
+                        R.id.nav_data, MAX_OUT_DIALOG);
+            } else {
+                Logging.error("unable to get fragment activity");
             }
-        } );
+        });
 
         //ALIBI: not technically a marker button, but clearly belongs with them visually/logically
         final Button deleteDbButton = view.findViewById(R.id.clear_db);
-        deleteDbButton.setOnClickListener( new OnClickListener() {
-            @Override
-            public void onClick( final View buttonView ) {
-                final FragmentActivity fa = getActivity();
-                if (null != fa) {
-                    MainActivity.createConfirmation(fa, getString(R.string.delete_db_confirm),
-                            R.id.nav_data, DELETE_DIALOG);
-                } else {
-                    Logging.error("unable to get fragment activity");
-                }
+        deleteDbButton.setOnClickListener(buttonView -> {
+            final FragmentActivity fa = getActivity();
+            if (null != fa) {
+                WiGLEConfirmationDialog.createConfirmation(fa, getString(R.string.delete_db_confirm),
+                        R.id.nav_data, DELETE_DIALOG);
+            } else {
+                Logging.error("unable to get fragment activity");
             }
-        } );
+        });
 
     }
 
     private void setupGpxExport( final View view ) {
         final Activity a = getActivity();
         if (a != null) {
-            final SharedPreferences prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+            final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
             //ONLY ENABLE IF WE ARE LOGGING
-            if (prefs.getBoolean(PREF_LOG_ROUTES, false)) {
+            if (prefs.getBoolean(PreferenceKeys.PREF_LOG_ROUTES, false)) {
                 final View exportGpxTools = view.findViewById(R.id.export_gpx_tools);
                 exportGpxTools.setVisibility(View.VISIBLE);
                 final Button exportGpxButton = view.findViewById(R.id.export_gpx_button);
-                exportGpxButton.setOnClickListener(new OnClickListener() {
-                    @Override
-                    public void onClick(final View buttonView) {
-                        final FragmentActivity fa = getActivity();
-                        if (null != fa) {
-                            MainActivity.createConfirmation(fa, getString(R.string.export_gpx_detail),
-                                    R.id.nav_data, EXPORT_GPX_DIALOG);
-                        } else {
-                            Logging.error("unable to get fragment activity");
-                        }
+                exportGpxButton.setOnClickListener(buttonView -> {
+                    final FragmentActivity fa = getActivity();
+                    if (null != fa) {
+                        WiGLEConfirmationDialog.createConfirmation(fa, getString(R.string.export_gpx_detail),
+                                R.id.nav_data, EXPORT_GPX_DIALOG);
+                    } else {
+                        Logging.error("unable to get fragment activity");
                     }
                 });
                 final Button manageGpxButton = view.findViewById(R.id.manage_gpx_button);
-                manageGpxButton.setOnClickListener(new OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        final Intent gpxIntent = new Intent(a.getApplicationContext(), GpxManagementActivity.class);
-                        a.startActivityForResult(gpxIntent, ACTION_GPX_MGMT);
-                    }
+                manageGpxButton.setOnClickListener(v -> {
+                    final Intent gpxIntent = new Intent(a.getApplicationContext(), GpxManagementActivity.class);
+                    a.startActivityForResult(gpxIntent, ACTION_GPX_MGMT);
                 });
             }
         }
@@ -395,16 +356,13 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
 
     private void setupM8bExport( final View view ) {
         final Button exportM8bButton = view.findViewById(R.id.export_m8b_button);
-        exportM8bButton.setOnClickListener(new OnClickListener() {
-            @Override
-            public void onClick(final View buttonView) {
-                final FragmentActivity fa = getActivity();
-                if (null != fa) {
-                    MainActivity.createConfirmation(fa, getString(R.string.export_m8b_detail),
-                            R.id.nav_data, EXPORT_M8B_DIALOG);
-                } else {
-                    Logging.error("unable to get fragment activity");
-                }
+        exportM8bButton.setOnClickListener(buttonView -> {
+            final FragmentActivity fa = getActivity();
+            if (null != fa) {
+                WiGLEConfirmationDialog.createConfirmation(fa, getString(R.string.export_m8b_detail),
+                        R.id.nav_data, EXPORT_M8B_DIALOG);
+            } else {
+                Logging.error("unable to get fragment activity");
             }
         });
     }
@@ -414,7 +372,7 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
     public void handleDialog(final int dialogId) {
         SharedPreferences prefs = null;
         if (getActivity() != null) {
-            prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+            prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
         }
         SharedPreferences.Editor editor = null;
         if (null != prefs) {
@@ -463,7 +421,7 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
             }
             case ZERO_OUT_DIALOG: {
                 if (null != editor) {
-                    editor.putLong(ListFragment.PREF_DB_MARKER, 0L);
+                    editor.putLong(PreferenceKeys.PREF_DB_MARKER, 0L);
                     editor.apply();
                     if (view != null) {
                         final TextView tv = view.findViewById(R.id.reset_maxid_text);
@@ -476,8 +434,8 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
             }
             case MAX_OUT_DIALOG: {
                 if (prefs != null && editor != null) {
-                    final long maxDB = prefs.getLong( ListFragment.PREF_MAX_DB, 0L );
-                    editor.putLong( ListFragment.PREF_DB_MARKER, maxDB );
+                    final long maxDB = prefs.getLong( PreferenceKeys.PREF_MAX_DB, 0L );
+                    editor.putLong( PreferenceKeys.PREF_DB_MARKER, maxDB );
                     editor.apply();
                     if (view != null) {
                         // set the text on the other button
@@ -495,8 +453,8 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
                 ListFragment.lameStatic.dbHelper.clearDatabase();
                 //update markers
                 if (null != editor) {
-                    editor.putLong(ListFragment.PREF_DB_MARKER, 0L);
-                    editor.putLong(ListFragment.PREF_DB_MARKER, 0L);
+                    editor.putLong(PreferenceKeys.PREF_DB_MARKER, 0L);
+                    editor.putLong(PreferenceKeys.PREF_DB_MARKER, 0L);
                     editor.apply();
                     if (view != null) {
                         final TextView tv = view.findViewById(R.id.reset_maxid_text);
@@ -863,7 +821,7 @@ public final class DataFragment extends Fragment implements ApiListener, Transfe
                     // Tidy up the finished writer
                     if (null != out) {
                         try {
-                            Charset utf8  = Charset.forName("UTF-8");
+                            Charset utf8  = StandardCharsets.UTF_8;
 
                             ByteBuffer bb = ByteBuffer.allocate(4096).order(ByteOrder.LITTLE_ENDIAN); // screw you, java
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/FilterActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/FilterActivity.java
@@ -11,13 +11,12 @@ import android.widget.EditText;
 
 import net.wigle.wigleandroid.ui.PrefsBackedCheckbox;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 /**
  * Building a filter activity for the network list
  * Created by arkasha on 20170801.
  */
-
-@SuppressWarnings("deprecation")
 public class FilterActivity extends AppCompatActivity {
 
     public static final String ADDR_FILTER_MESSAGE = "net.wigle.wigleandroid.filter.MESSAGE";
@@ -27,7 +26,7 @@ public class FilterActivity extends AppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        final SharedPreferences prefs = this.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+        final SharedPreferences prefs = this.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
         final SharedPreferences.Editor editor = prefs.edit();
         setContentView(R.layout.filtersettings);
 
@@ -37,8 +36,8 @@ public class FilterActivity extends AppCompatActivity {
         }
         View view = findViewById(android.R.id.content);
         Logging.info("Filter Fragment Selected");
-        final EditText regex = (EditText) findViewById( R.id.edit_regex );
-        final String regexKey = ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_REGEX;
+        final EditText regex = findViewById( R.id.edit_regex );
+        final String regexKey = PreferenceKeys.FILTER_PREF_PREFIX + PreferenceKeys.PREF_MAPF_REGEX;
         regex.setText( prefs.getString(regexKey, "") );
 
         regex.addTextChangedListener( new SettingsFragment.SetWatcher() {
@@ -60,40 +59,34 @@ public class FilterActivity extends AppCompatActivity {
         });
 
         PrefsBackedCheckbox.prefBackedCheckBox(this , view, R.id.showinvert,
-                ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_INVERT, false );
+                PreferenceKeys.FILTER_PREF_PREFIX + PreferenceKeys.PREF_MAPF_INVERT, false );
         PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showopen,
-                ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_OPEN, true );
+                PreferenceKeys.FILTER_PREF_PREFIX + PreferenceKeys.PREF_MAPF_OPEN, true );
         PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showwep,
-                ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_WEP, true );
+                PreferenceKeys.FILTER_PREF_PREFIX + PreferenceKeys.PREF_MAPF_WEP, true );
         PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showwpa,
-                ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_WPA, true );
+                PreferenceKeys.FILTER_PREF_PREFIX + PreferenceKeys.PREF_MAPF_WPA, true );
         PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showcell,
-                ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_CELL, true );
+                PreferenceKeys.FILTER_PREF_PREFIX + PreferenceKeys.PREF_MAPF_CELL, true );
         PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.enabled,
-                ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_ENABLED, true );
+                PreferenceKeys.FILTER_PREF_PREFIX + PreferenceKeys.PREF_MAPF_ENABLED, true );
         PrefsBackedCheckbox.prefBackedCheckBox(this, view, R.id.showbt,
-                ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_BT, true);
+                PreferenceKeys.FILTER_PREF_PREFIX + PreferenceKeys.PREF_MAPF_BT, true);
         PrefsBackedCheckbox.prefBackedCheckBox(this, view, R.id.showbtle,
-                ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_BTLE, true);
+                PreferenceKeys.FILTER_PREF_PREFIX + PreferenceKeys.PREF_MAPF_BTLE, true);
 
-        final Button filter_display_button = (Button) view.findViewById(R.id.display_filter_button);
-        filter_display_button.setOnClickListener( new View.OnClickListener() {
-            @Override
-            public void onClick( final View view ) {
-                final Intent macFilterIntent = new Intent(getApplicationContext(), MacFilterActivity.class );
-                macFilterIntent.putExtra(ADDR_FILTER_MESSAGE, INTENT_DISPLAY_FILTER);
-                startActivity( macFilterIntent );
-            }
+        final Button filter_display_button = view.findViewById(R.id.display_filter_button);
+        filter_display_button.setOnClickListener(view1 -> {
+            final Intent macFilterIntent = new Intent(getApplicationContext(), MacFilterActivity.class );
+            macFilterIntent.putExtra(ADDR_FILTER_MESSAGE, INTENT_DISPLAY_FILTER);
+            startActivity( macFilterIntent );
         });
 
-        final Button filter_log_button = (Button) view.findViewById(R.id.log_filter_button);
-        filter_log_button.setOnClickListener( new View.OnClickListener() {
-            @Override
-            public void onClick( final View view ) {
-                final Intent macFilterIntent = new Intent(getApplicationContext(), MacFilterActivity.class );
-                macFilterIntent.putExtra(ADDR_FILTER_MESSAGE, INTENT_LOG_FILTER);
-                startActivity( macFilterIntent );
-            }
+        final Button filter_log_button = view.findViewById(R.id.log_filter_button);
+        filter_log_button.setOnClickListener(view12 -> {
+            final Intent macFilterIntent = new Intent(getApplicationContext(), MacFilterActivity.class );
+            macFilterIntent.putExtra(ADDR_FILTER_MESSAGE, INTENT_LOG_FILTER);
+            startActivity( macFilterIntent );
         });
 
     }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/FilterActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/FilterActivity.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 
+import net.wigle.wigleandroid.ui.PrefsBackedCheckbox;
 import net.wigle.wigleandroid.util.Logging;
 
 /**
@@ -58,21 +59,21 @@ public class FilterActivity extends AppCompatActivity {
             }
         });
 
-        MainActivity.prefBackedCheckBox(this , view, R.id.showinvert,
+        PrefsBackedCheckbox.prefBackedCheckBox(this , view, R.id.showinvert,
                 ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_INVERT, false );
-        MainActivity.prefBackedCheckBox( this, view, R.id.showopen,
+        PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showopen,
                 ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_OPEN, true );
-        MainActivity.prefBackedCheckBox( this, view, R.id.showwep,
+        PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showwep,
                 ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_WEP, true );
-        MainActivity.prefBackedCheckBox( this, view, R.id.showwpa,
+        PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showwpa,
                 ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_WPA, true );
-        MainActivity.prefBackedCheckBox( this, view, R.id.showcell,
+        PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showcell,
                 ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_CELL, true );
-        MainActivity.prefBackedCheckBox( this, view, R.id.enabled,
+        PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.enabled,
                 ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_ENABLED, true );
-        MainActivity.prefBackedCheckBox(this, view, R.id.showbt,
+        PrefsBackedCheckbox.prefBackedCheckBox(this, view, R.id.showbt,
                 ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_BT, true);
-        MainActivity.prefBackedCheckBox(this, view, R.id.showbtle,
+        PrefsBackedCheckbox.prefBackedCheckBox(this, view, R.id.showbtle,
                 ListFragment.FILTER_PREF_PREFIX + ListFragment.PREF_MAPF_BTLE, true);
 
         final Button filter_display_button = (Button) view.findViewById(R.id.display_filter_button);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/FilterMatcher.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/FilterMatcher.java
@@ -9,13 +9,14 @@ import android.content.SharedPreferences;
 import net.wigle.wigleandroid.model.Network;
 import net.wigle.wigleandroid.model.NetworkType;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 /**
  * filter matchers
  */
 public final class FilterMatcher {
     private static boolean isSsidFilterOn( final SharedPreferences prefs, final String prefix ) {
-        return prefs.getBoolean( prefix + ListFragment.PREF_MAPF_ENABLED, true );
+        return prefs.getBoolean( prefix + PreferenceKeys.PREF_MAPF_ENABLED, true );
     }
 
     private static boolean isBssidFilterOn( final SharedPreferences prefs, final String addressKey) {
@@ -27,7 +28,7 @@ public final class FilterMatcher {
     }
 
     public static Matcher getSsidFilterMatcher( final SharedPreferences prefs, final String prefix ) {
-        final String regex = prefs.getString( prefix + ListFragment.PREF_MAPF_REGEX, "" );
+        final String regex = prefs.getString( prefix + PreferenceKeys.PREF_MAPF_REGEX, "" );
         Matcher matcher = null;
         if ( isSsidFilterOn( prefs, prefix ) && regex != null && ! "".equals(regex) ) {
             try {
@@ -46,7 +47,7 @@ public final class FilterMatcher {
     public static boolean isOk(final Matcher ssidMatcher, final Matcher bssidMatcher,
                                final SharedPreferences prefs, final String prefix, final Network network ) {
 
-        /**
+        /*
          * ALIBI: shouldn't be necessary, but seeing null network reports.
          */
         if (network == null) {
@@ -58,7 +59,7 @@ public final class FilterMatcher {
                 try {
                     final String ssid = network.getSsid();
                     ssidMatcher.reset(ssid);
-                    final boolean invert = prefs.getBoolean(prefix + ListFragment.PREF_MAPF_INVERT, false);
+                    final boolean invert = prefs.getBoolean(prefix + PreferenceKeys.PREF_MAPF_INVERT, false);
                     final boolean matches = ssidMatcher.find();
                     if (!matches && !invert) {
                         return false;
@@ -67,7 +68,7 @@ public final class FilterMatcher {
                     }
                 } catch (IllegalArgumentException iaex) {
                     Logging.warn("Matcher: IllegalArgument: " + network.getSsid() + "pattern: " + ssidMatcher.pattern());
-                    final boolean invert = prefs.getBoolean(prefix + ListFragment.PREF_MAPF_INVERT, false);
+                    final boolean invert = prefs.getBoolean(prefix + PreferenceKeys.PREF_MAPF_INVERT, false);
                     return !invert;
                 }
             }
@@ -75,19 +76,19 @@ public final class FilterMatcher {
             if ( NetworkType.WIFI.equals( network.getType() ) ) {
                 switch (network.getCrypto()) {
                     case Network.CRYPTO_NONE:
-                        if (!prefs.getBoolean(prefix + ListFragment.PREF_MAPF_OPEN, true)) {
+                        if (!prefs.getBoolean(prefix + PreferenceKeys.PREF_MAPF_OPEN, true)) {
                             return false;
                         }
                         break;
                     case Network.CRYPTO_WEP:
-                        if (!prefs.getBoolean(prefix + ListFragment.PREF_MAPF_WEP, true)) {
+                        if (!prefs.getBoolean(prefix + PreferenceKeys.PREF_MAPF_WEP, true)) {
                             return false;
                         }
                         break;
                     case Network.CRYPTO_WPA:
                     case Network.CRYPTO_WPA2:
                     case Network.CRYPTO_WPA3:
-                        if (!prefs.getBoolean(prefix + ListFragment.PREF_MAPF_WPA, true)) {
+                        if (!prefs.getBoolean(prefix + PreferenceKeys.PREF_MAPF_WPA, true)) {
                             return false;
                         }
                         break;
@@ -95,19 +96,19 @@ public final class FilterMatcher {
                         Logging.error("unhandled crypto: " + network);
                 }
             } else if (NetworkType.BT.equals(network.getType())) {
-                if (!prefs.getBoolean(prefix + ListFragment.PREF_MAPF_BT, true)) {
+                if (!prefs.getBoolean(prefix + PreferenceKeys.PREF_MAPF_BT, true)) {
                     return false;
                 }
             } else if (NetworkType.BLE.equals(network.getType()) ) {
-                if (!prefs.getBoolean(prefix + ListFragment.PREF_MAPF_BTLE, true)) {
+                if (!prefs.getBoolean(prefix + PreferenceKeys.PREF_MAPF_BTLE, true)) {
                     return false;
                 }
-            } else if (!prefs.getBoolean(prefix + ListFragment.PREF_MAPF_CELL, true)) {
+            } else if (!prefs.getBoolean(prefix + PreferenceKeys.PREF_MAPF_CELL, true)) {
                 return false;
             }
         }
 
-        if (isBssidFilterOn(prefs, ListFragment.PREF_EXCLUDE_DISPLAY_ADDRS)) {
+        if (isBssidFilterOn(prefs, PreferenceKeys.PREF_EXCLUDE_DISPLAY_ADDRS)) {
             if (bssidMatcher != null) { //ALIBI: fallthrough on Map call, since we're not applying this there?
                 try {
                     final String bssid = network.getBssid();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
@@ -511,7 +511,6 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
             TextView text = view.findViewById( R.id.text );
             text.setText( getString(R.string.sort_spin_label) );
 
-            final FragmentActivity a = getActivity();
             final SharedPreferences prefs = getActivity().getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0 );
             final Editor editor = prefs.edit();
 
@@ -569,7 +568,7 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
         final State state = MainActivity.getStaticState();
 
         Logging.info( "LIST: on config change" );
-        final FragmentActivity a= this.getActivity();
+        final FragmentActivity a = this.getActivity();
         if (null != a) {
             MainActivity.setLocale( a, newConfig);
         }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
@@ -3,6 +3,7 @@
 
 package net.wigle.wigleandroid;
 
+import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.Intent;
@@ -11,6 +12,8 @@ import android.content.SharedPreferences.Editor;
 import android.content.res.Configuration;
 import android.location.Location;
 import android.os.Bundle;
+
+import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
@@ -49,7 +52,9 @@ import net.wigle.wigleandroid.model.QueryArgs;
 import net.wigle.wigleandroid.ui.SetNetworkListAdapter;
 import net.wigle.wigleandroid.ui.NetworkListSorter;
 import net.wigle.wigleandroid.ui.UINumberFormat;
+import net.wigle.wigleandroid.ui.WiGLEConfirmationDialog;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 import org.json.JSONObject;
 
@@ -64,7 +69,7 @@ import static android.view.View.VISIBLE;
 /**
  * Main Network List View Fragment Adapter. Manages dynamic update of view apart from list when showing.
  * TODO: confirm that lameStatic values are being updated correctly, always.
- * @author: bobzilla, arkasha
+ * @author bobzilla, arkasha
  */
 public final class ListFragment extends Fragment implements ApiListener, DialogListener {
     private static final int MENU_WAKELOCK = 12;
@@ -77,104 +82,6 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
     private static final int SORT_DIALOG = 100;
     private static final int UPLOAD_DIALOG = 101;
     private static final int QUICK_PAUSE_DIALOG = 102;
-
-    // preferences
-    public static final String SHARED_PREFS = "WiglePrefs";
-    public static final String PREF_USERNAME = "username";
-    public static final String PREF_PASSWORD = "password";
-    public static final String PREF_AUTHNAME = "authname";
-    public static final String PREF_TOKEN = "token";
-    public static final String PREF_TOKEN_IV = "tokenIV";
-    public static final String PREF_TOKEN_TAG_LENGTH = "tokenTagLength";
-    public static final String PREF_SHOW_CURRENT = "showCurrent";
-    public static final String PREF_BE_ANONYMOUS = "beAnonymous";
-    public static final String PREF_DONATE = "donate";
-    public static final String PREF_DB_MARKER = "dbMarker";
-    public static final String PREF_MAX_DB = "maxDbMarker";
-    public static final String PREF_ROUTE_DB_RUN = "routeDbRun";
-    public static final String PREF_NETS_UPLOADED = "netsUploaded";
-    public static final String PREF_SCAN_PERIOD_STILL = "scanPeriodStill";
-    public static final String PREF_SCAN_PERIOD = "scanPeriod";
-    public static final String PREF_SCAN_PERIOD_FAST = "scanPeriodFast";
-    public static final String PREF_OG_BT_SCAN_PERIOD_STILL = "btGeneralScanPeriodStill";
-    public static final String PREF_OG_BT_SCAN_PERIOD = "btGeneralScanPeriod";
-    public static final String PREF_OG_BT_SCAN_PERIOD_FAST = "btGeneralScanPeriodFast";
-    public static final String PREF_QUICK_PAUSE = "quickScanPause";
-    public static final String GPS_SCAN_PERIOD = "gpsPeriod";
-    public static final String PREF_FOUND_SOUND = "foundSound";
-    public static final String PREF_FOUND_NEW_SOUND = "foundNewSound";
-    public static final String PREF_LANGUAGE = "speechLanguage";
-    public static final String PREF_RESET_WIFI_PERIOD = "resetWifiPeriod";
-    public static final String PREF_BATTERY_KILL_PERCENT = "batteryKillPercent";
-    public static final String PREF_MUTED = "muted";
-    public static final String PREF_BT_WAS_OFF = "btWasOff";
-    public static final String PREF_SCAN_BT = "scanBluetooth";
-    public static final String PREF_DISTANCE_RUN = "distRun";
-    public static final String PREF_STARTTIME_RUN = "timestampRunStart";
-    public static final String PREF_CUMULATIVE_SCANTIME_RUN = "millisScannedDuringRun";
-    public static final String PREF_STARTTIME_CURRENT_SCAN = "timestampScanStart";
-    public static final String PREF_DISTANCE_TOTAL = "distTotal";
-    public static final String PREF_DISTANCE_PREV_RUN = "distPrevRun";
-    public static final String PREF_PREV_LAT = "prevLat";
-    public static final String PREF_PREV_LON = "prevLon";
-    public static final String PREF_PREV_ZOOM = "prevZoom2";
-    public static final String PREF_LIST_SORT = "listSort";
-    public static final String PREF_SCAN_RUNNING = "scanRunning";
-    public static final String PREF_METRIC = "metric";
-    public static final String PREF_USE_NETWORK_LOC = "useNetworkLoc";
-    public static final String PREF_DISABLE_TOAST = "disableToast"; // bool
-    public static final String PREF_BLOWED_UP = "blowedUp";
-    public static final String PREF_CONFIRM_UPLOAD_USER = "confirmUploadUser";
-    public static final String PREF_EXCLUDE_DISPLAY_ADDRS = "displayExcludeAddresses";
-    public static final String PREF_EXCLUDE_LOG_ADDRS = "logExcludeAddresses";
-    public static final String PREF_GPS_TIMEOUT = "gpsTimeout";
-    public static final String PREF_GPS_KALMAN_FILTER = "gpsKalmanFilter";
-    public static final String PREF_NET_LOC_TIMEOUT = "networkLocationTimeout";
-    public static final String PREF_START_AT_BOOT = "startAtBoot";
-    public static final String PREF_LOG_ROUTES = "logRoutes";
-    public static final String PREF_DAYNIGHT_MODE = "dayNightMode";
-
-    // map prefs
-    public static final String PREF_MAP_NO_TILE = "NONE";
-    public static final String PREF_MAP_ONLYMINE_TILE = "MINE";
-    public static final String PREF_MAP_NOTMINE_TILE = "NOTMINE";
-    public static final String PREF_MAP_ALL_TILE = "ALL";
-    public static final String PREF_MAP_TYPE = "mapType";
-    public static final String PREF_MAP_ONLY_NEWDB = "mapOnlyNewDB";
-    public static final String PREF_MAP_LABEL = "mapLabel";
-    public static final String PREF_MAP_CLUSTER = "mapCluster";
-    public static final String PREF_MAP_TRAFFIC = "mapTraffic";
-    public static final String PREF_CIRCLE_SIZE_MAP = "circleSizeMap";
-    public static final String PREF_MAP_HIDE_NETS = "hideNetsMap";
-    public static final String PREF_VISUALIZE_ROUTE = "visualizeRoute";
-    public static final String PREF_SHOW_DISCOVERED_SINCE = "showDiscoveredSince";
-    public static final String PREF_SHOW_DISCOVERED = "showMyDiscovered";
-    public static final String PREF_MAPS_FOLLOW_DAYNIGHT = "mapThemeMatchDayNight";
-
-    // what to speak on announcements
-    public static final String PREF_SPEECH_PERIOD = "speechPeriod";
-    public static final String PREF_SPEECH_GPS = "speechGPS";
-    public static final String PREF_SPEAK_RUN = "speakRun";
-    public static final String PREF_SPEAK_NEW_WIFI = "speakNew";
-    public static final String PREF_SPEAK_NEW_CELL = "speakNewCell";
-    public static final String PREF_SPEAK_QUEUE = "speakQueue";
-    public static final String PREF_SPEAK_MILES = "speakMiles";
-    public static final String PREF_SPEAK_TIME = "speakTime";
-    public static final String PREF_SPEAK_BATTERY = "speakBattery";
-    public static final String PREF_SPEAK_SSID = "speakSsid";
-    public static final String PREF_SPEAK_WIFI_RESTART = "speakWifiRestart";
-
-    // map ssid filter
-    public static final String PREF_MAPF_REGEX = "mapfRegex";
-    public static final String PREF_MAPF_INVERT = "mapfInvert";
-    public static final String PREF_MAPF_OPEN = "mapfOpen";
-    public static final String PREF_MAPF_WEP = "mapfWep";
-    public static final String PREF_MAPF_WPA = "mapfWpa";
-    public static final String PREF_MAPF_CELL = "mapfCell";
-    public static final String PREF_MAPF_BT = "mapfBt";
-    public static final String PREF_MAPF_BTLE = "mapfBtle";
-    public static final String PREF_MAPF_ENABLED = "mapfEnabled";
-    public static final String FILTER_PREF_PREFIX = "LA";
 
     // rank stats data
     public static final String PREF_RANK = "rank";
@@ -255,16 +162,19 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
 
     /**
      * hide/show bluetooth new total
-     * @param on
+     * @param on desired bluetooth state
      */
     public void toggleBluetoothStats(final boolean on) {
         try {
-            View fragRoot = this.getActivity().findViewById(android.R.id.content);
-            View btView = fragRoot.findViewById(R.id.bt_list_total);
-            if (on) {
-                btView.setVisibility(VISIBLE);
-            } else {
-                btView.setVisibility(GONE);
+            final Activity a = this.getActivity();
+            if (null != a) {
+                final View fragRoot = this.getActivity().findViewById(android.R.id.content);
+                final View btView = fragRoot.findViewById(R.id.bt_list_total);
+                if (on) {
+                    btView.setVisibility(VISIBLE);
+                } else {
+                    btView.setVisibility(GONE);
+                }
             }
         } catch (Exception ex) {
             //this shouldn't be a critical failure if the view's not present.
@@ -287,9 +197,9 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
         if (view == null) {
             return;
         }
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        Handler handler = new Handler(Looper.getMainLooper());
-        TextView tv = (TextView) view.findViewById( R.id.stats_run );
+        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final Handler handler = new Handler(Looper.getMainLooper());
+        TextView tv = view.findViewById( R.id.stats_run );
         long netCount = state.wifiReceiver.getRunNetworkCount();
         if (null != state.bluetoothReceiver){
             netCount += state.bluetoothReceiver.getRunNetworkCount();
@@ -298,23 +208,23 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
         executor.execute(() -> {
             final long count = state.dbHelper.getNewWifiCount();
             handler.post(() -> {
-                TextView text = (TextView) view.findViewById( R.id.stats_wifi );
+                TextView text = view.findViewById( R.id.stats_wifi );
                 text.setText( ""+UINumberFormat.counterFormat(count) );
             });
         });
-        tv = (TextView) view.findViewById( R.id.stats_cell );
+        tv = view.findViewById( R.id.stats_cell );
         tv.setText( ""+UINumberFormat.counterFormat(lameStatic.newCells));
         executor.execute(() -> {
             final long count = state.dbHelper.getNewBtCount();
             handler.post(() -> {
-                TextView text = (TextView) view.findViewById( R.id.stats_bt );
+                TextView text = view.findViewById( R.id.stats_bt );
                 text.setText( ""+UINumberFormat.counterFormat(count) );
             });
         });
         executor.execute(() -> {
             final long count = state.dbHelper.getNetworkCount();
             handler.post(() -> {
-                TextView text = (TextView) view.findViewById( R.id.stats_dbnets );
+                TextView text = view.findViewById( R.id.stats_dbnets );
                 text.setText(""+count);
             });
         });
@@ -350,8 +260,8 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
                 Logging.error("Null activity context - can't set animation");
             }
 
-            final SharedPreferences prefs = getActivity().getSharedPreferences(SHARED_PREFS, 0);
-            String quickPausePref = prefs.getString(PREF_QUICK_PAUSE, QUICK_SCAN_UNSET);
+            final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+            String quickPausePref = prefs.getString(PreferenceKeys.PREF_QUICK_PAUSE, QUICK_SCAN_UNSET);
             if (!QUICK_SCAN_DO_NOTHING.equals(quickPausePref)) {
                 scanningImageButton.setContentDescription(getString(R.string.scan)+" "+getString(R.string.off));
                 notScanningImageButton.setContentDescription(getString(R.string.scan)+" "+getString(R.string.on));
@@ -360,25 +270,19 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
                 notScanningImageButton.setContentDescription(getString(R.string.list_scanning_off));
             }
 
-            scanningImageButton.setOnClickListener(new OnClickListener() {
-                @Override
-                public void onClick( final View buttonView ) {
-                    String quickPausePref = prefs.getString(PREF_QUICK_PAUSE, QUICK_SCAN_UNSET);
-                    if (QUICK_SCAN_DO_NOTHING.equals(quickPausePref)) return;
-                    if (QUICK_SCAN_PAUSE.equals(quickPausePref)) {
-                        toggleScan();
-                    } else {
-                        makeQuickPausePrefDialog(ma);
-                    }
+            scanningImageButton.setOnClickListener(buttonView -> {
+                String quickPausePref12 = prefs.getString(PreferenceKeys.PREF_QUICK_PAUSE, QUICK_SCAN_UNSET);
+                if (QUICK_SCAN_DO_NOTHING.equals(quickPausePref12)) return;
+                if (QUICK_SCAN_PAUSE.equals(quickPausePref12)) {
+                    toggleScan();
+                } else {
+                    makeQuickPausePrefDialog();
                 }
-           });
-            notScanningImageButton.setOnClickListener(new OnClickListener() {
-                    @Override
-                    public void onClick( final View buttonView ) {
-                        String quickPausePref = prefs.getString(PREF_QUICK_PAUSE, QUICK_SCAN_UNSET);
-                        if (QUICK_SCAN_DO_NOTHING.equals(quickPausePref)) return;
-                        toggleScan();
-                    }
+            });
+            notScanningImageButton.setOnClickListener(buttonView -> {
+                String quickPausePref1 = prefs.getString(PreferenceKeys.PREF_QUICK_PAUSE, QUICK_SCAN_UNSET);
+                if (QUICK_SCAN_DO_NOTHING.equals(quickPausePref1)) return;
+                toggleScan();
             });
         }
 
@@ -396,8 +300,8 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
     public void setScanningStatusIndicator(boolean scanning) {
         View view = getView();
         if (view != null) {
-            final ImageButton scanningImageButton = (ImageButton) view.findViewById(R.id.scanning);
-            final ImageButton notScanningImageButton = (ImageButton) view.findViewById(R.id.not_scanning);
+            final ImageButton scanningImageButton = view.findViewById(R.id.scanning);
+            final ImageButton notScanningImageButton = view.findViewById(R.id.not_scanning);
             if (scanning) {
                 scanningImageButton.setVisibility(VISIBLE);
                 notScanningImageButton.setVisibility(GONE);
@@ -425,7 +329,10 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
     public void onResume() {
         Logging.info( "LIST: resumed.");
         super.onResume();
-        getActivity().setTitle(R.string.list_app_name);
+        final Activity a = getActivity();
+        if (null != a) {
+            a.setTitle(R.string.list_app_name);
+        }
         //ALIBI: default status can confuse users on resume
         Logging.info("setNetCountUI");
         setNetCountUI(MainActivity.getStaticState(), getView());
@@ -465,7 +372,7 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
 
     /* Creates the menu items */
     @Override
-    public void onCreateOptionsMenu (final Menu menu, final MenuInflater inflater) {
+    public void onCreateOptionsMenu (final Menu menu, @NonNull final MenuInflater inflater) {
         MenuItem item = menu.add(0, MENU_MAP, 0, getString(R.string.tab_map));
         item.setIcon( android.R.drawable.ic_menu_mapmode );
         item.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
@@ -478,7 +385,7 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
         item.setIcon( android.R.drawable.ic_menu_sort_alphabetically );
         item.setShowAsAction(MenuItem.SHOW_AS_ACTION_IF_ROOM);
 
-        MainActivity main = MainActivity.getMainActivity(this);
+        final MainActivity main = MainActivity.getMainActivity(this);
         final String scan = (main == null || main.isScanning()) ? getString(R.string.off) : getString(R.string.on);
         item = menu.add(0, MENU_SCAN, 0, getString(R.string.scan) + " " + scan);
         item.setIcon((main == null || main.isScanning()) ? android.R.drawable.ic_media_pause : android.R.drawable.ic_media_play);
@@ -488,19 +395,15 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
         item = menu.add(0, MENU_WAKELOCK, 0, wake);
         item.setIcon( android.R.drawable.ic_menu_gallery );
 
-        final SharedPreferences prefs = getActivity().getSharedPreferences(SHARED_PREFS, 0);
-        boolean muted = prefs.getBoolean(PREF_MUTED, true);
-        item = menu.add(0, MENU_MUTE, 0,
-                muted ? getString(R.string.play) : getString(R.string.mute));
-        item.setIcon( muted ? android.R.drawable.ic_media_play
-                : android.R.drawable.ic_media_pause);
-
-        // item = menu.add(0, MENU_SETTINGS, 0, getString(R.string.menu_settings));
-        // item.setIcon( android.R.drawable.ic_menu_preferences );
-
-        // item = menu.add(0, MENU_EXIT, 0, getString(R.string.menu_exit));
-        // item.setIcon( android.R.drawable.ic_menu_close_clear_cancel );
-
+        final Activity a = getActivity();
+        if (null != a) {
+            final SharedPreferences prefs = a.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+            boolean muted = prefs.getBoolean(PreferenceKeys.PREF_MUTED, true);
+            item = menu.add(0, MENU_MUTE, 0,
+                    muted ? getString(R.string.play) : getString(R.string.mute));
+            item.setIcon(muted ? android.R.drawable.ic_media_play
+                    : android.R.drawable.ic_media_pause);
+        }
         super.onCreateOptionsMenu(menu, inflater);
     }
 
@@ -508,6 +411,7 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
     @Override
     public boolean onOptionsItemSelected( final MenuItem item ) {
         final MainActivity main = MainActivity.getMainActivity(this);
+        final FragmentActivity a = getActivity();
         switch ( item.getItemId() ) {
             case MENU_WAKELOCK: {
                 boolean screenLocked = ! MainActivity.isScreenLocked( this );
@@ -535,25 +439,31 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
             }
             case MENU_FILTER:
                 final Intent intent = new Intent(getActivity(), FilterActivity.class);
-                getActivity().startActivity(intent);
+                if (null != a) {
+                    a.startActivity(intent);
+                }
                 return true;
             case MENU_MAP:
-                NavigationView navigationView = (NavigationView) getActivity().findViewById(R.id.left_drawer);
-                MenuItem mapMenuItem = navigationView.getMenu().findItem(R.id.nav_map);
-                mapMenuItem.setCheckable(true);
-                navigationView.setCheckedItem(R.id.nav_map);
+                if (null != a) {
+                    NavigationView navigationView = a.findViewById(R.id.left_drawer);
+                    MenuItem mapMenuItem = navigationView.getMenu().findItem(R.id.nav_map);
+                    mapMenuItem.setCheckable(true);
+                    navigationView.setCheckedItem(R.id.nav_map);
+                }
                 if (main != null) main.selectFragment(R.id.nav_map);
                 return true;
             case MENU_MUTE:
-                final SharedPreferences prefs = getActivity().getSharedPreferences(SHARED_PREFS, 0);
-                boolean muted = prefs.getBoolean(PREF_MUTED, true);
-                muted = ! muted;
-                Editor editor = prefs.edit();
-                editor.putBoolean(PREF_MUTED, muted);
-                editor.apply();
+                if (null != a) {
+                    final SharedPreferences prefs = a.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+                    boolean muted = prefs.getBoolean(PreferenceKeys.PREF_MUTED, true);
+                    muted = !muted;
+                    Editor editor = prefs.edit();
+                    editor.putBoolean(PreferenceKeys.PREF_MUTED, muted);
+                    editor.apply();
                 item.setTitle(muted ? getString(R.string.play) : getString(R.string.mute));
                 item.setIcon(muted ? android.R.drawable.ic_media_play
                         : android.R.drawable.ic_media_pause);
+                }
                 return true;
         }
         return false;
@@ -581,8 +491,11 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
         }
 
         if (dialogFragment != null) {
-            final FragmentManager fm = getActivity().getSupportFragmentManager();
-            dialogFragment.show(fm, MainActivity.LIST_FRAGMENT_TAG);
+            final FragmentActivity a = getActivity();
+            if (null != a) {
+                final FragmentManager fm = a.getSupportFragmentManager();
+                dialogFragment.show(fm, MainActivity.LIST_FRAGMENT_TAG);
+            }
         }
     }
 
@@ -595,20 +508,21 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
             View view = inflater.inflate(R.layout.listdialog, container);
             dialog.setTitle(getString(R.string.sort_title));
 
-            TextView text = (TextView) view.findViewById( R.id.text );
+            TextView text = view.findViewById( R.id.text );
             text.setText( getString(R.string.sort_spin_label) );
 
-            final SharedPreferences prefs = getActivity().getSharedPreferences( SHARED_PREFS, 0 );
+            final FragmentActivity a = getActivity();
+            final SharedPreferences prefs = getActivity().getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0 );
             final Editor editor = prefs.edit();
 
-            Spinner spinner = (Spinner) view.findViewById( R.id.sort_spinner );
+            Spinner spinner = view.findViewById( R.id.sort_spinner );
             ArrayAdapter<String> adapter = new ArrayAdapter<>(
                     getActivity(), android.R.layout.simple_spinner_item);
             final int[] listSorts = new int[]{ NetworkListSorter.CHANNEL_COMPARE, NetworkListSorter.CRYPTO_COMPARE,
                     NetworkListSorter.FIND_TIME_COMPARE, NetworkListSorter.SIGNAL_COMPARE, NetworkListSorter.SSID_COMPARE };
             final String[] listSortName = new String[]{ getString(R.string.channel),getString(R.string.crypto),
                     getString(R.string.found_time),getString(R.string.signal),getString(R.string.ssid) };
-            int listSort = prefs.getInt( PREF_LIST_SORT, NetworkListSorter.SIGNAL_COMPARE );
+            int listSort = prefs.getInt( PreferenceKeys.PREF_LIST_SORT, NetworkListSorter.SIGNAL_COMPARE );
             int periodIndex = 0;
             for ( int i = 0; i < listSorts.length; i++ ) {
                 adapter.add( listSortName[i] );
@@ -624,27 +538,24 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
                 public void onItemSelected( final AdapterView<?> parent, final View v, final int position, final long id ) {
                     // set pref
                     final int listSort = listSorts[position];
-                    Logging.info( PREF_LIST_SORT + " setting list sort: " + listSort );
-                    editor.putInt( PREF_LIST_SORT, listSort );
+                    Logging.info( PreferenceKeys.PREF_LIST_SORT + " setting list sort: " + listSort );
+                    editor.putInt( PreferenceKeys.PREF_LIST_SORT, listSort );
                     editor.apply();
                 }
                 @Override
                 public void onNothingSelected( final AdapterView<?> arg0 ) {}
             });
 
-            Button ok = (Button) view.findViewById( R.id.listdialog_button );
-            ok.setOnClickListener( new OnClickListener() {
-                @Override
-                public void onClick( final View buttonView ) {
-                    try {
-                        dialog.dismiss();
-                    }
-                    catch ( Exception ex ) {
-                        // guess it wasn't there anyways
-                        Logging.info( "exception dismissing sort dialog: " + ex );
-                    }
+            Button ok = view.findViewById( R.id.listdialog_button );
+            ok.setOnClickListener(buttonView -> {
+                try {
+                    dialog.dismiss();
                 }
-            } );
+                catch ( Exception ex ) {
+                    // guess it wasn't there anyways
+                    Logging.info( "exception dismissing sort dialog: " + ex );
+                }
+            });
 
             return view;
         }
@@ -658,7 +569,10 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
         final State state = MainActivity.getStaticState();
 
         Logging.info( "LIST: on config change" );
-        MainActivity.setLocale( this.getActivity(), newConfig);
+        final FragmentActivity a= this.getActivity();
+        if (null != a) {
+            MainActivity.setLocale( a, newConfig);
+        }
         super.onConfigurationChanged( newConfig );
         // getActivity().setContentView( R.layout.list );
 
@@ -671,7 +585,7 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
 
     private void setupList( final View view ) {
         State state = MainActivity.getStaticState();
-        if (state.listAdapter == null) {
+        if (null != state && state.listAdapter == null) {
             state.listAdapter = new SetNetworkListAdapter( getActivity(), R.layout.row );
         }
         // always set our current list adapter
@@ -687,19 +601,16 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
                                          final SetNetworkListAdapter listAdapter, final boolean isDbResult) {
 
         listView.setAdapter(listAdapter);
-        listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, final int position, final long id) {
-                final Network network = (Network) parent.getItemAtPosition(position);
-                if (network != null) {
-                    MainActivity.getNetworkCache().put(network.getBssid(), network);
-                    final Intent intent = new Intent(activity, NetworkActivity.class);
-                    intent.putExtra(NETWORK_EXTRA_BSSID, network.getBssid());
-                    intent.putExtra(NETWORK_EXTRA_IS_DB_RESULT, isDbResult);
-                    activity.startActivity(intent);
-                } else {
-                    Logging.error("Null network onItemClick - ignoring");
-                }
+        listView.setOnItemClickListener((parent, view, position, id) -> {
+            final Network network = (Network) parent.getItemAtPosition(position);
+            if (network != null) {
+                MainActivity.getNetworkCache().put(network.getBssid(), network);
+                final Intent intent = new Intent(activity, NetworkActivity.class);
+                intent.putExtra(NETWORK_EXTRA_BSSID, network.getBssid());
+                intent.putExtra(NETWORK_EXTRA_IS_DB_RESULT, isDbResult);
+                activity.startActivity(intent);
+            } else {
+                Logging.error("Null network onItemClick - ignoring");
             }
         });
     }
@@ -707,7 +618,9 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
     private void setupLocation( final View view ) {
         // set on UI if we already have one
         final MainActivity main = MainActivity.getMainActivity(this);
-        setLocationUI(main, view);
+        if (null != main) {
+            setLocationUI(main, view);
+        }
         handleScanChange(main, view);
     }
 
@@ -750,7 +663,10 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
             tv.setText( getString(R.string.list_short_lon) + " " + (location == null ? "" : state.numberFormat8.format( location.getLongitude() ) ) );
 
             tv = view.findViewById( R.id.LocationTextView03 );
-            tv.setText( getString(R.string.list_speed) + " " + (location == null ? "" : metersPerSecondToSpeedString(state.numberFormat1, getActivity(), location.getSpeed()) ) );
+            final Activity a = getActivity();
+            if (null != a) {
+                tv.setText(getString(R.string.list_speed) + " " + (location == null ? "" : metersPerSecondToSpeedString(state.numberFormat1, a, location.getSpeed())));
+            }
 
             TextView tv4 = view.findViewById( R.id.LocationTextView04 );
             TextView tv5 = view.findViewById( R.id.LocationTextView05 );
@@ -759,7 +675,7 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
                 tv5.setText( "" );
             } else {
                 if (main != null) {
-                    final SharedPreferences prefs = main.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+                    final SharedPreferences prefs = main.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
                     final String distString = UINumberFormat.metersToString(prefs,
                             state.numberFormat0, main, location.getAccuracy(), true);
                     tv4.setText("+/- " + distString);
@@ -778,8 +694,8 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
     public static String metersPerSecondToSpeedString( final NumberFormat numberFormat, final Context context,
                                                        final float metersPerSecond ) {
 
-        final SharedPreferences prefs = context.getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
-        final boolean metric = prefs.getBoolean( ListFragment.PREF_METRIC, false );
+        final SharedPreferences prefs = context.getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0 );
+        final boolean metric = prefs.getBoolean( PreferenceKeys.PREF_METRIC, false );
 
         String retval;
         if ( metric ) {
@@ -798,16 +714,16 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
             button.setEnabled(false);
         }
 
-        button.setOnClickListener( new OnClickListener() {
-            @Override
-            public void onClick( final View view ) {
-                final MainActivity main = MainActivity.getMainActivity( ListFragment.this );
-                if (main == null) {return;}
-                final SharedPreferences prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
-                final boolean userConfirmed = prefs.getBoolean(ListFragment.PREF_CONFIRM_UPLOAD_USER,false);
+        button.setOnClickListener(view1 -> {
+            final MainActivity main = MainActivity.getMainActivity( ListFragment.this );
+            if (main == null) {return;}
+            final FragmentActivity a = getActivity();
+            if (null != a) {
+                final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+                final boolean userConfirmed = prefs.getBoolean(PreferenceKeys.PREF_CONFIRM_UPLOAD_USER, false);
                 final State state = MainActivity.getStaticState();
 
-                if (userConfirmed) {
+                if (userConfirmed && null != state) {
                     uploadFile( state.dbHelper );
                 } else {
                     makeUploadDialog(main);
@@ -817,45 +733,56 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
     }
 
     public void makeUploadDialog(final MainActivity main) {
-        final SharedPreferences prefs = main.getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
-        final boolean beAnonymous = prefs.getBoolean(ListFragment.PREF_BE_ANONYMOUS, false);
+        final SharedPreferences prefs = main.getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0 );
+        final boolean beAnonymous = prefs.getBoolean(PreferenceKeys.PREF_BE_ANONYMOUS, false);
         final String username = beAnonymous? "anonymous":
-                prefs.getString( ListFragment.PREF_USERNAME, "anonymous" );
+                prefs.getString( PreferenceKeys.PREF_USERNAME, "anonymous" );
 
         final String text = getString(R.string.list_upload) + "\n" + getString(R.string.username) + ": " + username;
-        MainActivity.createConfirmation( ListFragment.this.getActivity(), text, R.id.nav_list, UPLOAD_DIALOG);
+        final FragmentActivity a = getActivity();
+        if (null != a) {
+            WiGLEConfirmationDialog.createConfirmation(a, text, R.id.nav_list, UPLOAD_DIALOG);
+        }
     }
 
-    public void makeQuickPausePrefDialog(final MainActivity main) {
+    public void makeQuickPausePrefDialog() {
         final String dialogText = getString(R.string.quick_pause_text);
         final String checkboxText = getString(R.string.quick_pause_decision);
-        MainActivity.createCheckboxConfirmation(ListFragment.this.getActivity(), dialogText, checkboxText,
-                ListFragment.PREF_QUICK_PAUSE, ListFragment.QUICK_SCAN_PAUSE,
-                ListFragment.QUICK_SCAN_DO_NOTHING, R.id.nav_list, QUICK_PAUSE_DIALOG);
+        final FragmentActivity a = getActivity();
+        if (null != a) {
+            WiGLEConfirmationDialog.createCheckboxConfirmation(a, dialogText, checkboxText,
+                    PreferenceKeys.PREF_QUICK_PAUSE, ListFragment.QUICK_SCAN_PAUSE,
+                    ListFragment.QUICK_SCAN_DO_NOTHING, R.id.nav_list, QUICK_PAUSE_DIALOG);
+        }
     }
 
     @Override
     public void handleDialog(final int dialogId) {
-        final SharedPreferences prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
-        final SharedPreferences.Editor editor = prefs.edit();
-        switch (dialogId) {
-            case UPLOAD_DIALOG:
-                final State state = MainActivity.getStaticState();
-                final boolean userConfirmed = prefs.getBoolean(ListFragment.PREF_CONFIRM_UPLOAD_USER,false);
-                final String authUser = prefs.getString(ListFragment.PREF_AUTHNAME,"");
+        final FragmentActivity a = getActivity();
+        if (null != a) {
+            final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+            final SharedPreferences.Editor editor = prefs.edit();
+            switch (dialogId) {
+                case UPLOAD_DIALOG:
+                    final State state = MainActivity.getStaticState();
+                    final boolean userConfirmed = prefs.getBoolean(PreferenceKeys.PREF_CONFIRM_UPLOAD_USER, false);
+                    final String authUser = prefs.getString(PreferenceKeys.PREF_AUTHNAME, "");
 
-                if (!userConfirmed && !authUser.isEmpty()) {
-                    //remember the confirmation
-                    editor.putBoolean(ListFragment.PREF_CONFIRM_UPLOAD_USER, true);
-                    editor.apply();
-                }
-                uploadFile( state.dbHelper );
-                break;
-            case QUICK_PAUSE_DIALOG:
-                Logging.info("quick pause callback");
-                toggleScan();
-            default:
-                Logging.warn("ListFragment unhandled dialogId: " + dialogId);
+                    if (!userConfirmed && !authUser.isEmpty()) {
+                        //remember the confirmation
+                        editor.putBoolean(PreferenceKeys.PREF_CONFIRM_UPLOAD_USER, true);
+                        editor.apply();
+                    }
+                    if (null != state) {
+                        uploadFile(state.dbHelper);
+                    }
+                    break;
+                case QUICK_PAUSE_DIALOG:
+                    Logging.info("quick pause callback");
+                    toggleScan();
+                default:
+                    Logging.warn("ListFragment unhandled dialogId: " + dialogId);
+            }
         }
     }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
@@ -27,7 +27,6 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
@@ -197,7 +196,8 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
         if (view == null) {
             return;
         }
-        final ExecutorService executor = Executors.newSingleThreadExecutor();
+        final ExecutorService executor = Executors.newFixedThreadPool(3);
+        //ALIBI: the number of async requests to perform.
         final Handler handler = new Handler(Looper.getMainLooper());
         TextView tv = view.findViewById( R.id.stats_run );
         long netCount = state.wifiReceiver.getRunNetworkCount();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MacFilterActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MacFilterActivity.java
@@ -10,6 +10,7 @@ import android.widget.ListView;
 import com.google.gson.Gson;
 
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -24,14 +25,14 @@ public class MacFilterActivity extends AppCompatActivity {
 
     private String filterType;
     private String filterKey;
-    ArrayList<String> listItems=new ArrayList<String>();
+    ArrayList<String> listItems=new ArrayList<>();
     AddressFilterAdapter filtersAdapter;
 
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        final SharedPreferences prefs = this.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+        final SharedPreferences prefs = this.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
         setContentView(R.layout.addressfiltersettings);
 
 
@@ -40,21 +41,21 @@ public class MacFilterActivity extends AppCompatActivity {
         filterKey = "";
         Logging.info(filterType);
         if (FilterActivity.INTENT_DISPLAY_FILTER.equals(filterType)) {
-            filterKey = ListFragment.PREF_EXCLUDE_DISPLAY_ADDRS;
+            filterKey = PreferenceKeys.PREF_EXCLUDE_DISPLAY_ADDRS;
         } else if (FilterActivity.INTENT_LOG_FILTER.equals(filterType)) {
-            filterKey = ListFragment.PREF_EXCLUDE_LOG_ADDRS;
+            filterKey = PreferenceKeys.PREF_EXCLUDE_LOG_ADDRS;
         } else {
-            filterKey = ListFragment.PREF_EXCLUDE_DISPLAY_ADDRS;
+            filterKey = PreferenceKeys.PREF_EXCLUDE_DISPLAY_ADDRS;
         }
 
         //DEBUG: MainActivity.info(filterKey);
         Gson gson = new Gson();
         String[] values = gson.fromJson(prefs.getString(filterKey, "[]"), String[].class);
         if(values.length>0) {
-            listItems = new ArrayList<String>(Arrays.asList(values));
+            listItems = new ArrayList<>(Arrays.asList(values));
         }
 
-        ListView lv = (ListView) findViewById(R.id.addr_filter_list_view);
+        ListView lv = findViewById(R.id.addr_filter_list_view);
 
         filtersAdapter = new AddressFilterAdapter(listItems, this, prefs, filterKey);
 
@@ -62,10 +63,10 @@ public class MacFilterActivity extends AppCompatActivity {
     }
 
     public void addOui(View v) {
-        final MaskedEditText ouiInput = (MaskedEditText) findViewById(R.id.oui_input);
+        final MaskedEditText ouiInput = findViewById(R.id.oui_input);
         final String input = ouiInput.getRawText().toString();
-        if (null != input &&  (input.length() == 6)) {
-            final SharedPreferences prefs = this.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+        if (input.length() == 6) {
+            final SharedPreferences prefs = this.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
             if (addEntry(listItems, prefs, input, filterKey)) {
                 ouiInput.setText("");
                 filtersAdapter.notifyDataSetChanged();
@@ -74,10 +75,10 @@ public class MacFilterActivity extends AppCompatActivity {
     }
 
     public void addMac(View v) {
-        final MaskedEditText macInput = (MaskedEditText) findViewById(R.id.mac_address_input);
+        final MaskedEditText macInput = findViewById(R.id.mac_address_input);
         final String input = macInput.getRawText();
         if (null != input &&  (input.length() == 12)) {
-            final SharedPreferences prefs = this.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+            final SharedPreferences prefs = this.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
             if (addEntry(listItems, prefs, input, filterKey))  {
                 macInput.setText("");
                 filtersAdapter.notifyDataSetChanged();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MacFilterActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MacFilterActivity.java
@@ -14,6 +14,7 @@ import net.wigle.wigleandroid.util.PreferenceKeys;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import br.com.sapereaude.maskedEditText.MaskedEditText;
 
@@ -23,9 +24,8 @@ import br.com.sapereaude.maskedEditText.MaskedEditText;
 
 public class MacFilterActivity extends AppCompatActivity {
 
-    private String filterType;
     private String filterKey;
-    ArrayList<String> listItems=new ArrayList<>();
+    List<String> listItems=new ArrayList<>();
     AddressFilterAdapter filtersAdapter;
 
 
@@ -37,7 +37,7 @@ public class MacFilterActivity extends AppCompatActivity {
 
 
         Intent intent = getIntent();
-        filterType = intent.getStringExtra(FilterActivity.ADDR_FILTER_MESSAGE);
+        String filterType = intent.getStringExtra(FilterActivity.ADDR_FILTER_MESSAGE);
         filterKey = "";
         Logging.info(filterType);
         if (FilterActivity.INTENT_DISPLAY_FILTER.equals(filterType)) {
@@ -52,7 +52,7 @@ public class MacFilterActivity extends AppCompatActivity {
         Gson gson = new Gson();
         String[] values = gson.fromJson(prefs.getString(filterKey, "[]"), String[].class);
         if(values.length>0) {
-            listItems = new ArrayList<>(Arrays.asList(values));
+            listItems = Arrays.asList(values);
         }
 
         ListView lv = findViewById(R.id.addr_filter_list_view);
@@ -96,7 +96,7 @@ public class MacFilterActivity extends AppCompatActivity {
      * @param filterKey the preferences key
      * @return true if we've successfully updated preferences, false on existing or fail
      */
-    public static boolean addEntry(ArrayList<String> entries, SharedPreferences prefs,
+    public static boolean addEntry(List<String> entries, SharedPreferences prefs,
                                    final String rawEntry, final String filterKey) {
         String formatted = "";
         for (int i = 0; i < rawEntry.length(); i++) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -82,7 +82,6 @@ import net.wigle.wigleandroid.listener.BatteryLevelReceiver;
 import net.wigle.wigleandroid.listener.BluetoothReceiver;
 import net.wigle.wigleandroid.listener.GNSSListener;
 import net.wigle.wigleandroid.listener.PhoneState;
-import net.wigle.wigleandroid.listener.PrefCheckboxListener;
 import net.wigle.wigleandroid.listener.WifiReceiver;
 import net.wigle.wigleandroid.model.ConcurrentLinkedHashMap;
 import net.wigle.wigleandroid.model.Network;
@@ -166,26 +165,6 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
     private GnssStatus.Callback gnssStatusCallback = null;
 
     static Locale ORIG_LOCALE = Locale.getDefault();
-    // form auth
-    public static final String TOKEN_URL = "https://api.wigle.net/api/v2/activate";
-    // no auth
-    public static final String SITE_STATS_URL = "https://api.wigle.net/api/v2/stats/site";
-    public static final String RANK_STATS_URL = "https://api.wigle.net/api/v2/stats/standings";
-    public static final String NEWS_URL = "https://api.wigle.net/api/v2/news/latest";
-    // api token auth
-    public static final String UPLOADS_STATS_URL = "https://api.wigle.net/api/v2/file/transactions";
-    public static final String USER_STATS_URL = "https://api.wigle.net/api/v2/stats/user";
-    public static final String OBSERVED_URL = "https://api.wigle.net/api/v2/network/mine";
-    public static final String FILE_POST_URL = "https://api.wigle.net/api/v2/file/upload";
-    public static final String KML_TRANSID_URL_STEM = "https://api.wigle.net/api/v2/file/kml/";
-    public static final String CSV_TRANSID_URL_STEM = "https://api.wigle.net/api/v2/file/csv/";
-    public static final String SEARCH_WIFI_URL = "https://api.wigle.net/api/v2/network/search";
-    public static final String SEARCH_CELL_URL = "https://api.wigle.net/api/v2/cell/search";
-    public static final String WIGLE_BASE_URL = "https://wigle.net";
-
-    // registration web view
-    public static final String REG_URL = "https://wigle.net/register";
-
     public static final String ENCODING = "ISO-8859-1";
     private static final int PERMISSIONS_REQUEST = 1;
     private static final int ACTION_WIFI_CODE = 2;
@@ -346,30 +325,31 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             }
         }
 
-        Logging.info("setupService");
+        Logging.info("\tsetupService");
         setupService();
-        Logging.info("checkStorage");
+        Logging.info("\tcheckStorage");
         checkStorage();
-        Logging.info("setupDatabase");
+        Logging.info("\tsetupDatabase");
         setupDatabase(prefs);
-        Logging.info("setupBattery");
+        Logging.info("\tsetupBattery");
         setupBattery();
-        Logging.info("setupSound");
+        Logging.info("\tsetupSound");
         setupSound();
-        Logging.info("setupActivationDialog");
+        Logging.info("\tsetupActivationDialog");
         setupActivationDialog(prefs);
-        Logging.info("setupBluetooth");
+        Logging.info("\tsetupBluetooth");
         setupBluetooth(prefs);
-        Logging.info("setupWifi");
+        Logging.info("\tsetupWifi");
         setupWifi(prefs);
-        Logging.info("setupLocation"); // must be after setupWifi
+        Logging.info("\tsetupLocation"); // must be after setupWifi
         setupLocation(prefs);
-        Logging.info("setup tabs");
+        Logging.info("\tsetup tabs");
         if (savedInstanceState == null) {
             setupFragments();
         }
         setupFilters(prefs);
 
+        Logging.info("\tfirst install check");
         // ALIBI: don't inherit MxC implant failures from backups.
         if (InstallUtility.isFirstInstall(this)) {
             SharedPreferences mySPrefs = PreferenceManager.getDefaultSharedPreferences(this);
@@ -381,11 +361,13 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             editor.apply();
         }
 
+        Logging.info("\tcell data check");
         //TODO: if we can determine whether DB needs updating, we can avoid copying every time
         //if (!state.mxcDbHelper.isPresent()) {
         state.mxcDbHelper.implantMxcDatabase(this, isFinishing());
         //}
 
+        Logging.info("\tkeystore check");
         // rksh 20160202 - api/authuser secure preferences storage
         checkInitKeystore(prefs);
 
@@ -993,46 +975,6 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         if (state.mxcDbHelper == null) {
             state.mxcDbHelper = new MxcDatabaseHelper(getApplicationContext(), prefs);
         }
-    }
-
-    //TODO: refactor these out of MainActivity
-    public static CheckBox prefSetCheckBox(final Context context, final View view, final int id,
-                                           final String pref, final boolean def, final SharedPreferences prefs) {
-        final CheckBox checkbox = view.findViewById(id);
-        checkbox.setChecked(prefs.getBoolean(pref, def));
-        return checkbox;
-    }
-
-    private static CheckBox prefSetCheckBox(final SharedPreferences prefs, final View view, final int id, final String pref,
-                                            final boolean def) {
-        final CheckBox checkbox = view.findViewById(id);
-        if (checkbox == null) {
-            Logging.error("No checkbox for id: " + id);
-        } else {
-            checkbox.setChecked(prefs.getBoolean(pref, def));
-        }
-        return checkbox;
-    }
-
-    public static CheckBox prefBackedCheckBox(final Activity activity, final View view, final int id,
-                                              final String pref, final boolean def) {
-        return prefBackedCheckBox(activity, view, id, pref, def, null);
-    }
-
-    public static CheckBox prefBackedCheckBox(final Activity activity, final View view, final int id,
-                                              final String pref, final boolean def, final PrefCheckboxListener listener) {
-        final SharedPreferences prefs = activity.getSharedPreferences(ListFragment.SHARED_PREFS, Context.MODE_PRIVATE);
-        final Editor editor = prefs.edit();
-        final CheckBox checkbox = prefSetCheckBox(prefs, view, id, pref, def);
-        checkbox.setOnCheckedChangeListener((buttonView, isChecked) -> {
-            editor.putBoolean(pref, isChecked);
-            editor.apply();
-            if (null != listener) {
-                listener.preferenceSet(isChecked);
-            }
-        });
-
-        return checkbox;
     }
 
     public static State getStaticState() {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -873,10 +873,10 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
 
             //TODO: redundant with endBluetooth?
             final BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
-            if (bluetoothAdapter != null && bluetoothAdapter.isDiscovering()) {
-                    bluetoothAdapter.cancelDiscovery();
-            }
             try {
+                if (bluetoothAdapter != null && bluetoothAdapter.isDiscovering()) {
+                    bluetoothAdapter.cancelDiscovery();
+                }
                 Logging.info("unregister bluetoothReceiver");
                 unregisterReceiver(state.bluetoothReceiver);
             } catch (final IllegalArgumentException ex) {
@@ -886,12 +886,13 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             }
             if (state.bluetoothReceiver != null) {
                 state.bluetoothReceiver.stopScanning();
+                state.bluetoothReceiver.close();
             }
             finishSoon(DESTROY_FINISH_MILLIS, false);
         } else {
             state.uiRestart.set(false);
         }
-
+        mainActivity = null;
     }
 
     @Override

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -2120,7 +2120,20 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                 Logging.error("Error registering for gnss: " + ex, ex);
             }
         } else {
-            Logging.error("Failed to setup GPS - SDK < 24");
+            Logging.error("Failed to setup GPS - SDK < 24 ("+Build.VERSION.SDK_INT+")");
+            Handler handler = new Handler(Looper.getMainLooper());
+            handler.post(() -> {
+                AlertDialog.Builder iseDlgBuilder = new AlertDialog.Builder(this);
+                iseDlgBuilder.setMessage(R.string.gps_old_message)
+                        .setTitle(getString(R.string.gps_old_title))
+                        .setCancelable(true)
+                        .setPositiveButton(R.string.ok, (dialog, which) -> dialog.dismiss());
+                final Dialog dialog = iseDlgBuilder.create();
+                if (!isFinishing()) {
+                    dialog.show();
+                }
+            });
+
         }
 
         final SharedPreferences prefs = getSharedPreferences(PreferenceKeys.SHARED_PREFS, Context.MODE_PRIVATE);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -1734,7 +1734,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             }
         } else if (requestCode == ACTION_TTS_CODE) {
             if (resultCode == TextToSpeech.Engine.CHECK_VOICE_DATA_PASS) {
-                state.tts = new TextToSpeech(this, this);
+                state.tts = new TextToSpeech(getApplicationContext(), this);
             } else {
                 try {
                     PackageManager pm = getPackageManager();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -40,6 +40,7 @@ import android.provider.Settings;
 
 import androidx.annotation.NonNull;
 
+import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.material.navigation.NavigationView;
 
 import androidx.annotation.RequiresApi;
@@ -1070,11 +1071,11 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             state.wakeLock.acquire();
         }
 
-        final int serviceAvailable = GooglePlayServicesUtil.isGooglePlayServicesAvailable(getApplicationContext());
-        Logging.info("GooglePlayServicesAvailable: " + serviceAvailable);
+        final int serviceAvailable = GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(getApplicationContext());
+        Logging.info("GoogleApiAvailability: " + serviceAvailable);
         if (serviceAvailable != ConnectionResult.SUCCESS && !playServiceShown) {
-            Logging.error("service not available! " + serviceAvailable);
-            final Dialog dialog = GooglePlayServicesUtil.getErrorDialog(serviceAvailable, this, 0);
+            Logging.error("GoogleApiAvailability not available! " + serviceAvailable);
+            final Dialog dialog =GoogleApiAvailability.getInstance().getErrorDialog(this, serviceAvailable, 0);
             dialog.show();
             playServiceShown = true;
         }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -1808,7 +1808,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
 
                     // bluetooth scan listener
                     // this receiver is the main workhorse of bluetooth scanning
-                    state.bluetoothReceiver = new BluetoothReceiver(this, state.dbHelper,
+                    state.bluetoothReceiver = new BluetoothReceiver(state.dbHelper,
                             hasLeSupport, prefs);
                     state.bluetoothReceiver.setupBluetoothTimer(true);
                 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -426,7 +426,9 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                 if (!googleBug.contains("fixed")) {
                     Logging.info("working around google maps bug 154855417");
                     File corruptedZoomTables = new File(getFilesDir(), "ZoomTables.data");
-                    if (corruptedZoomTables.delete()) {
+                    if (corruptedZoomTables.exists() && corruptedZoomTables.delete()) {
+                        googleBug.edit().putBoolean("fixed", true).apply();
+                    } else if (!corruptedZoomTables.exists()) {
                         googleBug.edit().putBoolean("fixed", true).apply();
                     } else {
                         Logging.error("unable to work around corrupted ZoomTables.data error");

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MapFilterActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MapFilterActivity.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 
+import net.wigle.wigleandroid.ui.PrefsBackedCheckbox;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.SettingsUtil;
 
@@ -90,21 +91,21 @@ public class MapFilterActivity extends AppCompatActivity {
                 2001L, yearValueBase.toArray(new Long[0]),
                 yearLabelBase.toArray(new String[0]), MapFilterActivity.this );
 
-        MainActivity.prefBackedCheckBox(this , view, R.id.showinvert,
+        PrefsBackedCheckbox.prefBackedCheckBox(this , view, R.id.showinvert,
                 MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_INVERT, false );
-        MainActivity.prefBackedCheckBox( this, view, R.id.showopen,
+        PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showopen,
                 MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_OPEN, true );
-        MainActivity.prefBackedCheckBox( this, view, R.id.showwep,
+        PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showwep,
                 MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_WEP, true );
-        MainActivity.prefBackedCheckBox( this, view, R.id.showwpa,
+        PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showwpa,
                 MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_WPA, true );
-        MainActivity.prefBackedCheckBox( this, view, R.id.showcell,
+        PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showcell,
                 MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_CELL, true );
-        MainActivity.prefBackedCheckBox( this, view, R.id.showbt,
+        PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showbt,
                 MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_BT, true );
-        MainActivity.prefBackedCheckBox( this, view, R.id.showbtle,
+        PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showbtle,
                 MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_BTLE, true );
-        MainActivity.prefBackedCheckBox( this, view, R.id.enabled,
+        PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.enabled,
                 MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_ENABLED, true );
     }
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MapFilterActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MapFilterActivity.java
@@ -11,6 +11,7 @@ import android.widget.LinearLayout;
 
 import net.wigle.wigleandroid.ui.PrefsBackedCheckbox;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 import net.wigle.wigleandroid.util.SettingsUtil;
 
 import java.util.ArrayList;
@@ -22,25 +23,22 @@ import java.util.List;
  * Created by arkasha on 8/1/17.
  */
 
-@SuppressWarnings("deprecation")
 public class MapFilterActivity extends AppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        final SharedPreferences prefs = this.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+        final SharedPreferences prefs = this.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
         final SharedPreferences.Editor editor = prefs.edit();
         setContentView(R.layout.mapfilter);
 
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.HONEYCOMB) {
-            final androidx.appcompat.app.ActionBar actionBar = getSupportActionBar();
-            if (actionBar != null) {
-                actionBar.setDisplayHomeAsUpEnabled(true);
-            }
+        final androidx.appcompat.app.ActionBar actionBar = getSupportActionBar();
+        if (actionBar != null) {
+            actionBar.setDisplayHomeAsUpEnabled(true);
         }
         View view = findViewById(android.R.id.content);
         Logging.info("Filter Fragment Selected");
-        final EditText regex = (EditText) findViewById( R.id.edit_regex );
-        final String regexKey = MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_REGEX;
+        final EditText regex = findViewById( R.id.edit_regex );
+        final String regexKey = MappingFragment.MAP_DIALOG_PREFIX + PreferenceKeys.PREF_MAPF_REGEX;
         regex.setText( prefs.getString(regexKey, "") );
 
         regex.addTextChangedListener( new SettingsFragment.SetWatcher() {
@@ -62,50 +60,50 @@ public class MapFilterActivity extends AppCompatActivity {
         });
 
         //TODO: DRY up with SettingsFragment
-        final String authUser = prefs.getString(ListFragment.PREF_AUTHNAME,"");
-        final String authToken = prefs.getString(ListFragment.PREF_TOKEN, "");
-        final boolean isAnonymous = prefs.getBoolean( ListFragment.PREF_BE_ANONYMOUS, false);
+        final String authUser = prefs.getString(PreferenceKeys.PREF_AUTHNAME,"");
+        final String authToken = prefs.getString(PreferenceKeys.PREF_TOKEN, "");
+        final boolean isAnonymous = prefs.getBoolean( PreferenceKeys.PREF_BE_ANONYMOUS, false);
 
 
-        final String showDiscovered = prefs.getString( ListFragment.PREF_SHOW_DISCOVERED, ListFragment.PREF_MAP_NO_TILE);
+        final String showDiscovered = prefs.getString( PreferenceKeys.PREF_SHOW_DISCOVERED, PreferenceKeys.PREF_MAP_NO_TILE);
         final boolean isAuthenticated = (!authUser.isEmpty() && !authToken.isEmpty() && !isAnonymous);
         final String[] mapModes = SettingsUtil.getMapModes(isAuthenticated);
         final String[] mapModeName = SettingsUtil.getMapModeNames(isAuthenticated, MapFilterActivity.this);
 
-        if (!ListFragment.PREF_MAP_NO_TILE.equals(showDiscovered)) {
-            LinearLayout mainLayout = (LinearLayout) view.findViewById(R.id.show_map_discovered_since);
+        if (!PreferenceKeys.PREF_MAP_NO_TILE.equals(showDiscovered)) {
+            LinearLayout mainLayout = view.findViewById(R.id.show_map_discovered_since);
             mainLayout.setVisibility(View.VISIBLE);
         }
 
-        SettingsUtil.doMapSpinner( R.id.show_discovered, ListFragment.PREF_SHOW_DISCOVERED,
-                ListFragment.PREF_MAP_NO_TILE, mapModes, mapModeName, MapFilterActivity.this, view );
+        SettingsUtil.doMapSpinner( R.id.show_discovered, PreferenceKeys.PREF_SHOW_DISCOVERED,
+                PreferenceKeys.PREF_MAP_NO_TILE, mapModes, mapModeName, MapFilterActivity.this, view );
 
         int thisYear = Calendar.getInstance().get(Calendar.YEAR);
-        List<Long> yearValueBase = new ArrayList<Long>();
-        List<String> yearLabelBase = new ArrayList<String>();
+        List<Long> yearValueBase = new ArrayList<>();
+        List<String> yearLabelBase = new ArrayList<>();
         for (int i = 2001; i <= thisYear; i++) {
             yearValueBase.add((long)(i));
             yearLabelBase.add(Integer.toString(i));
         }
-        SettingsUtil.doSpinner( R.id.networks_discovered_since_year, view, ListFragment.PREF_SHOW_DISCOVERED_SINCE,
+        SettingsUtil.doSpinner( R.id.networks_discovered_since_year, view, PreferenceKeys.PREF_SHOW_DISCOVERED_SINCE,
                 2001L, yearValueBase.toArray(new Long[0]),
                 yearLabelBase.toArray(new String[0]), MapFilterActivity.this );
 
         PrefsBackedCheckbox.prefBackedCheckBox(this , view, R.id.showinvert,
-                MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_INVERT, false );
+                MappingFragment.MAP_DIALOG_PREFIX + PreferenceKeys.PREF_MAPF_INVERT, false );
         PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showopen,
-                MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_OPEN, true );
+                MappingFragment.MAP_DIALOG_PREFIX + PreferenceKeys.PREF_MAPF_OPEN, true );
         PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showwep,
-                MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_WEP, true );
+                MappingFragment.MAP_DIALOG_PREFIX + PreferenceKeys.PREF_MAPF_WEP, true );
         PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showwpa,
-                MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_WPA, true );
+                MappingFragment.MAP_DIALOG_PREFIX + PreferenceKeys.PREF_MAPF_WPA, true );
         PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showcell,
-                MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_CELL, true );
+                MappingFragment.MAP_DIALOG_PREFIX + PreferenceKeys.PREF_MAPF_CELL, true );
         PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showbt,
-                MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_BT, true );
+                MappingFragment.MAP_DIALOG_PREFIX + PreferenceKeys.PREF_MAPF_BT, true );
         PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.showbtle,
-                MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_BTLE, true );
+                MappingFragment.MAP_DIALOG_PREFIX + PreferenceKeys.PREF_MAPF_BTLE, true );
         PrefsBackedCheckbox.prefBackedCheckBox( this, view, R.id.enabled,
-                MappingFragment.MAP_DIALOG_PREFIX + ListFragment.PREF_MAPF_ENABLED, true );
+                MappingFragment.MAP_DIALOG_PREFIX + PreferenceKeys.PREF_MAPF_ENABLED, true );
     }
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MapRender.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MapRender.java
@@ -23,6 +23,7 @@ import com.google.maps.android.ui.IconGenerator;
 
 import net.wigle.wigleandroid.model.Network;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -96,7 +97,7 @@ public class MapRender implements ClusterManager.OnClusterClickListener<Network>
         }
 
         private boolean showDefaultIcon(final Network network) {
-            final boolean showLabel = prefs.getBoolean( ListFragment.PREF_MAP_LABEL, true );
+            final boolean showLabel = prefs.getBoolean( PreferenceKeys.PREF_MAP_LABEL, true );
             if (showLabel) {
                 final LatLngBounds bounds = map.getProjection().getVisibleRegion().latLngBounds;
                 if (bounds == null || network.getLatLng() == null) return false;
@@ -133,7 +134,7 @@ public class MapRender implements ClusterManager.OnClusterClickListener<Network>
 
         @Override
         protected boolean shouldRenderAsCluster(Cluster<Network> cluster) {
-            return (prefs.getBoolean( ListFragment.PREF_MAP_CLUSTER, true ) && cluster.getSize() > 4)
+            return (prefs.getBoolean( PreferenceKeys.PREF_MAP_CLUSTER, true ) && cluster.getSize() > 4)
                     || cluster.getSize() >= 100;
         }
 
@@ -155,7 +156,7 @@ public class MapRender implements ClusterManager.OnClusterClickListener<Network>
             }
             else if (network.isNew()) {
                 // handle case where network was not added before because it is not new
-                final boolean showNewDBOnly = prefs.getBoolean( ListFragment.PREF_MAP_ONLY_NEWDB, false );
+                final boolean showNewDBOnly = prefs.getBoolean( PreferenceKeys.PREF_MAP_ONLY_NEWDB, false );
                 if (showNewDBOnly) {
                     mClusterManager.addItem(network);
                     mClusterManager.cluster();
@@ -201,7 +202,7 @@ public class MapRender implements ClusterManager.OnClusterClickListener<Network>
     public MapRender(final Context context, final GoogleMap map, final boolean isDbResult) {
         this.map = map;
         this.isDbResult = isDbResult;
-        prefs = context.getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
+        prefs = context.getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0 );
         ssidMatcher = FilterMatcher.getSsidFilterMatcher( prefs, MappingFragment.MAP_DIALOG_PREFIX );
         mClusterManager = new ClusterManager<>(context, map);
         networkRenderer = new NetworkRenderer(context, map, mClusterManager);
@@ -242,8 +243,8 @@ public class MapRender implements ClusterManager.OnClusterClickListener<Network>
     }
 
     public boolean okForMapTab( final Network network ) {
-        final boolean hideNets = prefs.getBoolean( ListFragment.PREF_MAP_HIDE_NETS, false );
-        final boolean showNewDBOnly = prefs.getBoolean( ListFragment.PREF_MAP_ONLY_NEWDB, false )
+        final boolean hideNets = prefs.getBoolean( PreferenceKeys.PREF_MAP_HIDE_NETS, false );
+        final boolean showNewDBOnly = prefs.getBoolean( PreferenceKeys.PREF_MAP_ONLY_NEWDB, false )
                 && ! isDbResult;
         if (network.getPosition() != null && !hideNets) {
             if (!showNewDBOnly || network.isNew()) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
@@ -75,6 +75,7 @@ import net.wigle.wigleandroid.background.QueryThread;
 import net.wigle.wigleandroid.db.DatabaseHelper;
 import net.wigle.wigleandroid.model.ConcurrentLinkedHashMap;
 import net.wigle.wigleandroid.model.Network;
+import net.wigle.wigleandroid.ui.PrefsBackedCheckbox;
 import net.wigle.wigleandroid.ui.ThemeUtil;
 import net.wigle.wigleandroid.ui.UINumberFormat;
 import net.wigle.wigleandroid.ui.WiGLEToast;
@@ -983,17 +984,17 @@ public final class MappingFragment extends Fragment {
             final EditText regex = (EditText) view.findViewById( R.id.edit_regex );
             regex.setText( prefs.getString( prefix + ListFragment.PREF_MAPF_REGEX, "") );
 
-            final CheckBox invert = MainActivity.prefSetCheckBox( activity, view, R.id.showinvert,
+            final CheckBox invert = PrefsBackedCheckbox.prefSetCheckBox( activity, view, R.id.showinvert,
                     prefix + ListFragment.PREF_MAPF_INVERT, false ,prefs);
-            final CheckBox open = MainActivity.prefSetCheckBox( activity, view, R.id.showopen,
+            final CheckBox open = PrefsBackedCheckbox.prefSetCheckBox( activity, view, R.id.showopen,
                     prefix + ListFragment.PREF_MAPF_OPEN, true, prefs );
-            final CheckBox wep = MainActivity.prefSetCheckBox( activity, view, R.id.showwep,
+            final CheckBox wep = PrefsBackedCheckbox.prefSetCheckBox( activity, view, R.id.showwep,
                     prefix + ListFragment.PREF_MAPF_WEP, true, prefs );
-            final CheckBox wpa = MainActivity.prefSetCheckBox( activity, view, R.id.showwpa,
+            final CheckBox wpa = PrefsBackedCheckbox.prefSetCheckBox( activity, view, R.id.showwpa,
                     prefix + ListFragment.PREF_MAPF_WPA, true, prefs );
-            final CheckBox cell = MainActivity.prefSetCheckBox( activity, view, R.id.showcell,
+            final CheckBox cell = PrefsBackedCheckbox.prefSetCheckBox( activity, view, R.id.showcell,
                     prefix + ListFragment.PREF_MAPF_CELL, true, prefs );
-            final CheckBox enabled = MainActivity.prefSetCheckBox( activity, view, R.id.enabled,
+            final CheckBox enabled = PrefsBackedCheckbox.prefSetCheckBox( activity, view, R.id.enabled,
                     prefix + ListFragment.PREF_MAPF_ENABLED, true, prefs );
 
             Button ok = (Button) view.findViewById( R.id.ok_button );
@@ -1027,17 +1028,17 @@ public final class MappingFragment extends Fragment {
                 public void onClick( final View buttonView ) {
                     try {
                         regex.setText( prefs.getString( prefix + ListFragment.PREF_MAPF_REGEX, "") );
-                        MainActivity.prefSetCheckBox( activity, view, R.id.showinvert,
+                        PrefsBackedCheckbox.prefSetCheckBox( activity, view, R.id.showinvert,
                                 prefix + ListFragment.PREF_MAPF_INVERT, false, prefs );
-                        MainActivity.prefSetCheckBox( activity, view, R.id.showopen,
+                        PrefsBackedCheckbox.prefSetCheckBox( activity, view, R.id.showopen,
                                 prefix + ListFragment.PREF_MAPF_OPEN, true, prefs );
-                        MainActivity.prefSetCheckBox( activity, view, R.id.showwep,
+                        PrefsBackedCheckbox.prefSetCheckBox( activity, view, R.id.showwep,
                                 prefix + ListFragment.PREF_MAPF_WEP, true, prefs );
-                        MainActivity.prefSetCheckBox( activity, view, R.id.showwpa,
+                        PrefsBackedCheckbox.prefSetCheckBox( activity, view, R.id.showwpa,
                                 prefix + ListFragment.PREF_MAPF_WPA, true, prefs );
-                        MainActivity.prefSetCheckBox( activity, view, R.id.showcell,
+                        PrefsBackedCheckbox.prefSetCheckBox( activity, view, R.id.showcell,
                                 prefix + ListFragment.PREF_MAPF_CELL, true, prefs );
-                        MainActivity.prefSetCheckBox( activity, view, R.id.enabled,
+                        PrefsBackedCheckbox.prefSetCheckBox( activity, view, R.id.enabled,
                                 prefix + ListFragment.PREF_MAPF_ENABLED, true, prefs );
 
                         dialog.dismiss();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
@@ -1,5 +1,7 @@
 package net.wigle.wigleandroid;
 
+import static com.google.android.gms.maps.GoogleMap.*;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -259,10 +261,10 @@ public final class MappingFragment extends Fragment {
             if (null != prefs) {
                 final boolean showTraffic = prefs.getBoolean(PreferenceKeys.PREF_MAP_TRAFFIC, true);
                 googleMap.setTrafficEnabled(showTraffic);
-                final int mapType = prefs.getInt(PreferenceKeys.PREF_MAP_TYPE, GoogleMap.MAP_TYPE_NORMAL);
+                final int mapType = prefs.getInt(PreferenceKeys.PREF_MAP_TYPE, MAP_TYPE_NORMAL);
                 googleMap.setMapType(mapType);
             } else {
-                googleMap.setMapType(GoogleMap.MAP_TYPE_NORMAL);
+                googleMap.setMapType(MAP_TYPE_NORMAL);
             }
             final Activity a1 = getActivity();
             if (null != a1) {
@@ -272,7 +274,7 @@ public final class MappingFragment extends Fragment {
             // Seeing stack overflow crashes on multiple phones in specific locations, based on indoor svcs.
             googleMap.setIndoorEnabled(false);
 
-            googleMap.setOnMyLocationButtonClickListener(new GoogleMap.OnMyLocationButtonClickListener() {
+            googleMap.setOnMyLocationButtonClickListener(new OnMyLocationButtonClickListener() {
                 @Override
                 public boolean onMyLocationButtonClick() {
                     if (!state.locked) {
@@ -290,7 +292,7 @@ public final class MappingFragment extends Fragment {
             });
 
             googleMap.setOnCameraMoveStartedListener(reason -> {
-                if (reason == GoogleMap.OnCameraMoveStartedListener.REASON_GESTURE) {
+                if (reason == OnCameraMoveStartedListener.REASON_GESTURE) {
                     if (state.locked) {
                         state.locked = false;
                         if (menu != null) {
@@ -299,10 +301,10 @@ public final class MappingFragment extends Fragment {
                             item.setTitle(name);
                         }
                     }
-                } else if (reason == GoogleMap.OnCameraMoveStartedListener.REASON_API_ANIMATION) {
+                } else if (reason == OnCameraMoveStartedListener.REASON_API_ANIMATION) {
                     //DEBUG: MainActivity.info("Camera moved due to user tap");
                     //TODO: should we combine this case with REASON_GESTURE?
-                } else if (reason == GoogleMap.OnCameraMoveStartedListener.REASON_DEVELOPER_ANIMATION) {
+                } else if (reason == OnCameraMoveStartedListener.REASON_DEVELOPER_ANIMATION) {
                     //MainActivity.info("Camera moved due to app directive");
                 }
             });
@@ -442,7 +444,7 @@ public final class MappingFragment extends Fragment {
 
                 PolylineOptions pOptions = new PolylineOptions()
                                 .clickable(false);
-                final int mapMode = prefs.getInt(PreferenceKeys.PREF_MAP_TYPE, GoogleMap.MAP_TYPE_NORMAL);
+                final int mapMode = prefs.getInt(PreferenceKeys.PREF_MAP_TYPE, MAP_TYPE_NORMAL);
                 final boolean nightMode = ThemeUtil.shouldUseMapNightMode(getContext(), prefs);
                 try (Cursor routeCursor = ListFragment.lameStatic.dbHelper
                         .getCurrentVisibleRouteIterator(prefs)) {
@@ -573,7 +575,7 @@ public final class MappingFragment extends Fragment {
                                 if (routePolyline != null) {
                                     final List<LatLng> routePoints = routePolyline.getPoints();
                                     routePoints.add(new LatLng(location.getLatitude(), location.getLongitude()));
-                                    final int mapMode = prefs.getInt(PreferenceKeys.PREF_MAP_TYPE, GoogleMap.MAP_TYPE_NORMAL);
+                                    final int mapMode = prefs.getInt(PreferenceKeys.PREF_MAP_TYPE, MAP_TYPE_NORMAL);
                                     final boolean nightMode = ThemeUtil.shouldUseMapNightMode(getContext(), prefs);
                                     routePolyline.setColor(getRouteColorForMapType(mapMode, nightMode));
 
@@ -913,23 +915,23 @@ public final class MappingFragment extends Fragment {
                     mapView.getMapAsync(new OnMapReadyCallback() {
                         @Override
                         public void onMapReady(@NonNull final GoogleMap googleMap) {
-                            int newMapType = prefs.getInt(PreferenceKeys.PREF_MAP_TYPE, GoogleMap.MAP_TYPE_NORMAL);
+                            int newMapType = prefs.getInt(PreferenceKeys.PREF_MAP_TYPE, MAP_TYPE_NORMAL);
                             final Activity a = getActivity();
                             switch (newMapType) {
-                                case GoogleMap.MAP_TYPE_NORMAL:
-                                    newMapType = GoogleMap.MAP_TYPE_SATELLITE;
+                                case MAP_TYPE_NORMAL:
+                                    newMapType = MAP_TYPE_SATELLITE;
                                     WiGLEToast.showOverActivity(a, R.string.tab_map, getString(R.string.map_toast_satellite), Toast.LENGTH_SHORT);
                                     break;
-                                case GoogleMap.MAP_TYPE_SATELLITE:
-                                    newMapType = GoogleMap.MAP_TYPE_HYBRID;
+                                case MAP_TYPE_SATELLITE:
+                                    newMapType = MAP_TYPE_HYBRID;
                                     WiGLEToast.showOverActivity(a, R.string.tab_map, getString(R.string.map_toast_hybrid), Toast.LENGTH_SHORT);
                                     break;
-                                case GoogleMap.MAP_TYPE_HYBRID:
-                                    newMapType = GoogleMap.MAP_TYPE_TERRAIN;
+                                case MAP_TYPE_HYBRID:
+                                    newMapType = MAP_TYPE_TERRAIN;
                                     WiGLEToast.showOverActivity(a, R.string.tab_map, getString(R.string.map_toast_terrain), Toast.LENGTH_SHORT);
                                     break;
-                                case GoogleMap.MAP_TYPE_TERRAIN:
-                                    newMapType = GoogleMap.MAP_TYPE_NORMAL;
+                                case MAP_TYPE_TERRAIN:
+                                    newMapType = MAP_TYPE_NORMAL;
                                     WiGLEToast.showOverActivity(a, R.string.tab_map, getString(R.string.map_toast_normal), Toast.LENGTH_SHORT);
                                     break;
                                 default:
@@ -1104,8 +1106,8 @@ public final class MappingFragment extends Fragment {
     public static int getRouteColorForMapType(final int mapType, final boolean nightMode) {
         if (nightMode) {
                 return OVERLAY_LIGHT;
-        } else if (mapType != GoogleMap.MAP_TYPE_NORMAL && mapType != GoogleMap.MAP_TYPE_TERRAIN
-                && mapType != GoogleMap.MAP_TYPE_NONE) {
+        } else if (mapType != MAP_TYPE_NORMAL && mapType != MAP_TYPE_TERRAIN
+                && mapType != MAP_TYPE_NONE) {
             return OVERLAY_LIGHT;
         }
         return OVERLAY_DARK;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
@@ -243,7 +243,7 @@ public final class MappingFragment extends Fragment {
 
         // conditionally replace the tile source
         final Activity a = getActivity();
-        final SharedPreferences prefs = (null != a)?getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0):null;
+        final SharedPreferences prefs = (null != a)?a.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0):null;
         final boolean visualizeRoute = prefs != null && prefs.getBoolean(PreferenceKeys.PREF_VISUALIZE_ROUTE, false);
         rlView.addView(mapView);
         // guard against not having google play services
@@ -763,7 +763,7 @@ public final class MappingFragment extends Fragment {
         MenuItem item;
         final Activity a = getActivity();
         if (null != a) {
-            final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+            final SharedPreferences prefs = a.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
             final boolean showNewDBOnly = prefs.getBoolean(PreferenceKeys.PREF_MAP_ONLY_NEWDB, false);
             final boolean showLabel = prefs.getBoolean(PreferenceKeys.PREF_MAP_LABEL, true);
             final boolean showCluster = prefs.getBoolean(PreferenceKeys.PREF_MAP_CLUSTER, true);
@@ -823,7 +823,7 @@ public final class MappingFragment extends Fragment {
     public boolean onOptionsItemSelected(@NonNull final MenuItem item ) {
         final Activity a = getActivity();
         if (null != a) {
-            final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+            final SharedPreferences prefs = a.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
             switch (item.getItemId()) {
                 case MENU_ZOOM_IN: {
                     mapView.getMapAsync(googleMap -> {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
@@ -444,8 +444,8 @@ public final class MappingFragment extends Fragment {
                                 .clickable(false);
                 final int mapMode = prefs.getInt(PreferenceKeys.PREF_MAP_TYPE, GoogleMap.MAP_TYPE_NORMAL);
                 final boolean nightMode = ThemeUtil.shouldUseMapNightMode(getContext(), prefs);
-                try {
-                    Cursor routeCursor = ListFragment.lameStatic.dbHelper.getCurrentVisibleRouteIterator(prefs);
+                try (Cursor routeCursor = ListFragment.lameStatic.dbHelper
+                        .getCurrentVisibleRouteIterator(prefs)) {
                     if (null == routeCursor) {
                         Logging.info("null route cursor; not mapping");
                     } else {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/NewsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/NewsFragment.java
@@ -23,6 +23,7 @@ import net.wigle.wigleandroid.background.ApiListener;
 import net.wigle.wigleandroid.background.DownloadHandler;
 import net.wigle.wigleandroid.model.NewsItem;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.UrlConfig;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -89,7 +90,7 @@ public class NewsFragment extends Fragment {
                 getActivity().getPackageName(), getResources());
         handler.setNewsListAdapter(listAdapter);
         final ApiDownloader task = new ApiDownloader(getActivity(), ListFragment.lameStatic.dbHelper,
-                "news-cache.json", MainActivity.NEWS_URL, false, false, false,
+                "news-cache.json", UrlConfig.NEWS_URL, false, false, false,
                 ApiDownloader.REQUEST_GET,
                 new ApiListener() {
                     @Override

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RankListAdapter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RankListAdapter.java
@@ -10,9 +10,11 @@ import android.widget.TextView;
 
 import net.wigle.wigleandroid.model.RankUser;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 /**
- * the array adapter for a list of usersO.
+ * the array adapter for a list of users.
+ * @author arkasha, bobzilla
  */
 public final class RankListAdapter extends AbstractListAdapter<RankUser> {
     private static final String ANONYMOUS = "anonymous";
@@ -21,8 +23,8 @@ public final class RankListAdapter extends AbstractListAdapter<RankUser> {
 
     public RankListAdapter(final Context context, final int rowLayout ) {
         super( context, rowLayout );
-        final SharedPreferences prefs = context.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
-        username = prefs.getString(ListFragment.PREF_USERNAME, "");
+        final SharedPreferences prefs = context.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+        username = prefs.getString(PreferenceKeys.PREF_USERNAME, "");
     }
 
     public void setMonthRanking(final boolean monthRanking) {
@@ -51,13 +53,13 @@ public final class RankListAdapter extends AbstractListAdapter<RankUser> {
             return row;
         }
 
-        TextView tv = (TextView) row.findViewById( R.id.rank );
+        TextView tv = row.findViewById( R.id.rank );
         tv.setText(numberFormat.format(rankUser.getRank()));
 
-        tv = (TextView) row.findViewById( R.id.rankdiff );
+        tv = row.findViewById( R.id.rankdiff );
         UserStatsFragment.diffToString(rankUser.getRankDiff(), tv);
 
-        tv = (TextView) row.findViewById( R.id.username );
+        tv = row.findViewById( R.id.username );
         String rankUsername = rankUser.getUsername();
         if (ANONYMOUS.equals(rankUser.getUsername())) {
             tv.setTypeface(null, Typeface.ITALIC);
@@ -71,15 +73,15 @@ public final class RankListAdapter extends AbstractListAdapter<RankUser> {
         }
         tv.setText(rankUsername);
 
-        tv = (TextView) row.findViewById( R.id.month_wifi_gps );
+        tv = row.findViewById( R.id.month_wifi_gps );
         tv.setText(numberFormat.format(
                 monthRanking ? rankUser.getMonthWifiGps() : rankUser.getTotalWifiGps()));
 
-        tv = (TextView) row.findViewById( R.id.total_bt_gps );
+        tv = row.findViewById( R.id.total_bt_gps );
         tv.setText(getContext().getString(R.string.total_bt) + ": "
                 + numberFormat.format(rankUser.getTotalBtGps()));
 
-        tv = (TextView) row.findViewById( R.id.total_cell_gps );
+        tv = row.findViewById( R.id.total_cell_gps );
         tv.setText(getContext().getString(R.string.total_cell) + ": "
                 + numberFormat.format(rankUser.getTotalCellGps()));
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RankStatsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RankStatsFragment.java
@@ -31,6 +31,7 @@ import net.wigle.wigleandroid.model.RankUser;
 import net.wigle.wigleandroid.ui.WiGLEToast;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.MenuUtil;
+import net.wigle.wigleandroid.util.UrlConfig;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -201,7 +202,7 @@ public class RankStatsFragment extends Fragment {
 
         final String cacheName = (doMonthRanking ? "month" : "all") + top;
 
-        final String monthUrl = MainActivity.RANK_STATS_URL + "?pagestart=" + pageStart
+        final String monthUrl = UrlConfig.RANK_STATS_URL + "?pagestart=" + pageStart
                 + "&pageend=" + (pageStart + ROW_COUNT) + "&sort=" + sort;
         final ApiDownloader task = new ApiDownloader(getActivity(), ListFragment.lameStatic.dbHelper,
                 "rank-stats-" + cacheName + "-cache.json", monthUrl, false, false, false,

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RankStatsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RankStatsFragment.java
@@ -226,7 +226,7 @@ public class RankStatsFragment extends Fragment {
     private void setupListView(final View view) {
         final Activity a = getActivity();
         if (null != a) {
-            final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+            final SharedPreferences prefs = a.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
             if (listAdapter == null) {
                 listAdapter = new RankListAdapter(getActivity(), R.layout.rankrow);
             } else if (!listAdapter.isEmpty() && !TokenAccess.hasApiToken(prefs)) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RankStatsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RankStatsFragment.java
@@ -1,5 +1,6 @@
 package net.wigle.wigleandroid;
 
+import android.app.Activity;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
@@ -8,6 +9,8 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 import android.os.Parcelable;
+
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.core.view.MenuItemCompat;
@@ -31,6 +34,7 @@ import net.wigle.wigleandroid.model.RankUser;
 import net.wigle.wigleandroid.ui.WiGLEToast;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.MenuUtil;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 import net.wigle.wigleandroid.util.UrlConfig;
 
 import org.json.JSONArray;
@@ -109,8 +113,10 @@ public class RankStatsFragment extends Fragment {
         super.onCreate(savedInstanceState);
         setHasOptionsMenu(true);
         // set language
-        MainActivity.setLocale(getActivity());
-
+        final Activity a = getActivity();
+        if (null != a) {
+            MainActivity.setLocale(a);
+        }
         // media volume
         getActivity().setVolumeControlStream(AudioManager.STREAM_MUSIC);
 
@@ -132,43 +138,43 @@ public class RankStatsFragment extends Fragment {
         setupSwipeRefresh(rootView);
         setupListView(rootView);
 
-        handler = new RankDownloadHandler(rootView, numberFormat,
-                getActivity().getPackageName(), getResources(), monthRanking);
-        handler.setRankListAdapter(listAdapter);
-        final SharedPreferences prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+        final Activity a = getActivity();
+        if (null != a) {
+            handler = new RankDownloadHandler(rootView, numberFormat,
+                    getActivity().getPackageName(), getResources(), monthRanking);
+            handler.setRankListAdapter(listAdapter);
+            final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
 
-        //TODO: we should only perform user DL if there's a user set
-        UserStatsFragment.executeUserDownload(this, new UserStatsFragment.UserDownloadApiListener(new Handler() {
-            @Override
-            public void handleMessage(final Message msg) {
-                final Bundle bundle = msg.getData();
-                final boolean isCache = bundle.getBoolean(UserStatsFragment.KEY_IS_CACHE);
-                Logging.info("got user message, isCache: " + isCache);
+            //TODO: we should only perform user DL if there's a user set
+            UserStatsFragment.executeUserDownload(this, new UserStatsFragment.UserDownloadApiListener(new Handler() {
+                @Override
+                public void handleMessage(final Message msg) {
+                    final Bundle bundle = msg.getData();
+                    final boolean isCache = bundle.getBoolean(UserStatsFragment.KEY_IS_CACHE);
+                    Logging.info("got user message, isCache: " + isCache);
 
-                final SharedPreferences.Editor editor = prefs.edit();
-                editor.putLong( ListFragment.PREF_RANK, bundle.getLong(UserStatsFragment.KEY_RANK) );
-                editor.putLong( ListFragment.PREF_MONTH_RANK, bundle.getLong(UserStatsFragment.KEY_MONTH_RANK) );
-                editor.apply();
-                downloadRanks(isCache);
-            }
-        }));
+                    final SharedPreferences.Editor editor = prefs.edit();
+                    editor.putLong(ListFragment.PREF_RANK, bundle.getLong(UserStatsFragment.KEY_RANK));
+                    editor.putLong(ListFragment.PREF_MONTH_RANK, bundle.getLong(UserStatsFragment.KEY_MONTH_RANK));
+                    editor.apply();
+                    downloadRanks(isCache);
+                }
+            }));
+        }
 
         return rootView;
     }
 
     private void setupSwipeRefresh(final LinearLayout rootView) {
         // Lookup the swipe container view
-        final SwipeRefreshLayout swipeContainer = (SwipeRefreshLayout) rootView.findViewById(R.id.rank_swipe_container);
+        final SwipeRefreshLayout swipeContainer = rootView.findViewById(R.id.rank_swipe_container);
 
         // Setup refresh listener which triggers new data loading
-        swipeContainer.setOnRefreshListener(new SwipeRefreshLayout.OnRefreshListener() {
-            @Override
-            public void onRefresh() {
-                // Your code to refresh the list here.
-                // Make sure you call swipeContainer.setRefreshing(false)
-                // once the network request has completed successfully.
-                downloadRanks(false);
-            }
+        swipeContainer.setOnRefreshListener(() -> {
+            // Your code to refresh the list here.
+            // Make sure you call swipeContainer.setRefreshing(false)
+            // once the network request has completed successfully.
+            downloadRanks(false);
         });
     }
 
@@ -190,7 +196,7 @@ public class RankStatsFragment extends Fragment {
         if (userCentric.get()) {
             top = "";
             final String userRankKey = doMonthRanking ? ListFragment.PREF_MONTH_RANK : ListFragment.PREF_RANK;
-            final SharedPreferences prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+            final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
             final long userRank = prefs.getLong(userRankKey, 0);
             final long startRank = userRank - 50;
             pageStart = startRank > 0 ? startRank : 0;
@@ -207,12 +213,7 @@ public class RankStatsFragment extends Fragment {
         final ApiDownloader task = new ApiDownloader(getActivity(), ListFragment.lameStatic.dbHelper,
                 "rank-stats-" + cacheName + "-cache.json", monthUrl, false, false, false,
                 ApiDownloader.REQUEST_GET,
-                new ApiListener() {
-                    @Override
-                    public void requestComplete(final JSONObject json, final boolean isCache) {
-                        handleRankStats(json, handler, finalSelected);
-                    }
-                });
+                (json, isCache1) -> handleRankStats(json, handler, finalSelected));
         task.setCacheOnly(isCache);
         try {
             task.startDownload(this);
@@ -223,17 +224,18 @@ public class RankStatsFragment extends Fragment {
     }
 
     private void setupListView(final View view) {
-        final SharedPreferences prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
-        if (listAdapter == null) {
-            listAdapter = new RankListAdapter(getActivity(), R.layout.rankrow);
-        } else if (!listAdapter.isEmpty() && !TokenAccess.hasApiToken(prefs)) {
-            listAdapter.clear();
+        final Activity a = getActivity();
+        if (null != a) {
+            final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+            if (listAdapter == null) {
+                listAdapter = new RankListAdapter(getActivity(), R.layout.rankrow);
+            } else if (!listAdapter.isEmpty() && !TokenAccess.hasApiToken(prefs)) {
+                listAdapter.clear();
+            }
+            // always set our current list adapter
+            final ListView listView = view.findViewById(R.id.rank_list_view);
+            listView.setAdapter(listAdapter);
         }
-
-        // always set our current list adapter
-        final ListView listView = (ListView) view.findViewById(R.id.rank_list_view);
-        listView.setAdapter(listAdapter);
-
     }
 
     private final static class RankDownloadHandler extends DownloadHandler {
@@ -257,7 +259,7 @@ public class RankStatsFragment extends Fragment {
             final ArrayList<Parcelable> results = bundle.getParcelableArrayList(RESULT_LIST_KEY);
             // MainActivity.info("handleMessage. results: " + results);
             if (msg.what == MSG_RANKING_DONE && results != null && rankListAdapter != null) {
-                TextView tv = (TextView) view.findViewById(R.id.rankstats_type);
+                TextView tv = view.findViewById(R.id.rankstats_type);
                 final boolean doMonthRanking = monthRanking.get();
                 tv.setText(doMonthRanking ? R.string.monthcount_title : R.string.all_time_title);
                 final String rankDiffKey = doMonthRanking ? KEY_PREV_MONTH_RANK : KEY_PREV_RANK;
@@ -276,11 +278,11 @@ public class RankStatsFragment extends Fragment {
                         rankListAdapter.add(rankUser);
                     }
                 }
-                final ListView listView = (ListView) view.findViewById(R.id.rank_list_view);
+                final ListView listView = view.findViewById(R.id.rank_list_view);
                 listView.setSelectionFromTop((int)selected, 20);
 
                 final SwipeRefreshLayout swipeRefreshLayout =
-                        (SwipeRefreshLayout) view.findViewById(R.id.rank_swipe_container);
+                        view.findViewById(R.id.rank_swipe_container);
                 swipeRefreshLayout.setRefreshing(false);
             }
             //TODO: swipeRefreshLayout.setRefreshing(false); anyway if request is done?
@@ -337,7 +339,10 @@ public class RankStatsFragment extends Fragment {
     public void onResume() {
         Logging.info("RANKSTATS: onResume");
         super.onResume();
-        getActivity().setTitle(R.string.rank_stats_app_name);
+        final Activity a = getActivity();
+        if (null != a) {
+            a.setTitle(R.string.rank_stats_app_name);
+        }
     }
 
     @Override
@@ -359,24 +364,24 @@ public class RankStatsFragment extends Fragment {
     }
 
     @Override
-    public void onConfigurationChanged( final Configuration newConfig ) {
+    public void onConfigurationChanged(@NonNull final Configuration newConfig ) {
         Logging.info("RANKSTATS: config changed");
         super.onConfigurationChanged( newConfig );
     }
 
     /* Creates the menu items */
     @Override
-    public void onCreateOptionsMenu (final Menu menu, final MenuInflater inflater) {
+    public void onCreateOptionsMenu (final Menu menu, @NonNull final MenuInflater inflater) {
         MenuItem item = menu.add(0, MENU_USER_STATS, 0, getString(R.string.user_stats_app_name));
         item.setIcon( android.R.drawable.ic_menu_myplaces );
-        MenuItemCompat.setShowAsAction(item, MenuItemCompat.SHOW_AS_ACTION_IF_ROOM);
+        MenuItemCompat.setShowAsAction(item, MenuItem.SHOW_AS_ACTION_IF_ROOM);
 
         item = menu.add(0, MENU_USER_STATS, 0, getString(R.string.user_stats_app_name));
         item.setIcon(android.R.drawable.ic_menu_myplaces);
 
         item = menu.add(0, MENU_SITE_STATS, 0, getString(R.string.site_stats_app_name));
         item.setIcon( R.drawable.wiglewifi_small_black_white );
-        MenuItemCompat.setShowAsAction(item, MenuItemCompat.SHOW_AS_ACTION_IF_ROOM);
+        MenuItemCompat.setShowAsAction(item, MenuItem.SHOW_AS_ACTION_IF_ROOM);
 
         item = menu.add(0, MENU_SITE_STATS, 0, getString(R.string.site_stats_app_name));
         item.setIcon(R.drawable.wiglewifi_small_black_white);
@@ -400,27 +405,29 @@ public class RankStatsFragment extends Fragment {
 
     /* Handles item selections */
     @Override
-    public boolean onOptionsItemSelected( final MenuItem item ) {
+    public boolean onOptionsItemSelected(@NonNull final MenuItem item ) {
         final MainActivity main = MainActivity.getMainActivity();
-        NavigationView navigationView = (NavigationView) getActivity().findViewById(R.id.left_drawer);
-
-        switch ( item.getItemId() ) {
-            case MENU_USER_STATS:
-                MenuUtil.selectStatsSubmenuItem(navigationView, main, R.id.nav_user_stats);
-                return true;
-            case MENU_SITE_STATS:
-                MenuUtil.selectStatsSubmenuItem(navigationView, main, R.id.nav_site_stats);
-                return true;
-            case MENU_RANK_SWAP:
-                monthRanking.set(!monthRanking.get());
-                item.setTitle(getRankSwapString());
-                downloadRanks(false);
-                return true;
-            case MENU_USER_CENTRIC_SWAP:
-                userCentric.set(!userCentric.get());
-                item.setTitle(getUserCentricSwapString());
-                downloadRanks(false);
-                return true;
+        final Activity a = getActivity();
+        if (null != a) {
+            NavigationView navigationView = a.findViewById(R.id.left_drawer);
+            switch ( item.getItemId() ) {
+                case MENU_USER_STATS:
+                    MenuUtil.selectStatsSubmenuItem(navigationView, main, R.id.nav_user_stats);
+                    return true;
+                case MENU_SITE_STATS:
+                    MenuUtil.selectStatsSubmenuItem(navigationView, main, R.id.nav_site_stats);
+                    return true;
+                case MENU_RANK_SWAP:
+                    monthRanking.set(!monthRanking.get());
+                    item.setTitle(getRankSwapString());
+                    downloadRanks(false);
+                    return true;
+                case MENU_USER_CENTRIC_SWAP:
+                    userCentric.set(!userCentric.get());
+                    item.setTitle(getUserCentricSwapString());
+                    downloadRanks(false);
+                    return true;
+            }
         }
         return false;
     }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RegistrationActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RegistrationActivity.java
@@ -11,6 +11,7 @@ import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import net.wigle.wigleandroid.background.WiGLERegistrationInterface;
+import net.wigle.wigleandroid.util.UrlConfig;
 
 /**
  * Created by arkasha on 1/8/18.
@@ -39,7 +40,7 @@ public class RegistrationActivity extends AppCompatActivity {
         }
         regWebView.addJavascriptInterface(new WiGLERegistrationInterface(this),
                 "WiGLEWiFi");
-        regWebView.loadUrl(MainActivity.REG_URL);
+        regWebView.loadUrl(UrlConfig.REG_URL);
     }
 
     /**

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SearchFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SearchFragment.java
@@ -18,6 +18,7 @@ import android.widget.TextView;
 
 import net.wigle.wigleandroid.ui.WiGLEToast;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 import net.wigle.wigleandroid.util.SearchUtil;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -66,8 +67,8 @@ public class SearchFragment extends Fragment {
 
         final Activity a = getActivity();
         final SharedPreferences prefs = (null != a)?a.getApplicationContext().
-                getSharedPreferences(ListFragment.SHARED_PREFS, 0):null;
-        if ((null == prefs || prefs.getString(ListFragment.PREF_AUTHNAME, "").isEmpty()) || !TokenAccess.hasApiToken(prefs)) {
+                getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0):null;
+        if ((null == prefs || prefs.getString(PreferenceKeys.PREF_AUTHNAME, "").isEmpty()) || !TokenAccess.hasApiToken(prefs)) {
             RadioButton rb = scrollView.findViewById(R.id.radio_search_local);
             if (null != rb) {
                 rb.setChecked(true);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
@@ -121,7 +121,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
     public void handleDialog(final int dialogId) {
         final Activity a = getActivity();
         if (null != a) {
-            final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+            final SharedPreferences prefs = a.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
             final Editor editor = prefs.edit();
             final View view = getView();
 
@@ -182,7 +182,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
 
         final Activity a = getActivity();
         if (null != a) {
-            final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+            final SharedPreferences prefs = a.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
             // donate
             final boolean isDonate = prefs.getBoolean(PreferenceKeys.PREF_DONATE, false);
             if (isDonate) {
@@ -577,7 +577,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
     private void updateRegister(final View view) {
         final Activity a = getActivity();
         if (null != a) {
-            final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+            final SharedPreferences prefs = a.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
             final String username = prefs.getString(PreferenceKeys.PREF_USERNAME, "");
             final boolean isAnonymous = prefs.getBoolean(PreferenceKeys.PREF_BE_ANONYMOUS, false);
             if (view != null) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
@@ -1,12 +1,12 @@
 package net.wigle.wigleandroid;
 
 import java.io.File;
-import java.io.FilenameFilter;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
 import android.annotation.SuppressLint;
+import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -21,6 +21,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
@@ -37,12 +38,9 @@ import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
-import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.CheckBox;
-import android.widget.CompoundButton;
-import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -50,10 +48,11 @@ import android.widget.TextView;
 import net.wigle.wigleandroid.background.ApiDownloader;
 import net.wigle.wigleandroid.background.DownloadHandler;
 import net.wigle.wigleandroid.listener.GNSSListener;
-import net.wigle.wigleandroid.listener.PrefCheckboxListener;
 import net.wigle.wigleandroid.ui.PrefsBackedCheckbox;
+import net.wigle.wigleandroid.ui.WiGLEConfirmationDialog;
 import net.wigle.wigleandroid.util.FileUtility;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 import net.wigle.wigleandroid.util.SettingsUtil;
 import net.wigle.wigleandroid.util.UrlConfig;
 
@@ -91,7 +90,10 @@ public final class SettingsFragment extends Fragment implements DialogListener {
         super.onCreate(savedInstanceState);
 
         // set language
-        MainActivity.setLocale(getActivity());
+        final Activity a = getActivity();
+        if (null != a) {
+            MainActivity.setLocale(a);
+        }
         setHasOptionsMenu(true);
     }
 
@@ -101,10 +103,13 @@ public final class SettingsFragment extends Fragment implements DialogListener {
         final View view = inflater.inflate(R.layout.settings, container, false);
 
         // force media volume controls
-        getActivity().setVolumeControlStream(AudioManager.STREAM_MUSIC);
+        final Activity a = getActivity();
+        if (null != a) {
+            a.setVolumeControlStream(AudioManager.STREAM_MUSIC);
+        }
 
         // don't let the textbox have focus to start with, so we don't see a keyboard right away
-        final LinearLayout linearLayout = (LinearLayout) view.findViewById(R.id.linearlayout);
+        final LinearLayout linearLayout = view.findViewById(R.id.linearlayout);
         linearLayout.setFocusableInTouchMode(true);
         linearLayout.requestFocus();
         updateView(view);
@@ -114,57 +119,60 @@ public final class SettingsFragment extends Fragment implements DialogListener {
     @SuppressLint("SetTextI18n")
     @Override
     public void handleDialog(final int dialogId) {
-        final SharedPreferences prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
-        final Editor editor = prefs.edit();
-        final View view = getView();
+        final Activity a = getActivity();
+        if (null != a) {
+            final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+            final Editor editor = prefs.edit();
+            final View view = getView();
 
-        switch (dialogId) {
-            case DONATE_DIALOG: {
-                editor.putBoolean(ListFragment.PREF_DONATE, true);
-                editor.apply();
+            switch (dialogId) {
+                case DONATE_DIALOG: {
+                    editor.putBoolean(PreferenceKeys.PREF_DONATE, true);
+                    editor.apply();
 
-                if (view != null) {
-                    final CheckBox donate = (CheckBox) view.findViewById(R.id.donate);
-                    donate.setChecked(true);
+                    if (view != null) {
+                        final CheckBox donate = view.findViewById(R.id.donate);
+                        donate.setChecked(true);
+                    }
+                    // poof
+                    eraseDonate();
+                    break;
                 }
-                // poof
-                eraseDonate();
-                break;
+                case ANONYMOUS_DIALOG: {
+                    // turn anonymous
+                    editor.putBoolean(PreferenceKeys.PREF_BE_ANONYMOUS, true);
+                    editor.remove(PreferenceKeys.PREF_USERNAME);
+                    editor.remove(PreferenceKeys.PREF_PASSWORD);
+                    editor.remove(PreferenceKeys.PREF_AUTHNAME);
+                    editor.remove(PreferenceKeys.PREF_TOKEN);
+                    editor.apply();
+
+                    if (view != null) {
+                        this.updateView(view);
+                    }
+                    break;
+                }
+                case DEAUTHORIZE_DIALOG: {
+                    editor.remove(PreferenceKeys.PREF_AUTHNAME);
+                    editor.remove(PreferenceKeys.PREF_TOKEN);
+                    editor.remove(PreferenceKeys.PREF_CONFIRM_UPLOAD_USER);
+
+                    String mapTileMode = prefs.getString(PreferenceKeys.PREF_SHOW_DISCOVERED,
+                            PreferenceKeys.PREF_MAP_NO_TILE);
+                    if (PreferenceKeys.PREF_MAP_NOTMINE_TILE.equals(mapTileMode) ||
+                            PreferenceKeys.PREF_MAP_ONLYMINE_TILE.equals(mapTileMode)) {
+                        // ALIBI: clear show mine/others on deauthorize
+                        editor.putString(PreferenceKeys.PREF_SHOW_DISCOVERED, PreferenceKeys.PREF_MAP_NO_TILE);
+                    }
+                    editor.apply();
+                    if (view != null) {
+                        this.updateView(view);
+                    }
+                    break;
+                }
+                default:
+                    Logging.warn("Settings unhandled dialogId: " + dialogId);
             }
-            case ANONYMOUS_DIALOG: {
-                // turn anonymous
-                editor.putBoolean( ListFragment.PREF_BE_ANONYMOUS, true );
-                editor.remove(ListFragment.PREF_USERNAME);
-                editor.remove(ListFragment.PREF_PASSWORD);
-                editor.remove(ListFragment.PREF_AUTHNAME);
-                editor.remove(ListFragment.PREF_TOKEN);
-                editor.apply();
-
-                if (view != null) {
-                    this.updateView(view);
-                }
-                break;
-            }
-            case DEAUTHORIZE_DIALOG: {
-                editor.remove(ListFragment.PREF_AUTHNAME);
-                editor.remove(ListFragment.PREF_TOKEN);
-                editor.remove(ListFragment.PREF_CONFIRM_UPLOAD_USER);
-
-                String mapTileMode = prefs.getString(ListFragment.PREF_SHOW_DISCOVERED,
-                        ListFragment.PREF_MAP_NO_TILE);
-                if (ListFragment.PREF_MAP_NOTMINE_TILE.equals(mapTileMode) ||
-                        ListFragment.PREF_MAP_ONLYMINE_TILE.equals(mapTileMode)) {
-                    // ALIBI: clear show mine/others on deauthorize
-                    editor.putString(ListFragment.PREF_SHOW_DISCOVERED, ListFragment.PREF_MAP_NO_TILE);
-                }
-                editor.apply();
-                if (view != null) {
-                    this.updateView(view);
-                }
-                break;
-            }
-            default:
-                Logging.warn("Settings unhandled dialogId: " + dialogId);
         }
     }
 
@@ -172,28 +180,31 @@ public final class SettingsFragment extends Fragment implements DialogListener {
     public void onResume() {
         Logging.info("resume settings.");
 
-        final SharedPreferences prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
-        // donate
-        final boolean isDonate = prefs.getBoolean(ListFragment.PREF_DONATE, false);
-        if ( isDonate ) {
-            eraseDonate();
+        final Activity a = getActivity();
+        if (null != a) {
+            final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+            // donate
+            final boolean isDonate = prefs.getBoolean(PreferenceKeys.PREF_DONATE, false);
+            if (isDonate) {
+                eraseDonate();
+            }
+            super.onResume();
+            Logging.info("Resume with allow: " + allowRefresh);
+            if (allowRefresh) {
+                allowRefresh = false;
+                final View view = getView();
+
+                updateView(view);
+
+                //ALIBI: what doesn't work here:
+                //does not successfully reload
+                //getFragmentManager().beginTransaction().replace(this.container.getId(),this).commit();
+
+                // WTF: actually re-pauses and resumes.
+                //getFragmentManager().beginTransaction().detach(this).attach(this).commit();
+            }
+            a.setTitle(R.string.settings_app_name);
         }
-        super.onResume();
-        Logging.info("Resume with allow: "+allowRefresh);
-        if (allowRefresh) {
-            allowRefresh = false;
-            final View view = getView();
-
-            updateView(view);
-
-            //ALIBI: what doesn't work here:
-            //does not successfully reload
-            //getFragmentManager().beginTransaction().replace(this.container.getId(),this).commit();
-
-            // WTF: actually re-pauses and resumes.
-            //getFragmentManager().beginTransaction().detach(this).attach(this).commit();
-        }
-        getActivity().setTitle(R.string.settings_app_name);
     }
 
     @Override
@@ -206,37 +217,37 @@ public final class SettingsFragment extends Fragment implements DialogListener {
     private void updateView(final View view) {
         final FragmentActivity activity = getActivity();
         if (activity == null) return;
-        final SharedPreferences prefs = activity.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+        final SharedPreferences prefs = activity.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
         final Editor editor = prefs.edit();
 
         // donate
-        final CheckBox donate = (CheckBox) view.findViewById(R.id.donate);
-        final boolean isDonate = prefs.getBoolean( ListFragment.PREF_DONATE, false);
+        final CheckBox donate = view.findViewById(R.id.donate);
+        final boolean isDonate = prefs.getBoolean( PreferenceKeys.PREF_DONATE, false);
         donate.setChecked( isDonate );
         if ( isDonate ) {
             eraseDonate();
         }
-        donate.setOnCheckedChangeListener(new OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged( final CompoundButton buttonView, final boolean isChecked ) {
-                if ( isChecked == prefs.getBoolean( ListFragment.PREF_DONATE, false) ) {
-                    // this would cause no change, bail
-                    return;
-                }
+        donate.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if ( isChecked == prefs.getBoolean( PreferenceKeys.PREF_DONATE, false) ) {
+                // this would cause no change, bail
+                return;
+            }
 
-                if ( isChecked ) {
-                    // turn off until confirmed
-                    buttonView.setChecked( false );
-                    // confirm
-                    MainActivity.createConfirmation( getActivity(),
+            if ( isChecked ) {
+                // turn off until confirmed
+                buttonView.setChecked( false );
+                // confirm
+                final FragmentActivity a = getActivity();
+                if (null != a) {
+                    WiGLEConfirmationDialog.createConfirmation(a,
                             getString(R.string.donate_question) + "\n\n"
                                     + getString(R.string.donate_explain),
                             R.id.nav_settings, DONATE_DIALOG);
                 }
-                else {
-                    editor.putBoolean( ListFragment.PREF_DONATE, false);
-                    editor.apply();
-                }
+            }
+            else {
+                editor.putBoolean( PreferenceKeys.PREF_DONATE, false);
+                editor.apply();
             }
         });
 
@@ -262,16 +273,16 @@ public final class SettingsFragment extends Fragment implements DialogListener {
             }
         }
 
-        final String authUser = prefs.getString(ListFragment.PREF_AUTHNAME,"");
-        final EditText user = (EditText) view.findViewById(R.id.edit_username);
-        final TextView authUserDisplay = (TextView) view.findViewById(R.id.show_authuser);
+        final String authUser = prefs.getString(PreferenceKeys.PREF_AUTHNAME,"");
+        final EditText user = view.findViewById(R.id.edit_username);
+        final TextView authUserDisplay = view.findViewById(R.id.show_authuser);
         final View authUserLayout = view.findViewById(R.id.show_authuser_label);
-        final EditText passEdit = (EditText) view.findViewById(R.id.edit_password);
+        final EditText passEdit = view.findViewById(R.id.edit_password);
         final View passEditLayout = view.findViewById(R.id.edit_password_label);
-        final CheckBox showPass = (CheckBox) view.findViewById(R.id.showpassword);
-        final String authToken = prefs.getString(ListFragment.PREF_TOKEN, "");
-        final Button deauthButton = (Button) view.findViewById(R.id.deauthorize_client);
-        final Button authButton = (Button) view.findViewById(R.id.authorize_client);
+        final CheckBox showPass = view.findViewById(R.id.showpassword);
+        final String authToken = prefs.getString(PreferenceKeys.PREF_TOKEN, "");
+        final Button deauthButton = view.findViewById(R.id.deauthorize_client);
+        final Button authButton = view.findViewById(R.id.authorize_client);
 
         if (!authUser.isEmpty()) {
             authUserDisplay.setText(authUser);
@@ -279,14 +290,9 @@ public final class SettingsFragment extends Fragment implements DialogListener {
             authUserLayout.setVisibility(View.VISIBLE);
             if (!authToken.isEmpty()) {
                 deauthButton.setVisibility(View.VISIBLE);
-                deauthButton.setOnClickListener(new OnClickListener() {
-                    @Override
-                    public void onClick(View view) {
-                        MainActivity.createConfirmation( getActivity(),
-                                getString(R.string.deauthorize_confirm),
-                                R.id.nav_settings, DEAUTHORIZE_DIALOG );
-                    }
-                });
+                deauthButton.setOnClickListener(view13 -> WiGLEConfirmationDialog.createConfirmation( getActivity(),
+                        getString(R.string.deauthorize_confirm),
+                        R.id.nav_settings, DEAUTHORIZE_DIALOG ));
                 authButton.setVisibility(View.GONE);
                 passEdit.setVisibility(View.GONE);
                 passEditLayout.setVisibility(View.GONE);
@@ -308,61 +314,58 @@ public final class SettingsFragment extends Fragment implements DialogListener {
                     getResources(), this);
             final UserStatsFragment.UserDownloadApiListener apiListener =
                     new UserStatsFragment.UserDownloadApiListener(handler);
-            authButton.setOnClickListener(new OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    final ApiDownloader task = new ApiDownloader(getActivity(), ListFragment.lameStatic.dbHelper,
-                            "user-stats-cache.json", UrlConfig.USER_STATS_URL, false, true, true,
-                            ApiDownloader.REQUEST_GET,
-                            apiListener);
-                    try {
-                        task.startDownload(SettingsFragment.this);
-                    } catch (WiGLEAuthException waex) {
-                        Logging.info("User authentication failed");
-                    }
+            authButton.setOnClickListener(view12 -> {
+                final ApiDownloader task = new ApiDownloader(getActivity(), ListFragment.lameStatic.dbHelper,
+                        "user-stats-cache.json", UrlConfig.USER_STATS_URL, false, true, true,
+                        ApiDownloader.REQUEST_GET,
+                        apiListener);
+                try {
+                    task.startDownload(SettingsFragment.this);
+                } catch (WiGLEAuthException waex) {
+                    Logging.info("User authentication failed");
                 }
             });
         }
 
         // anonymous
-        final CheckBox beAnonymous = (CheckBox) view.findViewById(R.id.be_anonymous);
-        final boolean isAnonymous = prefs.getBoolean( ListFragment.PREF_BE_ANONYMOUS, false);
+        final CheckBox beAnonymous = view.findViewById(R.id.be_anonymous);
+        final boolean isAnonymous = prefs.getBoolean( PreferenceKeys.PREF_BE_ANONYMOUS, false);
         if ( isAnonymous ) {
             user.setEnabled( false );
             passEdit.setEnabled( false );
         }
 
         beAnonymous.setChecked( isAnonymous );
-        beAnonymous.setOnCheckedChangeListener(new OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged( final CompoundButton buttonView, final boolean isChecked ) {
-                if ( isChecked == prefs.getBoolean(ListFragment.PREF_BE_ANONYMOUS, false) ) {
-                    // this would cause no change, bail
-                    return;
-                }
+        beAnonymous.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if ( isChecked == prefs.getBoolean(PreferenceKeys.PREF_BE_ANONYMOUS, false) ) {
+                // this would cause no change, bail
+                return;
+            }
 
-                if ( isChecked ) {
-                    // turn off until confirmed
-                    buttonView.setChecked( false );
-                    // confirm
-                    MainActivity.createConfirmation( getActivity(),
+            if ( isChecked ) {
+                // turn off until confirmed
+                buttonView.setChecked( false );
+                // confirm
+                final Activity a = getActivity();
+                if (null != a) {
+                    WiGLEConfirmationDialog.createConfirmation(getActivity(),
                             getString(R.string.anonymous_confirm), R.id.nav_settings,
-                            ANONYMOUS_DIALOG );
-                } else {
-                    // unset anonymous
-                    user.setEnabled(true);
-                    passEdit.setEnabled(true);
-                    editor.putBoolean( ListFragment.PREF_BE_ANONYMOUS, false );
-                    editor.apply();
-
-                    // might have to remove or show register link
-                    updateRegister(view);
+                            ANONYMOUS_DIALOG);
                 }
+            } else {
+                // unset anonymous
+                user.setEnabled(true);
+                passEdit.setEnabled(true);
+                editor.putBoolean( PreferenceKeys.PREF_BE_ANONYMOUS, false );
+                editor.apply();
+
+                // might have to remove or show register link
+                updateRegister(view);
             }
         });
 
         // register link
-        final TextView register = (TextView) view.findViewById(R.id.register);
+        final TextView register = view.findViewById(R.id.register);
         final String registerString = getString(R.string.register);
         final String activateString = getString(R.string.activate);
         String registerBlurb = "<a href='net.wigle.wigleandroid.register://register'>" + registerString +
@@ -387,137 +390,118 @@ public final class SettingsFragment extends Fragment implements DialogListener {
         register.setMovementMethod(LinkMovementMethod.getInstance());
         updateRegister(view);
 
-        user.setText( prefs.getString( ListFragment.PREF_USERNAME, "" ) );
+        user.setText( prefs.getString( PreferenceKeys.PREF_USERNAME, "" ) );
         user.addTextChangedListener( new SetWatcher() {
             @Override
             public void onTextChanged( final String s ) {
-                credentialsUpdate(ListFragment.PREF_USERNAME, editor, prefs, s);
+                credentialsUpdate(PreferenceKeys.PREF_USERNAME, editor, prefs, s);
 
                 // might have to remove or show register link
                 updateRegister(view);
             }
         });
 
-        final CheckBox showPassword = (CheckBox) view.findViewById(R.id.showpassword);
-        showPassword.setOnCheckedChangeListener(new OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged( final CompoundButton buttonView, final boolean isChecked ) {
-                if ( isChecked ) {
-                    passEdit.setTransformationMethod(SingleLineTransformationMethod.getInstance());
-                }
-                else {
-                    passEdit.setTransformationMethod(PasswordTransformationMethod.getInstance());
-                }
+        final CheckBox showPassword = view.findViewById(R.id.showpassword);
+        showPassword.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if ( isChecked ) {
+                passEdit.setTransformationMethod(SingleLineTransformationMethod.getInstance());
+            }
+            else {
+                passEdit.setTransformationMethod(PasswordTransformationMethod.getInstance());
             }
         });
-;
 
-        final String showDiscovered = prefs.getString( ListFragment.PREF_SHOW_DISCOVERED, ListFragment.PREF_MAP_NO_TILE);
+        final String showDiscovered = prefs.getString( PreferenceKeys.PREF_SHOW_DISCOVERED, PreferenceKeys.PREF_MAP_NO_TILE);
         final boolean isAuthenticated = (!authUser.isEmpty() && !authToken.isEmpty() && !isAnonymous);
         final String[] mapModes = SettingsUtil.getMapModes(isAuthenticated);
         final String[] mapModeName = SettingsUtil.getMapModeNames(isAuthenticated, this.getContext());
 
-        if (!ListFragment.PREF_MAP_NO_TILE.equals(showDiscovered)) {
-            LinearLayout mainLayout = (LinearLayout) view.findViewById(R.id.show_map_discovered_since);
+        if (!PreferenceKeys.PREF_MAP_NO_TILE.equals(showDiscovered)) {
+            LinearLayout mainLayout = view.findViewById(R.id.show_map_discovered_since);
             mainLayout.setVisibility(View.VISIBLE);
         }
 
-        SettingsUtil.doMapSpinner( R.id.show_discovered, ListFragment.PREF_SHOW_DISCOVERED,
-                ListFragment.PREF_MAP_NO_TILE, mapModes, mapModeName, getContext(), view );
+        SettingsUtil.doMapSpinner( R.id.show_discovered, PreferenceKeys.PREF_SHOW_DISCOVERED,
+                PreferenceKeys.PREF_MAP_NO_TILE, mapModes, mapModeName, getContext(), view );
 
         int thisYear = Calendar.getInstance().get(Calendar.YEAR);
-        List<Long> yearValueBase = new ArrayList<Long>();
-        List<String> yearLabelBase = new ArrayList<String>();
+        List<Long> yearValueBase = new ArrayList<>();
+        List<String> yearLabelBase = new ArrayList<>();
         for (int i = 2001; i <= thisYear; i++) {
             yearValueBase.add((long)(i));
             yearLabelBase.add(Integer.toString(i));
         }
-        SettingsUtil.doSpinner( R.id.networks_discovered_since_year, view, ListFragment.PREF_SHOW_DISCOVERED_SINCE,
+        SettingsUtil.doSpinner( R.id.networks_discovered_since_year, view, PreferenceKeys.PREF_SHOW_DISCOVERED_SINCE,
                 2001L, yearValueBase.toArray(new Long[0]),
                 yearLabelBase.toArray(new String[0]), getContext() );
 
-        passEdit.setText( prefs.getString( ListFragment.PREF_PASSWORD, "" ) );
+        passEdit.setText( prefs.getString( PreferenceKeys.PREF_PASSWORD, "" ) );
         passEdit.addTextChangedListener( new SetWatcher() {
             @Override
             public void onTextChanged( final String s ) {
-                credentialsUpdate(ListFragment.PREF_PASSWORD, editor, prefs, s);
+                credentialsUpdate(PreferenceKeys.PREF_PASSWORD, editor, prefs, s);
             }
         });
 
-        final Button button = (Button) view.findViewById(R.id.speech_button);
-        button.setOnClickListener( new OnClickListener() {
-            @Override
-            public void onClick( final View view ) {
-                final Intent errorReportIntent = new Intent( getActivity(), SpeechActivity.class );
-                SettingsFragment.this.startActivity( errorReportIntent );
-            }
+        final Button button = view.findViewById(R.id.speech_button);
+        button.setOnClickListener(view1 -> {
+            final Intent errorReportIntent = new Intent( getActivity(), SpeechActivity.class );
+            SettingsFragment.this.startActivity( errorReportIntent );
         });
 
         // period spinners
-        SettingsUtil.doScanSpinner( R.id.periodstill_spinner, ListFragment.PREF_SCAN_PERIOD_STILL,
+        SettingsUtil.doScanSpinner( R.id.periodstill_spinner, PreferenceKeys.PREF_SCAN_PERIOD_STILL,
                 MainActivity.SCAN_STILL_DEFAULT, getString(R.string.nonstop), view, getContext() );
-        SettingsUtil.doScanSpinner( R.id.period_spinner, ListFragment.PREF_SCAN_PERIOD,
+        SettingsUtil.doScanSpinner( R.id.period_spinner, PreferenceKeys.PREF_SCAN_PERIOD,
                 MainActivity.SCAN_DEFAULT, getString(R.string.nonstop), view, getContext() );
-        SettingsUtil.doScanSpinner( R.id.periodfast_spinner, ListFragment.PREF_SCAN_PERIOD_FAST,
+        SettingsUtil.doScanSpinner( R.id.periodfast_spinner, PreferenceKeys.PREF_SCAN_PERIOD_FAST,
                 MainActivity.SCAN_FAST_DEFAULT, getString(R.string.nonstop), view, getContext() );
-        SettingsUtil.doScanSpinner( R.id.gps_spinner, ListFragment.GPS_SCAN_PERIOD,
+        SettingsUtil.doScanSpinner( R.id.gps_spinner, PreferenceKeys.GPS_SCAN_PERIOD,
                 MainActivity.LOCATION_UPDATE_INTERVAL, getString(R.string.setting_tie_wifi), view, getContext() );
 
-        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.edit_showcurrent, ListFragment.PREF_SHOW_CURRENT, true);
-        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.use_metric, ListFragment.PREF_METRIC, false);
-        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.found_sound, ListFragment.PREF_FOUND_SOUND, true);
-        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.found_new_sound, ListFragment.PREF_FOUND_NEW_SOUND, true);
-        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.circle_size_map, ListFragment.PREF_CIRCLE_SIZE_MAP, false);
-        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.no_individual_nets_map, ListFragment.PREF_MAP_HIDE_NETS, false);
-        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.use_network_location, ListFragment.PREF_USE_NETWORK_LOC, false);
-        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.disable_toast, ListFragment.PREF_DISABLE_TOAST, false);
-        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.boot_start, ListFragment.PREF_START_AT_BOOT, false, new PrefCheckboxListener() {
-            @Override
-            public void preferenceSet(boolean value) {
-                if (Build.VERSION.SDK_INT >= 29) {
-                    if (value) {
-                        if (!Settings.canDrawOverlays(getContext())) {
-                            Intent intent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, Uri.parse("package:net.wigle.wigleandroid"));
-                            startActivityForResult(intent, 0);
-                        }
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.edit_showcurrent, PreferenceKeys.PREF_SHOW_CURRENT, true);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.use_metric, PreferenceKeys.PREF_METRIC, false);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.found_sound, PreferenceKeys.PREF_FOUND_SOUND, true);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.found_new_sound, PreferenceKeys.PREF_FOUND_NEW_SOUND, true);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.circle_size_map, PreferenceKeys.PREF_CIRCLE_SIZE_MAP, false);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.no_individual_nets_map, PreferenceKeys.PREF_MAP_HIDE_NETS, false);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.use_network_location, PreferenceKeys.PREF_USE_NETWORK_LOC, false);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.disable_toast, PreferenceKeys.PREF_DISABLE_TOAST, false);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.boot_start, PreferenceKeys.PREF_START_AT_BOOT, false, value -> {
+            if (Build.VERSION.SDK_INT >= 29) {
+                if (value) {
+                    if (!Settings.canDrawOverlays(getContext())) {
+                        Intent intent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION, Uri.parse("package:net.wigle.wigleandroid"));
+                        startActivityForResult(intent, 0);
                     }
                 }
             }
         });
-        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.bluetooth_ena, ListFragment.PREF_SCAN_BT, true, new PrefCheckboxListener() {
-            @Override
-            public void preferenceSet(boolean value) {
-                Logging.info("Signaling bluetooth change: "+value);
-                if (value) {
-                    MainActivity.getMainActivity().setupBluetooth(prefs);
-                } else {
-                    MainActivity.getMainActivity().endBluetooth(prefs);
-                }
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.bluetooth_ena, PreferenceKeys.PREF_SCAN_BT, true, value -> {
+            Logging.info("Signaling bluetooth change: "+value);
+            if (value) {
+                MainActivity.getMainActivity().setupBluetooth(prefs);
+            } else {
+                MainActivity.getMainActivity().endBluetooth(prefs);
             }
         });
-        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.enable_route_map_display , ListFragment.PREF_VISUALIZE_ROUTE, false, new PrefCheckboxListener() {
-            @Override
-            public void preferenceSet(boolean value) {
-                Logging.info("Signaling route mapping change: "+value);
-                if (value) {
-                    MainActivity.getMainActivity().startRouteMapping(prefs);
-                } else {
-                    MainActivity.getMainActivity().endRouteMapping(prefs);
-                }
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.enable_route_map_display , PreferenceKeys.PREF_VISUALIZE_ROUTE, false, value -> {
+            Logging.info("Signaling route mapping change: "+value);
+            if (value) {
+                MainActivity.getMainActivity().startRouteMapping(prefs);
+            } else {
+                MainActivity.getMainActivity().endRouteMapping(prefs);
             }
         });
-        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.enable_route_logging, ListFragment.PREF_LOG_ROUTES, false, new PrefCheckboxListener() {
-            @Override
-            public void preferenceSet(boolean value) {
-                Logging.info("Signaling route logging change: "+value);
-                if (value) {
-                    MainActivity.getMainActivity().startRouteLogging(prefs);
-                } else {
-                    MainActivity.getMainActivity().endRouteLogging();
-                }
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.enable_route_logging, PreferenceKeys.PREF_LOG_ROUTES, false, value -> {
+            Logging.info("Signaling route logging change: "+value);
+            if (value) {
+                MainActivity.getMainActivity().startRouteLogging(prefs);
+            } else {
+                MainActivity.getMainActivity().endRouteLogging();
             }
         });
-        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.enable_map_theme , ListFragment.PREF_MAPS_FOLLOW_DAYNIGHT, false);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.enable_map_theme , PreferenceKeys.PREF_MAPS_FOLLOW_DAYNIGHT, false);
         final String[] languages = new String[]{ "", "en", "ar", "cs", "da", "de", "es-rES", "fi", "fr", "fy",
                 "he", "hi-rIN", "hu", "it", "ja-rJP", "ko", "nl", "no", "pl", "pt-rPT", "pt-rBR", "ro-rRO", "ru", "sv",
                 "sw", "tr", "zh-rCN", "zh-rTW", "zh-rHK" };
@@ -532,14 +516,14 @@ public final class SettingsFragment extends Fragment implements DialogListener {
                 getString(R.string.language_sv), getString(R.string.language_sw), getString(R.string.language_tr),
                 getString(R.string.language_zh_cn), getString(R.string.language_zh_tw), getString(R.string.language_zh_hk),
         };
-        SettingsUtil.doSpinner( R.id.language_spinner, view, ListFragment.PREF_LANGUAGE, "", languages, languageName, getContext() );
+        SettingsUtil.doSpinner( R.id.language_spinner, view, PreferenceKeys.PREF_LANGUAGE, "", languages, languageName, getContext() );
 
         if (Build.VERSION.SDK_INT > 28) {
             View theme = view.findViewById(R.id.theme_section);
             theme.setVisibility(View.VISIBLE);
             final Integer[] themes = new Integer[] {AppCompatDelegate.MODE_NIGHT_YES, AppCompatDelegate.MODE_NIGHT_NO, AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM};
             final String[] themeName = new String[]{getString(R.string.theme_dark_label), getString(R.string.theme_light_label), getString(R.string.theme_follow_label)};
-            SettingsUtil.doSpinner(R.id.theme_spinner, view, ListFragment.PREF_DAYNIGHT_MODE, AppCompatDelegate.MODE_NIGHT_YES, themes, themeName, getContext());
+            SettingsUtil.doSpinner(R.id.theme_spinner, view, PreferenceKeys.PREF_DAYNIGHT_MODE, AppCompatDelegate.MODE_NIGHT_YES, themes, themeName, getContext());
         }
 
         final String off = getString(R.string.off);
@@ -549,34 +533,34 @@ public final class SettingsFragment extends Fragment implements DialogListener {
         // battery kill spinner
         final Long[] batteryPeriods = new Long[]{ 1L,2L,3L,4L,5L,10L,15L,20L,0L };
         final String[] batteryName = new String[]{ "1 %","2 %","3 %","4 %","5 %","10 %","15 %","20 %",off };
-        SettingsUtil.doSpinner( R.id.battery_kill_spinner, view, ListFragment.PREF_BATTERY_KILL_PERCENT,
+        SettingsUtil.doSpinner( R.id.battery_kill_spinner, view, PreferenceKeys.PREF_BATTERY_KILL_PERCENT,
                 MainActivity.DEFAULT_BATTERY_KILL_PERCENT, batteryPeriods, batteryName, getContext() );
 
         // reset wifi spinner
         final Long[] resetPeriods = new Long[]{ 15000L,30000L,60000L,90000L,120000L,300000L,600000L,0L };
         final String[] resetName = new String[]{ "15" + sec, "30" + sec,"1" + min,"1.5" + min,
                 "2" + min,"5" + min,"10" + min,off };
-        SettingsUtil.doSpinner( R.id.reset_wifi_spinner, view, ListFragment.PREF_RESET_WIFI_PERIOD,
+        SettingsUtil.doSpinner( R.id.reset_wifi_spinner, view, PreferenceKeys.PREF_RESET_WIFI_PERIOD,
                 MainActivity.DEFAULT_RESET_WIFI_PERIOD, resetPeriods, resetName, getContext() );
 
         final Long[] timeoutPeriods = new Long[]{GNSSListener.GPS_TIMEOUT_DEFAULT, 30000L, GNSSListener.NET_LOC_TIMEOUT_DEFAULT, 300000L, 1800000L, 3600000L};
         final String[] timeoutName = new String[]{ "15" + sec, "30" + sec,"1" + min,"5" + min,
                 "30" + min,"60" + min};
         // gps timeout spinner
-        SettingsUtil.doSpinner( R.id.gps_timeout_spinner, view, ListFragment.PREF_GPS_TIMEOUT,
+        SettingsUtil.doSpinner( R.id.gps_timeout_spinner, view, PreferenceKeys.PREF_GPS_TIMEOUT,
                 GNSSListener.GPS_TIMEOUT_DEFAULT, timeoutPeriods, timeoutName, getContext() );
 
         // net loc timeout spinner
-        SettingsUtil.doSpinner( R.id.net_loc_timeout_spinner, view, ListFragment.PREF_NET_LOC_TIMEOUT,
+        SettingsUtil.doSpinner( R.id.net_loc_timeout_spinner, view, PreferenceKeys.PREF_NET_LOC_TIMEOUT,
                 GNSSListener.NET_LOC_TIMEOUT_DEFAULT, timeoutPeriods, timeoutName, getContext() );
 
         // prefs setting for tap-to-pause scan indicator
         final String[] pauseOptions = new String[] {ListFragment.QUICK_SCAN_UNSET, ListFragment.QUICK_SCAN_PAUSE, ListFragment.QUICK_SCAN_DO_NOTHING};
         final String[] pauseOptionNames = new String[] {getString(R.string.quick_pause_unset), getString(R.string.quick_pause), getString(R.string.quick_pause_do_nothing)};
-        SettingsUtil.doSpinner( R.id.quick_pause_spinner, view, ListFragment.PREF_QUICK_PAUSE,
+        SettingsUtil.doSpinner( R.id.quick_pause_spinner, view, PreferenceKeys.PREF_QUICK_PAUSE,
                 ListFragment.QUICK_SCAN_UNSET, pauseOptions, pauseOptionNames, getContext() );
 
-        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.enable_kalman, ListFragment.PREF_GPS_KALMAN_FILTER ,true);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.enable_kalman, PreferenceKeys.PREF_GPS_KALMAN_FILTER ,true);
 
         TextView appVersion = view.findViewById(R.id.app_version);
         final String appName = getString(R.string.app_name);
@@ -591,21 +575,23 @@ public final class SettingsFragment extends Fragment implements DialogListener {
     }
 
     private void updateRegister(final View view) {
-        final SharedPreferences prefs = getActivity().getSharedPreferences(ListFragment.SHARED_PREFS, 0);
-        final String username = prefs.getString(ListFragment.PREF_USERNAME, "");
-        final boolean isAnonymous = prefs.getBoolean(ListFragment.PREF_BE_ANONYMOUS, false);
+        final Activity a = getActivity();
+        if (null != a) {
+            final SharedPreferences prefs = getActivity().getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+            final String username = prefs.getString(PreferenceKeys.PREF_USERNAME, "");
+            final boolean isAnonymous = prefs.getBoolean(PreferenceKeys.PREF_BE_ANONYMOUS, false);
+            if (view != null) {
+                final TextView register = view.findViewById(R.id.register);
 
-        if (view != null) {
-            final TextView register = (TextView) view.findViewById(R.id.register);
-
-            //ALIBI: ActivateAcitivity.receiveDetections sets isAnonymous = false
-            if ("".equals(username) || isAnonymous) {
-                register.setEnabled(true);
-                register.setVisibility(View.VISIBLE);
-            } else {
-                // poof
-                register.setEnabled(false);
-                register.setVisibility(View.GONE);
+                //ALIBI: ActivateAcitivity.receiveDetections sets isAnonymous = false
+                if ("".equals(username) || isAnonymous) {
+                    register.setEnabled(true);
+                    register.setVisibility(View.VISIBLE);
+                } else {
+                    // poof
+                    register.setEnabled(false);
+                    register.setVisibility(View.GONE);
+                }
             }
         }
     }
@@ -630,9 +616,9 @@ public final class SettingsFragment extends Fragment implements DialogListener {
             editor.putString(key, newValue.trim());
         }
         // ALIBI: if the u|p changes, force refetch token
-        editor.remove(ListFragment.PREF_AUTHNAME);
-        editor.remove(ListFragment.PREF_TOKEN);
-        editor.remove(ListFragment.PREF_CONFIRM_UPLOAD_USER);
+        editor.remove(PreferenceKeys.PREF_AUTHNAME);
+        editor.remove(PreferenceKeys.PREF_TOKEN);
+        editor.remove(PreferenceKeys.PREF_CONFIRM_UPLOAD_USER);
         editor.apply();
         this.clearCachefiles();
     }
@@ -643,13 +629,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
      */
     private void clearCachefiles() {
         final File cacheDir = new File(FileUtility.getSDPath());
-        final File[] cacheFiles = cacheDir.listFiles(new FilenameFilter() {
-            @Override
-            public boolean accept( final File dir,
-                                   final String name ) {
-                return name.matches( ".*-cache\\.json" );
-            }
-        } );
+        final File[] cacheFiles = cacheDir.listFiles((dir, name) -> name.matches( ".*-cache\\.json" ));
         if (null != cacheFiles) {
             for (File cache: cacheFiles) {
                 //DEBUG: MainActivity.info("deleting: " + cache.getAbsolutePath());
@@ -664,7 +644,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
     private void eraseDonate() {
         final View view = getView();
         if (view != null) {
-            final CheckBox donate = (CheckBox) view.findViewById(R.id.donate);
+            final CheckBox donate = view.findViewById(R.id.donate);
             donate.setEnabled(false);
             donate.setVisibility(View.GONE);
         }
@@ -672,7 +652,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
 
     /* Creates the menu items */
     @Override
-    public void onCreateOptionsMenu(final Menu menu, final MenuInflater inflater) {
+    public void onCreateOptionsMenu(final Menu menu, @NonNull final MenuInflater inflater) {
         MenuItem item = menu.add(0, MENU_DEBUG, 0, getString(R.string.menu_debug));
         item.setIcon( android.R.drawable.ic_media_previous );
 
@@ -702,7 +682,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
      * used for authentication - this seems really heavy
      */
     private final static class UserDownloadHandler extends DownloadHandler {
-        private SettingsFragment fragment;
+        private final SettingsFragment fragment;
         private UserDownloadHandler(final View view, final String packageName,
                                     final Resources resources, SettingsFragment settingsFragment) {
             super(view, null, packageName, resources);
@@ -721,9 +701,9 @@ public final class SettingsFragment extends Fragment implements DialogListener {
                     Logging.info("Settings auth successful");
                     final SharedPreferences prefs = MainActivity.getMainActivity()
                             .getApplicationContext()
-                            .getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+                            .getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
                     final Editor editor = prefs.edit();
-                    editor.remove(ListFragment.PREF_PASSWORD);
+                    editor.remove(PreferenceKeys.PREF_PASSWORD);
                     editor.apply();
                     //TODO: order dependent -verify no risk of race condition here.
                     fragment.updateView(view);
@@ -732,7 +712,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
         }
     }
 
-    private final static void addDevModeMesgIfApplicable(StringBuilder builder, final Context c, final String message) {
+    private static void addDevModeMesgIfApplicable(StringBuilder builder, final Context c, final String message) {
         if (!MainActivity.isDevMode(c)) {
             builder.append("\n\n");
             builder.append(message);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
@@ -51,9 +51,11 @@ import net.wigle.wigleandroid.background.ApiDownloader;
 import net.wigle.wigleandroid.background.DownloadHandler;
 import net.wigle.wigleandroid.listener.GNSSListener;
 import net.wigle.wigleandroid.listener.PrefCheckboxListener;
+import net.wigle.wigleandroid.ui.PrefsBackedCheckbox;
 import net.wigle.wigleandroid.util.FileUtility;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.SettingsUtil;
+import net.wigle.wigleandroid.util.UrlConfig;
 
 import static net.wigle.wigleandroid.UserStatsFragment.MSG_USER_DONE;
 
@@ -310,7 +312,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
                 @Override
                 public void onClick(View view) {
                     final ApiDownloader task = new ApiDownloader(getActivity(), ListFragment.lameStatic.dbHelper,
-                            "user-stats-cache.json", MainActivity.USER_STATS_URL, false, true, true,
+                            "user-stats-cache.json", UrlConfig.USER_STATS_URL, false, true, true,
                             ApiDownloader.REQUEST_GET,
                             apiListener);
                     try {
@@ -461,15 +463,15 @@ public final class SettingsFragment extends Fragment implements DialogListener {
         SettingsUtil.doScanSpinner( R.id.gps_spinner, ListFragment.GPS_SCAN_PERIOD,
                 MainActivity.LOCATION_UPDATE_INTERVAL, getString(R.string.setting_tie_wifi), view, getContext() );
 
-        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.edit_showcurrent, ListFragment.PREF_SHOW_CURRENT, true);
-        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.use_metric, ListFragment.PREF_METRIC, false);
-        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.found_sound, ListFragment.PREF_FOUND_SOUND, true);
-        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.found_new_sound, ListFragment.PREF_FOUND_NEW_SOUND, true);
-        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.circle_size_map, ListFragment.PREF_CIRCLE_SIZE_MAP, false);
-        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.no_individual_nets_map, ListFragment.PREF_MAP_HIDE_NETS, false);
-        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.use_network_location, ListFragment.PREF_USE_NETWORK_LOC, false);
-        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.disable_toast, ListFragment.PREF_DISABLE_TOAST, false);
-        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.boot_start, ListFragment.PREF_START_AT_BOOT, false, new PrefCheckboxListener() {
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.edit_showcurrent, ListFragment.PREF_SHOW_CURRENT, true);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.use_metric, ListFragment.PREF_METRIC, false);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.found_sound, ListFragment.PREF_FOUND_SOUND, true);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.found_new_sound, ListFragment.PREF_FOUND_NEW_SOUND, true);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.circle_size_map, ListFragment.PREF_CIRCLE_SIZE_MAP, false);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.no_individual_nets_map, ListFragment.PREF_MAP_HIDE_NETS, false);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.use_network_location, ListFragment.PREF_USE_NETWORK_LOC, false);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.disable_toast, ListFragment.PREF_DISABLE_TOAST, false);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.boot_start, ListFragment.PREF_START_AT_BOOT, false, new PrefCheckboxListener() {
             @Override
             public void preferenceSet(boolean value) {
                 if (Build.VERSION.SDK_INT >= 29) {
@@ -482,7 +484,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
                 }
             }
         });
-        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.bluetooth_ena, ListFragment.PREF_SCAN_BT, true, new PrefCheckboxListener() {
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.bluetooth_ena, ListFragment.PREF_SCAN_BT, true, new PrefCheckboxListener() {
             @Override
             public void preferenceSet(boolean value) {
                 Logging.info("Signaling bluetooth change: "+value);
@@ -493,7 +495,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
                 }
             }
         });
-        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.enable_route_map_display , ListFragment.PREF_VISUALIZE_ROUTE, false, new PrefCheckboxListener() {
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.enable_route_map_display , ListFragment.PREF_VISUALIZE_ROUTE, false, new PrefCheckboxListener() {
             @Override
             public void preferenceSet(boolean value) {
                 Logging.info("Signaling route mapping change: "+value);
@@ -504,7 +506,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
                 }
             }
         });
-        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.enable_route_logging, ListFragment.PREF_LOG_ROUTES, false, new PrefCheckboxListener() {
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.enable_route_logging, ListFragment.PREF_LOG_ROUTES, false, new PrefCheckboxListener() {
             @Override
             public void preferenceSet(boolean value) {
                 Logging.info("Signaling route logging change: "+value);
@@ -515,7 +517,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
                 }
             }
         });
-        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.enable_map_theme , ListFragment.PREF_MAPS_FOLLOW_DAYNIGHT, false);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.enable_map_theme , ListFragment.PREF_MAPS_FOLLOW_DAYNIGHT, false);
         final String[] languages = new String[]{ "", "en", "ar", "cs", "da", "de", "es-rES", "fi", "fr", "fy",
                 "he", "hi-rIN", "hu", "it", "ja-rJP", "ko", "nl", "no", "pl", "pt-rPT", "pt-rBR", "ro-rRO", "ru", "sv",
                 "sw", "tr", "zh-rCN", "zh-rTW", "zh-rHK" };
@@ -574,7 +576,7 @@ public final class SettingsFragment extends Fragment implements DialogListener {
         SettingsUtil.doSpinner( R.id.quick_pause_spinner, view, ListFragment.PREF_QUICK_PAUSE,
                 ListFragment.QUICK_SCAN_UNSET, pauseOptions, pauseOptionNames, getContext() );
 
-        MainActivity.prefBackedCheckBox(this.getActivity(), view, R.id.enable_kalman, ListFragment.PREF_GPS_KALMAN_FILTER ,true);
+        PrefsBackedCheckbox.prefBackedCheckBox(this.getActivity(), view, R.id.enable_kalman, ListFragment.PREF_GPS_KALMAN_FILTER ,true);
 
         TextView appVersion = view.findViewById(R.id.app_version);
         final String appName = getString(R.string.app_name);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SiteStatsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SiteStatsFragment.java
@@ -24,6 +24,7 @@ import net.wigle.wigleandroid.background.ApiListener;
 import net.wigle.wigleandroid.background.DownloadHandler;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.MenuUtil;
+import net.wigle.wigleandroid.util.UrlConfig;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -137,7 +138,7 @@ public class SiteStatsFragment extends Fragment {
         final Handler handler = new SiteDownloadHandler(view, numberFormat, getActivity().getPackageName(),
                 getResources());
         final ApiDownloader task = new ApiDownloader(getActivity(), ListFragment.lameStatic.dbHelper,
-                "site-stats-cache.json", MainActivity.SITE_STATS_URL, false, false, false,
+                "site-stats-cache.json", UrlConfig.SITE_STATS_URL, false, false, false,
                 ApiDownloader.REQUEST_GET,
                 new ApiListener() {
                     @Override

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SpeechActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SpeechActivity.java
@@ -9,12 +9,13 @@ import androidx.appcompat.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.CheckBox;
-import android.widget.CompoundButton;
-import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.Spinner;
 import android.widget.TextView;
 
+import net.wigle.wigleandroid.util.PreferenceKeys;
 import net.wigle.wigleandroid.util.SettingsUtil;
+
+import java.util.Objects;
 
 public class SpeechActivity extends AppCompatActivity {
     private static final int MENU_RETURN = 12;
@@ -40,25 +41,25 @@ public class SpeechActivity extends AppCompatActivity {
         // force media volume controls
         this.setVolumeControlStream( AudioManager.STREAM_MUSIC );
 
-        final SharedPreferences prefs = this.getSharedPreferences( ListFragment.SHARED_PREFS, 0);
-        doTtsCheckbox( prefs, R.id.speech_gps, ListFragment.PREF_SPEECH_GPS );
-        doTtsCheckbox( prefs, R.id.speech_run, ListFragment.PREF_SPEAK_RUN );
-        doTtsCheckbox( prefs, R.id.speech_new_wifi, ListFragment.PREF_SPEAK_NEW_WIFI );
-        doTtsCheckbox( prefs, R.id.speech_new_cell, ListFragment.PREF_SPEAK_NEW_CELL );
-        doTtsCheckbox( prefs, R.id.speech_queue, ListFragment.PREF_SPEAK_QUEUE );
-        doTtsCheckbox( prefs, R.id.speech_miles, ListFragment.PREF_SPEAK_MILES );
-        doTtsCheckbox( prefs, R.id.speech_time, ListFragment.PREF_SPEAK_TIME );
-        doTtsCheckbox( prefs, R.id.speech_battery, ListFragment.PREF_SPEAK_BATTERY );
-        doTtsCheckbox( prefs, R.id.speech_ssid, ListFragment.PREF_SPEAK_SSID, false );
-        doTtsCheckbox( prefs, R.id.speech_wifi_restart, ListFragment.PREF_SPEAK_WIFI_RESTART );
+        final SharedPreferences prefs = this.getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0);
+        doTtsCheckbox( prefs, R.id.speech_gps, PreferenceKeys.PREF_SPEECH_GPS );
+        doTtsCheckbox( prefs, R.id.speech_run, PreferenceKeys.PREF_SPEAK_RUN );
+        doTtsCheckbox( prefs, R.id.speech_new_wifi, PreferenceKeys.PREF_SPEAK_NEW_WIFI );
+        doTtsCheckbox( prefs, R.id.speech_new_cell, PreferenceKeys.PREF_SPEAK_NEW_CELL );
+        doTtsCheckbox( prefs, R.id.speech_queue, PreferenceKeys.PREF_SPEAK_QUEUE );
+        doTtsCheckbox( prefs, R.id.speech_miles, PreferenceKeys.PREF_SPEAK_MILES );
+        doTtsCheckbox( prefs, R.id.speech_time, PreferenceKeys.PREF_SPEAK_TIME );
+        doTtsCheckbox( prefs, R.id.speech_battery, PreferenceKeys.PREF_SPEAK_BATTERY );
+        doTtsCheckbox( prefs, R.id.speech_ssid, PreferenceKeys.PREF_SPEAK_SSID, false );
+        doTtsCheckbox( prefs, R.id.speech_wifi_restart, PreferenceKeys.PREF_SPEAK_WIFI_RESTART );
 
         // speech spinner
         Spinner spinner = findViewById(R.id.speak_spinner );
         //TODO: this may no longer be necessary
-        if (MainActivity.getMainActivity() == null || MainActivity.getStaticState().tts == null) {
+        if (MainActivity.getMainActivity() == null || Objects.requireNonNull(MainActivity.getStaticState()).tts == null) {
             // no text to speech :(
             spinner.setEnabled( false );
-            final TextView speakText = (TextView) findViewById(R.id.speak_text );
+            final TextView speakText = findViewById(R.id.speak_text );
             speakText.setText(getString(R.string.no_tts));
         }
 
@@ -69,7 +70,7 @@ public class SpeechActivity extends AppCompatActivity {
         final Long[] speechPeriods = new Long[]{ 10L,15L,30L,60L,120L,300L,600L,900L,1800L,0L };
         final String[] speechName = new String[]{ "10" + sec,"15" + sec,"30" + sec,
                 "1" + min,"2" + min,"5" + min,"10" + min,"15" + min,"30" + min, off };
-        SettingsUtil.doSpinner((Spinner)findViewById(R.id.speak_spinner), ListFragment.PREF_SPEECH_PERIOD,
+        SettingsUtil.doSpinner(findViewById(R.id.speak_spinner), PreferenceKeys.PREF_SPEECH_PERIOD,
                 MainActivity.DEFAULT_SPEECH_PERIOD, speechPeriods, speechName, this);
     }
 
@@ -86,17 +87,14 @@ public class SpeechActivity extends AppCompatActivity {
     private void doTtsCheckbox(final SharedPreferences prefs, final int id, final String pref, final boolean defaultVal ) {
         final CheckBox box = findViewById( id );
         box.setChecked( prefs.getBoolean( pref, defaultVal ) );
-        box.setOnCheckedChangeListener( new OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged( final CompoundButton buttonView, final boolean isChecked ) {
-                final Editor editor = prefs.edit();
-                editor.putBoolean( pref, isChecked );
-                editor.apply();
-                if (!isChecked) {
-                    MainActivity m = MainActivity.getMainActivity();
-                    if (null != m && !m.isFinishing()) {
-                        m.interruptSpeak();
-                    }
+        box.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            final Editor editor = prefs.edit();
+            editor.putBoolean( pref, isChecked );
+            editor.apply();
+            if (!isChecked) {
+                MainActivity m = MainActivity.getMainActivity();
+                if (null != m && !m.isFinishing()) {
+                    m.interruptSpeak();
                 }
             }
         });

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/TokenAccess.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/TokenAccess.java
@@ -9,9 +9,11 @@ import android.security.keystore.KeyProperties;
 import android.util.Base64;
 
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
 import java.security.KeyPairGenerator;
@@ -48,38 +50,32 @@ public class TokenAccess {
     public static final String KEYSTORE_WIGLE_CREDS_KEY_V1 = "WiGLEKey";
     public static final String KEYSTORE_WIGLE_CREDS_KEY_V2 = "WiGLEKeyAES";
     public static final String ANDROID_KEYSTORE = "AndroidKeyStore";
-    public static final String UTF8 = "UTF-8";
     private static final String AES_CIPHER = "AES/GCM/NoPadding";
     private static final String RSA_OLD_CIPHER = "RSA/ECB/PKCS1Padding";
     private static final String RSA_CIPHER = "RSA/ECB/OAEPWithSHA-256AndMGF1Padding";
 
     /**
      * test presence of a necessary API key, Keystore entry if applicable
-     * @param prefs
      * @return true if present, otherwise false
      */
     public static boolean hasApiToken(SharedPreferences prefs) {
-        if (!prefs.getString(ListFragment.PREF_TOKEN,"").isEmpty()) {
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
+        if (!prefs.getString(PreferenceKeys.PREF_TOKEN,"").isEmpty()) {
 
-                try {
-                    final KeyStore keyStore = getKeyStore();
+            try {
+                final KeyStore keyStore = getKeyStore();
 
-                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
-                        if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V1)
-                                || keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V2)) {
-                            //TODO: it would be best to test decrypt here, but makes this heavier
-                            return true;
-                        }
-                    } else if  (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V0)) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V1)
+                            || keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V2)) {
+                        //TODO: it would be best to test decrypt here, but makes this heavier
                         return true;
                     }
-                } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
-                    Logging.error("[TOKEN] Error trying to test token existence: ", e);
-                    return false;
+                } else if  (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V0)) {
+                    return true;
                 }
-            } else {
-                return true;
+            } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException | IOException e) {
+                Logging.error("[TOKEN] Error trying to test token existence: ", e);
+                return false;
             }
         }
         return false;
@@ -87,12 +83,10 @@ public class TokenAccess {
 
     /**
      * remove the token preference
-     * @param prefs
-     * @return
      */
     public static void clearApiToken(SharedPreferences prefs) {
         final SharedPreferences.Editor editor = prefs.edit();
-        editor.remove(ListFragment.PREF_TOKEN);
+        editor.remove(PreferenceKeys.PREF_TOKEN);
         editor.apply();
     }
 
@@ -128,9 +122,9 @@ public class TokenAccess {
         final int tagLength = (cypherToken.length - input.length) * 8;
 
         final SharedPreferences.Editor editor = prefs.edit();
-        editor.putString(ListFragment.PREF_TOKEN, Base64.encodeToString(cypherToken, Base64.DEFAULT));
-        editor.putString(ListFragment.PREF_TOKEN_IV, Base64.encodeToString(iv, Base64.DEFAULT));
-        editor.putInt(ListFragment.PREF_TOKEN_TAG_LENGTH, tagLength);
+        editor.putString(PreferenceKeys.PREF_TOKEN, Base64.encodeToString(cypherToken, Base64.DEFAULT));
+        editor.putString(PreferenceKeys.PREF_TOKEN_IV, Base64.encodeToString(iv, Base64.DEFAULT));
+        editor.putInt(PreferenceKeys.PREF_TOKEN_TAG_LENGTH, tagLength);
         editor.apply();
         Logging.info("[TOKEN] setApiTokenVersion2 set token length: " + apiToken.length());
         return true;
@@ -142,11 +136,6 @@ public class TokenAccess {
             InvalidAlgorithmParameterException {
 
         try {
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT) {
-                // GCMParameterSpec not in < 19 - prevent compiler warnings
-                Logging.warn("[TOKEN] getApiTokenVersion2 sdk not K+: " + Build.VERSION.SDK_INT);
-                return null;
-            } else {
                 final KeyStore keyStore = getKeyStore();
                 final SecretKey key = (SecretKey) keyStore.getKey(KEYSTORE_WIGLE_CREDS_KEY_V2, null);
                 if (null == key ) {
@@ -155,16 +144,15 @@ public class TokenAccess {
                 }
                 final Cipher decrypt = Cipher.getInstance(AES_CIPHER);
 
-                final byte[] cypherToken = Base64.decode(prefs.getString(ListFragment.PREF_TOKEN, ""), Base64.DEFAULT);
-                final byte[] iv = Base64.decode(prefs.getString(ListFragment.PREF_TOKEN_IV, ""), Base64.DEFAULT);
-                final int tagLength = prefs.getInt(ListFragment.PREF_TOKEN_TAG_LENGTH, 128);
+                final byte[] cypherToken = Base64.decode(prefs.getString(PreferenceKeys.PREF_TOKEN, ""), Base64.DEFAULT);
+                final byte[] iv = Base64.decode(prefs.getString(PreferenceKeys.PREF_TOKEN_IV, ""), Base64.DEFAULT);
+                final int tagLength = prefs.getInt(PreferenceKeys.PREF_TOKEN_TAG_LENGTH, 128);
 
                 decrypt.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(tagLength, iv));
                 final byte[] done = decrypt.doFinal(cypherToken);
-                final String token = new String(done, UTF8);
+                final String token = new String(done, StandardCharsets.UTF_8);
                 Logging.info("[TOKEN] aes decrypted token length: " + token.length());
                 return token;
-            }
         } catch (Exception ex) {
             Logging.error("Failed to decrypt token with AES-GCM (v2 cipher): ", ex);
             return null;
@@ -179,82 +167,65 @@ public class TokenAccess {
      */
     public static boolean setApiToken(SharedPreferences prefs, String apiToken) {
         final SharedPreferences.Editor editor = prefs.edit();
-        if (android.os.Build.VERSION.SDK_INT <
-                android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            //ALIBI: no crypto available here
-            editor.putString(ListFragment.PREF_TOKEN, apiToken);
-            editor.apply();
-            return true;
-        } else {
-            try {
-                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    return setApiTokenVersion2(prefs, apiToken);
-                }
+        try {
+            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                return setApiTokenVersion2(prefs, apiToken);
+            }
 
-                byte[] cypherToken;
+            byte[] cypherToken;
+            String keyStr = KEYSTORE_WIGLE_CREDS_KEY_V1;
 
-                String keyStr = KEYSTORE_WIGLE_CREDS_KEY_V0;
-                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    keyStr = KEYSTORE_WIGLE_CREDS_KEY_V1;
-                }
-                final KeyStore keyStore = getKeyStore();
+            final KeyStore keyStore = getKeyStore();
 
-                KeyStore.PrivateKeyEntry privateKeyEntry = (KeyStore.PrivateKeyEntry)
-                        keyStore.getEntry(keyStr, null);
+            KeyStore.PrivateKeyEntry privateKeyEntry = (KeyStore.PrivateKeyEntry)
+                    keyStore.getEntry(keyStr, null);
 
-                if (null != privateKeyEntry) {
-                    PublicKey publicKey =
-                            privateKeyEntry.getCertificate().getPublicKey();
-                    Cipher c = null;
+            if (null != privateKeyEntry) {
+                PublicKey publicKey =
+                        privateKeyEntry.getCertificate().getPublicKey();
 
-                    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                        c = Cipher.getInstance(RSA_CIPHER);
-                    } else if (android.os.Build.VERSION.SDK_INT >=
-                            android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
-                        c = Cipher.getInstance(RSA_OLD_CIPHER);
-                    }
-                    if (null != c) {
-                        c.init(Cipher.ENCRYPT_MODE, publicKey);
-                        cypherToken = c.doFinal(apiToken.getBytes());
-                        if (null != cypherToken) {
-                            //TODO: use same prefskey? make a new one + clear old one?
-                            editor.putString(ListFragment.PREF_TOKEN,
-                                    Base64.encodeToString(cypherToken, Base64.DEFAULT));
-                            editor.apply();
-                            return true;
-                        } else {
-                            // ALIBI: DEBUG should be unreachable.
-                            Logging.error("[TOKEN] ERROR: unreachable condition," +
-                                    "cipherToken NULL.  APIv" +
-                                    android.os.Build.VERSION.SDK_INT);
-                        }
+                Cipher c = Cipher.getInstance(RSA_CIPHER);
+                if (null != c) {
+                    c.init(Cipher.ENCRYPT_MODE, publicKey);
+                    cypherToken = c.doFinal(apiToken.getBytes());
+                    if (null != cypherToken) {
+                        //TODO: use same prefskey? make a new one + clear old one?
+                        editor.putString(PreferenceKeys.PREF_TOKEN,
+                                Base64.encodeToString(cypherToken, Base64.DEFAULT));
+                        editor.apply();
+                        return true;
                     } else {
                         // ALIBI: DEBUG should be unreachable.
                         Logging.error("[TOKEN] ERROR: unreachable condition," +
-                                "cipher NULL.  APIv" +
+                                "cipherToken NULL.  APIv" +
                                 android.os.Build.VERSION.SDK_INT);
                     }
                 } else {
                     // ALIBI: DEBUG should be unreachable.
-                    Logging.error("[TOKEN] ERROR: setApiToken for APIv" +
-                            android.os.Build.VERSION.SDK_INT +
-                            ", privateKey Entry NULL. Key: " +
-                            keyStr);
-                    editor.putString(ListFragment.PREF_TOKEN, apiToken);
-                    editor.apply();
-                    return true;
+                    Logging.error("[TOKEN] ERROR: unreachable condition," +
+                            "cipher NULL.  APIv" +
+                            android.os.Build.VERSION.SDK_INT);
                 }
-            } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException |
-                    IOException | UnrecoverableEntryException | NoSuchPaddingException |
-                    InvalidKeyException | BadPaddingException | IllegalBlockSizeException ex) {
-                Logging.error("[TOKEN] Failed to set token: ",ex);
-                ex.printStackTrace();
-            } catch (Exception e) {
-                Logging.error("[TOKEN] Other error - failed to set token: ",e);
-                e.printStackTrace();
+            } else {
+                // ALIBI: DEBUG should be unreachable.
+                Logging.error("[TOKEN] ERROR: setApiToken for APIv" +
+                        android.os.Build.VERSION.SDK_INT +
+                        ", privateKey Entry NULL. Key: " +
+                        keyStr);
+                editor.putString(PreferenceKeys.PREF_TOKEN, apiToken);
+                editor.apply();
+                return true;
             }
-            return false;
+        } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException |
+                IOException | UnrecoverableEntryException | NoSuchPaddingException |
+                InvalidKeyException | BadPaddingException | IllegalBlockSizeException ex) {
+            Logging.error("[TOKEN] Failed to set token: ",ex);
+            ex.printStackTrace();
+        } catch (Exception e) {
+            Logging.error("[TOKEN] Other error - failed to set token: ",e);
+            e.printStackTrace();
         }
+        return false;
     }
 
     /**
@@ -263,65 +234,58 @@ public class TokenAccess {
      * @return the String token or null if unavailable
      */
     public static String getApiToken(SharedPreferences prefs) {
-        if (android.os.Build.VERSION.SDK_INT <
-                android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            //ALIBI: no crypto available here
-            return prefs.getString(ListFragment.PREF_TOKEN, "");
-        } else {
-            try {
-                final KeyStore keyStore = getKeyStore();
+        try {
+            final KeyStore keyStore = getKeyStore();
 
-                KeyStore.PrivateKeyEntry privateKeyEntry;
+            KeyStore.PrivateKeyEntry privateKeyEntry;
 
-                // prefer v2 key -> v1 key -> v0 key, nada as applicable
-                int versionThreshold = android.os.Build.VERSION_CODES.M;
-                if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V2)) {
-                    //DEBUG: MainActivity.info("Using v2: " + KEYSTORE_WIGLE_CREDS_KEY_V2);
-                    return getApiTokenVersion2(prefs);
-                } else if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V1)) {
-                    privateKeyEntry = (KeyStore.PrivateKeyEntry)
-                            keyStore.getEntry(KEYSTORE_WIGLE_CREDS_KEY_V1, null);
-                } else if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V0)) {
-                    privateKeyEntry = (KeyStore.PrivateKeyEntry)
-                            keyStore.getEntry(KEYSTORE_WIGLE_CREDS_KEY_V0, null);
-                    versionThreshold = Build.VERSION_CODES.JELLY_BEAN_MR2;
-                } else {
-                    Logging.warn("[TOKEN] Compatible build, but no key set: " +
-                            android.os.Build.VERSION.SDK_INT + " - returning plaintext.");
-                    return prefs.getString(ListFragment.PREF_TOKEN, "");
-                }
+            // prefer v2 key -> v1 key -> v0 key, nada as applicable
+            int versionThreshold = android.os.Build.VERSION_CODES.M;
+            if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V2)) {
+                //DEBUG: MainActivity.info("Using v2: " + KEYSTORE_WIGLE_CREDS_KEY_V2);
+                return getApiTokenVersion2(prefs);
+            } else if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V1)) {
+                privateKeyEntry = (KeyStore.PrivateKeyEntry)
+                        keyStore.getEntry(KEYSTORE_WIGLE_CREDS_KEY_V1, null);
+            } else if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V0)) {
+                privateKeyEntry = (KeyStore.PrivateKeyEntry)
+                        keyStore.getEntry(KEYSTORE_WIGLE_CREDS_KEY_V0, null);
+                versionThreshold = Build.VERSION_CODES.JELLY_BEAN_MR2;
+            } else {
+                Logging.warn("[TOKEN] Compatible build, but no key set: " +
+                        android.os.Build.VERSION.SDK_INT + " - returning plaintext.");
+                return prefs.getString(PreferenceKeys.PREF_TOKEN, "");
+            }
 
 
-                if (null != privateKeyEntry) {
-                    String encodedCypherText = prefs.getString(ListFragment.PREF_TOKEN, "");
-                    if (!encodedCypherText.isEmpty()) {
-                        byte[] cypherText = Base64.decode(encodedCypherText, Base64.DEFAULT);
-                        PrivateKey privateKey = privateKeyEntry.getPrivateKey();
+            if (null != privateKeyEntry) {
+                String encodedCypherText = prefs.getString(PreferenceKeys.PREF_TOKEN, "");
+                if (!encodedCypherText.isEmpty()) {
+                    byte[] cypherText = Base64.decode(encodedCypherText, Base64.DEFAULT);
+                    PrivateKey privateKey = privateKeyEntry.getPrivateKey();
 
-                        Cipher c;
-                        if (versionThreshold >= android.os.Build.VERSION_CODES.M) {
-                            c = Cipher.getInstance(RSA_CIPHER);
-                        } else {
-                            c = Cipher.getInstance(RSA_OLD_CIPHER);
-                        }
-                        c.init(Cipher.DECRYPT_MODE, privateKey);
-                        String key = new String(c.doFinal(cypherText), UTF8);
-                        return key;
+                    Cipher c;
+                    if (versionThreshold >= android.os.Build.VERSION_CODES.M) {
+                        c = Cipher.getInstance(RSA_CIPHER);
                     } else {
-                        Logging.error("[TOKEN] NULL encoded cyphertext on token decrypt.");
-                        return null;
+                        c = Cipher.getInstance(RSA_OLD_CIPHER);
                     }
+                    c.init(Cipher.DECRYPT_MODE, privateKey);
+                    return new String(c.doFinal(cypherText), StandardCharsets.UTF_8);
                 } else {
-                    Logging.error("[TOKEN] NULL Private Key on token decrypt.");
+                    Logging.error("[TOKEN] NULL encoded cyphertext on token decrypt.");
                     return null;
                 }
-            } catch (CertificateException | NoSuchAlgorithmException | IOException |
-                    KeyStoreException | UnrecoverableEntryException | NoSuchPaddingException |
-                    InvalidKeyException | BadPaddingException | IllegalBlockSizeException |
-                    InvalidAlgorithmParameterException ex) {
-                Logging.error("[TOKEN] Failed to get API Token: ", ex);
+            } else {
+                Logging.error("[TOKEN] NULL Private Key on token decrypt.");
                 return null;
             }
+        } catch (CertificateException | NoSuchAlgorithmException | IOException |
+                KeyStoreException | UnrecoverableEntryException | NoSuchPaddingException |
+                InvalidKeyException | BadPaddingException | IllegalBlockSizeException |
+                InvalidAlgorithmParameterException ex) {
+            Logging.error("[TOKEN] Failed to get API Token: ", ex);
+            return null;
         }
     }
 
@@ -379,142 +343,135 @@ public class TokenAccess {
 
     private static boolean checkMigrateKeystoreVersion1(SharedPreferences prefs, Context context) {
         boolean initOnly = false;
-        if (prefs.getString(ListFragment.PREF_TOKEN, "").isEmpty()) {
+        if (prefs.getString(PreferenceKeys.PREF_TOKEN, "").isEmpty()) {
             Logging.info("[TOKEN] No auth token stored - no preference migration possible.");
             initOnly = true;
         }
 
-        if (android.os.Build.VERSION.SDK_INT <
-                android.os.Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            // no reliable keystore here
-            Logging.info("[TOKEN] No KeyStore support - no preference migration possible.");
-            return false;
-        } else {
-            try {
-                Logging.info("[TOKEN] Using Android Keystore; check need for new key...");
-                final KeyStore keyStore = getKeyStore();
-                KeyPairGenerator kpg = KeyPairGenerator.getInstance(
-                        KeyProperties.KEY_ALGORITHM_RSA, ANDROID_KEYSTORE);
+        try {
+            Logging.info("[TOKEN] Using Android Keystore; check need for new key...");
+            final KeyStore keyStore = getKeyStore();
+            KeyPairGenerator kpg = KeyPairGenerator.getInstance(
+                    KeyProperties.KEY_ALGORITHM_RSA, ANDROID_KEYSTORE);
 
-                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
-                    if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V1)) {
-                        Logging.info("[TOKEN] Key present and up-to-date M - no change.");
-                        return false;
-                    }
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+                if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V1)) {
+                    Logging.info("[TOKEN] Key present and up-to-date M - no change.");
+                    return false;
+                }
 
-                    Logging.info("[TOKEN] Initializing SDKv23 Key...");
-                    String token = "";
-                    if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V0)) {
-                        //ALIBI: fetch token with V0 key if it's stored that way
-                        token = TokenAccess.getApiToken(prefs);
-                    }
-                    KeyGenParameterSpec spec = new KeyGenParameterSpec.Builder(
-                            KEYSTORE_WIGLE_CREDS_KEY_V1,
-                            KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
-                            .setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
-                            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_OAEP)
-                            .build();
+                Logging.info("[TOKEN] Initializing SDKv23 Key...");
+                String token = "";
+                if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V0)) {
+                    //ALIBI: fetch token with V0 key if it's stored that way
+                    token = TokenAccess.getApiToken(prefs);
+                }
+                KeyGenParameterSpec spec = new KeyGenParameterSpec.Builder(
+                        KEYSTORE_WIGLE_CREDS_KEY_V1,
+                        KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
+                        .setDigests(KeyProperties.DIGEST_SHA256, KeyProperties.DIGEST_SHA512)
+                        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_OAEP)
+                        .build();
 
-                    kpg.initialize(spec);
-                    kpg.generateKeyPair();
+                kpg.initialize(spec);
+                kpg.generateKeyPair();
 
-                    if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V0)) {
-                        Logging.info("[TOKEN] Upgrading from v0->v1 token...");
-                        if ((null == token) || token.isEmpty()) return false;
-                        keyStore.deleteEntry(KEYSTORE_WIGLE_CREDS_KEY_V0);
-                    } else {
-                        token = prefs.getString(ListFragment.PREF_TOKEN, "");
-                        //DEBUG: MainActivity.info("[TOKEN] +"+token+"+");
-                        Logging.info("[TOKEN] Encrypting token at v1...");
-                        if (token.isEmpty()) {
-                            Logging.info("[TOKEN] ...no token, returning after init.");
-                            return false;
-                        }
-                    }
-                    if (!initOnly) {
-                        if (TokenAccess.setApiToken(prefs, token)) {
-                            Logging.info("[TOKEN] ...token set at v1.");
-                            return true;
-                        } else {
-                            /**
-                             * ALIBI: if you can't migrate it, clear it to force re-authentication.
-                             * this isn't optimal, but it beats the alternative.
-                             * This is vital here, since Marshmallow and up can backup/restore
-                             * SharedPreferences, but NOT keystore entries
-                             */
-                            Logging.error("[TOKEN] ...Failed token encryption; clearing.");
-                            clearApiToken(prefs);
-                        }
-                    } else {
-                        Logging.error("[TOKEN] v1 Keystore initialized, but no token present.");
-                    }
-                } else if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-                    if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V0)) {
-                        Logging.info(
-                                "[TOKEN] Key present and up-to-date JB-MR2 - no action required.");
-                        return false;
-                    }
-                    Logging.info("[TOKEN] Initializing SDKv18 Key...");
-                    Calendar notBefore = Calendar.getInstance();
-                    Calendar notAfter = Calendar.getInstance();
-                    notAfter.add(Calendar.YEAR, 3);
-                    KeyPairGeneratorSpec spec = null;
-                    spec = new KeyPairGeneratorSpec.Builder(context)
-                            .setAlias(KEYSTORE_WIGLE_CREDS_KEY_V0)
-                            // TODO: for some reason, type/size only supported >= SDKv19
-                            //.setKeyType(KeyProperties.KEY_ALGORITHM_RSA)
-                            //.setKeySize(4096)
-                            .setSubject(new X500Principal("CN=wigle"))
-                            .setSerialNumber(BigInteger.ONE)
-                            .setStartDate(notBefore.getTime())
-                            //TODO: does endDate for the generation cert => key expiration?
-                            .setEndDate(notAfter.getTime())
-                            .build();
-
-                    kpg.initialize(spec);
-                    kpg.generateKeyPair();
-
-                    String token = prefs.getString(ListFragment.PREF_TOKEN, "");
+                if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V0)) {
+                    Logging.info("[TOKEN] Upgrading from v0->v1 token...");
+                    if ((null == token) || token.isEmpty()) return false;
+                    keyStore.deleteEntry(KEYSTORE_WIGLE_CREDS_KEY_V0);
+                } else {
+                    token = prefs.getString(PreferenceKeys.PREF_TOKEN, "");
+                    //DEBUG: MainActivity.info("[TOKEN] +"+token+"+");
+                    Logging.info("[TOKEN] Encrypting token at v1...");
                     if (token.isEmpty()) {
                         Logging.info("[TOKEN] ...no token, returning after init.");
                         return false;
                     }
-                    Logging.info("[TOKEN] Encrypting token at v0...");
-
-                    if (!initOnly) {
-                        if (TokenAccess.setApiToken(prefs, token)) {
-                            Logging.info("[TOKEN] ...token set at v0.");
-                            return true;
-                        } else {
-                            /**
-                             * ALIBI: if you can't migrate it, clear it to force re-authentication.
-                             * this isn't optimal, but it beats the alternative.
-                             * This may not be necessary in the pre-Marshmallow world.
-                             */
-                            Logging.error("[TOKEN] ...Failed token encryption; clearing.");
-                            clearApiToken(prefs);
-                        }
-                    } else {
-                        Logging.error("[TOKEN] v0 Keystore initialized, but no token present.");
-                    }
                 }
-            } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException |
-                    IOException | NoSuchProviderException | InvalidAlgorithmParameterException |
-                    ProviderException ex) {
-                Logging.error("Upgrade/init of token storage failed: ", ex);
-                ex.printStackTrace();
-                //TODO: should we clear here?
-                //clearApiToken(prefs);
-                return false;
-            } catch (Exception e) {
-                /**
-                 * ALIBI: after production evidence of a ProviderException (runtime), adding belt to
-                 * suspenders
-                 */
-                Logging.error("Unexpected error in upgrade/init of token storage failed: ", e);
-                e.printStackTrace();
-                return false;
+                if (!initOnly) {
+                    if (TokenAccess.setApiToken(prefs, token)) {
+                        Logging.info("[TOKEN] ...token set at v1.");
+                        return true;
+                    } else {
+                        /**
+                         * ALIBI: if you can't migrate it, clear it to force re-authentication.
+                         * this isn't optimal, but it beats the alternative.
+                         * This is vital here, since Marshmallow and up can backup/restore
+                         * SharedPreferences, but NOT keystore entries
+                         */
+                        Logging.error("[TOKEN] ...Failed token encryption; clearing.");
+                        clearApiToken(prefs);
+                    }
+                } else {
+                    Logging.error("[TOKEN] v1 Keystore initialized, but no token present.");
+                }
+            } else if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                if (keyStore.containsAlias(KEYSTORE_WIGLE_CREDS_KEY_V0)) {
+                    Logging.info(
+                            "[TOKEN] Key present and up-to-date JB-MR2 - no action required.");
+                    return false;
+                }
+                Logging.info("[TOKEN] Initializing SDKv18 Key...");
+                Calendar notBefore = Calendar.getInstance();
+                Calendar notAfter = Calendar.getInstance();
+                notAfter.add(Calendar.YEAR, 3);
+                KeyPairGeneratorSpec spec = null;
+                spec = new KeyPairGeneratorSpec.Builder(context)
+                        .setAlias(KEYSTORE_WIGLE_CREDS_KEY_V0)
+                        // TODO: for some reason, type/size only supported >= SDKv19
+                        //.setKeyType(KeyProperties.KEY_ALGORITHM_RSA)
+                        //.setKeySize(4096)
+                        .setSubject(new X500Principal("CN=wigle"))
+                        .setSerialNumber(BigInteger.ONE)
+                        .setStartDate(notBefore.getTime())
+                        //TODO: does endDate for the generation cert => key expiration?
+                        .setEndDate(notAfter.getTime())
+                        .build();
+
+                kpg.initialize(spec);
+                kpg.generateKeyPair();
+
+                String token = prefs.getString(PreferenceKeys.PREF_TOKEN, "");
+                if (token.isEmpty()) {
+                    Logging.info("[TOKEN] ...no token, returning after init.");
+                    return false;
+                }
+                Logging.info("[TOKEN] Encrypting token at v0...");
+
+                if (!initOnly) {
+                    if (TokenAccess.setApiToken(prefs, token)) {
+                        Logging.info("[TOKEN] ...token set at v0.");
+                        return true;
+                    } else {
+                        /*
+                         * ALIBI: if you can't migrate it, clear it to force re-authentication.
+                         * this isn't optimal, but it beats the alternative.
+                         * This may not be necessary in the pre-Marshmallow world.
+                         */
+                        Logging.error("[TOKEN] ...Failed token encryption; clearing.");
+                        clearApiToken(prefs);
+                    }
+                } else {
+                    Logging.error("[TOKEN] v0 Keystore initialized, but no token present.");
+                }
             }
+        } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException |
+                IOException | NoSuchProviderException | InvalidAlgorithmParameterException |
+                ProviderException ex) {
+            Logging.error("Upgrade/init of token storage failed: ", ex);
+            ex.printStackTrace();
+            //TODO: should we clear here?
+            //clearApiToken(prefs);
+            return false;
+        } catch (Exception e) {
+            /*
+             * ALIBI: after production evidence of a ProviderException (runtime), adding belt to
+             * suspenders
+             */
+            Logging.error("Unexpected error in upgrade/init of token storage failed: ", e);
+            e.printStackTrace();
+            return false;
         }
         return false;
     }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UploadsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UploadsFragment.java
@@ -35,6 +35,7 @@ import net.wigle.wigleandroid.ui.EndlessScrollListener;
 import net.wigle.wigleandroid.util.FileUtility;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.MenuUtil;
+import net.wigle.wigleandroid.util.UrlConfig;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -200,7 +201,7 @@ public class UploadsFragment extends Fragment {
         }
         if (busy.compareAndSet(false, true)) {
             final int pageStart = page * ROW_COUNT;
-            final String downloadUrl = MainActivity.UPLOADS_STATS_URL + "?pagestart=" + pageStart + "&pageend=" + (pageStart + ROW_COUNT);
+            final String downloadUrl = UrlConfig.UPLOADS_STATS_URL + "?pagestart=" + pageStart + "&pageend=" + (pageStart + ROW_COUNT);
             final ApiDownloader task = new ApiDownloader(getActivity(), ListFragment.lameStatic.dbHelper, null,
                     /*page == 0 ? "uploads-cache.json" : "uploads-cache-p" + page + ".json",*/
                     //ALIBI: cachefiles are too problematic with infinite scroll

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UploadsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UploadsFragment.java
@@ -35,6 +35,7 @@ import net.wigle.wigleandroid.ui.EndlessScrollListener;
 import net.wigle.wigleandroid.util.FileUtility;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.MenuUtil;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 import net.wigle.wigleandroid.util.UrlConfig;
 
 import org.json.JSONArray;
@@ -229,7 +230,7 @@ public class UploadsFragment extends Fragment {
         final Activity a = getActivity();
         SharedPreferences prefs;
         if (null != a) {
-            prefs = a.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+            prefs = a.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
             if (listAdapter == null) {
                 listAdapter = new UploadsListAdapter(getActivity(), R.layout.uploadrow, prefs, this);
             } else if (!listAdapter.isEmpty() && !TokenAccess.hasApiToken(prefs)) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UserStatsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UserStatsFragment.java
@@ -1,6 +1,6 @@
 package net.wigle.wigleandroid;
 
-import static net.wigle.wigleandroid.MainActivity.WIGLE_BASE_URL;
+import static net.wigle.wigleandroid.util.UrlConfig.WIGLE_BASE_URL;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
@@ -33,6 +33,7 @@ import net.wigle.wigleandroid.background.ApiListener;
 import net.wigle.wigleandroid.background.DownloadHandler;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.MenuUtil;
+import net.wigle.wigleandroid.util.UrlConfig;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -143,7 +144,7 @@ public class UserStatsFragment extends Fragment {
 
     public static void executeUserDownload(final Fragment fragment, final ApiListener apiListener) {
         final ApiDownloader task = new ApiDownloader(fragment.getActivity(), ListFragment.lameStatic.dbHelper,
-                "user-stats-cache.json", MainActivity.USER_STATS_URL, false, true, true,
+                "user-stats-cache.json", UrlConfig.USER_STATS_URL, false, true, true,
                 ApiDownloader.REQUEST_GET,
                 apiListener);
         try {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/WigleService.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/WigleService.java
@@ -21,6 +21,7 @@ import androidx.core.app.NotificationCompat;
 
 import net.wigle.wigleandroid.ui.UINumberFormat;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 import java.text.NumberFormat;
 import java.util.Locale;
@@ -182,7 +183,7 @@ public final class WigleService extends Service {
                 String text = context.getString(R.string.list_waiting_gps);
 
                 String distString = "";
-                SharedPreferences prefs = getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+                SharedPreferences prefs = getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
                 if (prefs != null) {
                     Locale locale = null;
                     Configuration sysConfig = getResources().getConfiguration();
@@ -195,7 +196,7 @@ public final class WigleService extends Service {
                     NumberFormat numberFormat = NumberFormat.getNumberInstance(locale);
                     numberFormat.setMaximumFractionDigits(1);
 
-                    final float dist = prefs.getFloat(ListFragment.PREF_DISTANCE_RUN, 0f);
+                    final float dist = prefs.getFloat(PreferenceKeys.PREF_DISTANCE_RUN, 0f);
                     distString = " ("+UINumberFormat.metersToString(prefs, numberFormat, this, dist, true) + ")";
                 }
                 if (dbNets > 0) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/WigleUncaughtExceptionHandler.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/WigleUncaughtExceptionHandler.java
@@ -4,7 +4,10 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 
+import androidx.annotation.NonNull;
+
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 public class WigleUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
     private final Context applicationContext;
@@ -16,15 +19,15 @@ public class WigleUncaughtExceptionHandler implements Thread.UncaughtExceptionHa
     }
 
     @SuppressLint("ApplySharedPref")
-    public void uncaughtException(Thread thread, Throwable throwable ) {
+    public void uncaughtException(@NonNull Thread thread, Throwable throwable ) {
         String error = "Thread: " + thread + " throwable: " + throwable;
         Logging.error( error );
         throwable.printStackTrace();
 
         MainActivity.writeError( thread, throwable, applicationContext );
         // set flag for error activity on next run
-        final SharedPreferences prefs = applicationContext.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
-        prefs.edit().putBoolean(ListFragment.PREF_BLOWED_UP, true).commit();
+        final SharedPreferences prefs = applicationContext.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+        prefs.edit().putBoolean(PreferenceKeys.PREF_BLOWED_UP, true).commit();
 
         // give it to the regular handler
         origHandler.uncaughtException( thread, throwable );

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractApiRequest.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractApiRequest.java
@@ -14,6 +14,7 @@ import net.wigle.wigleandroid.TokenAccess;
 import net.wigle.wigleandroid.WiGLEAuthException;
 import net.wigle.wigleandroid.util.FileUtility;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.UrlConfig;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -347,7 +348,7 @@ public abstract class AbstractApiRequest extends AbstractBackgroundTask {
      */
     protected void downloadTokenAndStart(final Fragment fragment) {
         final ApiDownloader task = new ApiDownloader(fragment.getActivity(), ListFragment.lameStatic.dbHelper,
-                null, MainActivity.TOKEN_URL, true, false, true, AbstractApiRequest.REQUEST_POST,
+                null, UrlConfig.TOKEN_URL, true, false, true, AbstractApiRequest.REQUEST_POST,
                 new ApiListener() {
                     @Override
                     public void requestComplete(final JSONObject json, final boolean isCache)

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractApiRequest.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractApiRequest.java
@@ -7,13 +7,13 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import android.util.Base64;
 
-import net.wigle.wigleandroid.db.DatabaseHelper;
 import net.wigle.wigleandroid.ListFragment;
-import net.wigle.wigleandroid.MainActivity;
+import net.wigle.wigleandroid.db.DatabaseHelper;
 import net.wigle.wigleandroid.TokenAccess;
 import net.wigle.wigleandroid.WiGLEAuthException;
 import net.wigle.wigleandroid.util.FileUtility;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 import net.wigle.wigleandroid.util.UrlConfig;
 
 import org.json.JSONException;
@@ -29,6 +29,7 @@ import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Abstract base class for WiGLE API connections
@@ -165,7 +166,7 @@ public abstract class AbstractApiRequest extends AbstractBackgroundTask {
     }
 
     public JSONObject getCached() {
-        File file = null;
+        File file;
         if (FileUtility.hasSD()) {
             file = new File(FileUtility.getSDPath() + outputFileName);
             if (!file.exists() || !file.canRead()) {
@@ -250,11 +251,11 @@ public abstract class AbstractApiRequest extends AbstractBackgroundTask {
             throw new WiGLEAuthException("Unable to access Activity for authentication preferences.");
         }
         final SharedPreferences prefs = fragmentActivity.getSharedPreferences(
-                ListFragment.SHARED_PREFS, 0);
-        final boolean beAnonymous = prefs.getBoolean(ListFragment.PREF_BE_ANONYMOUS, false);
-        final String authname = prefs.getString(ListFragment.PREF_AUTHNAME, null);
-        final String username = prefs.getString(ListFragment.PREF_USERNAME, null);
-        final String password = prefs.getString(ListFragment.PREF_PASSWORD, null);
+                PreferenceKeys.SHARED_PREFS, 0);
+        final boolean beAnonymous = prefs.getBoolean(PreferenceKeys.PREF_BE_ANONYMOUS, false);
+        final String authname = prefs.getString(PreferenceKeys.PREF_AUTHNAME, null);
+        final String username = prefs.getString(PreferenceKeys.PREF_USERNAME, null);
+        final String password = prefs.getString(PreferenceKeys.PREF_PASSWORD, null);
         Logging.info("authname: " + authname);
         if (beAnonymous && requiresLogin) {
             Logging.info("anonymous, not running ApiRequest: " + this);
@@ -291,10 +292,10 @@ public abstract class AbstractApiRequest extends AbstractBackgroundTask {
 
         PreConnectConfigurator preConnectConfigurator = null;
         if (doBasicLogin) {
-            final SharedPreferences prefs = context.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
-            final String authname = prefs.getString(ListFragment.PREF_AUTHNAME, null);
+            final SharedPreferences prefs = context.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+            final String authname = prefs.getString(PreferenceKeys.PREF_AUTHNAME, null);
             final String token = TokenAccess.getApiToken(prefs);
-            final String encoded = Base64.encodeToString((authname + ":" + token).getBytes("UTF-8"), Base64.NO_WRAP);
+            final String encoded = Base64.encodeToString((authname + ":" + token).getBytes(StandardCharsets.UTF_8), Base64.NO_WRAP);
             // Cannot set request property after connection is made
             preConnectConfigurator = new PreConnectConfigurator() {
                 @Override
@@ -317,8 +318,8 @@ public abstract class AbstractApiRequest extends AbstractBackgroundTask {
             if (doFormLogin) {
                 final String username = getUsername();
                 final String password = getPassword();
-                final String content = "credential_0=" + URLEncoder.encode(username, HttpFileUploader.ENCODING) +
-                        "&credential_1=" + URLEncoder.encode(password, HttpFileUploader.ENCODING);
+                final String content = "credential_0=" + URLEncoder.encode(username, StandardCharsets.UTF_8.toString()) +
+                        "&credential_1=" + URLEncoder.encode(password, StandardCharsets.UTF_8.toString());
                 printout.writeBytes(content);
             }
             printout.flush();
@@ -329,7 +330,7 @@ public abstract class AbstractApiRequest extends AbstractBackgroundTask {
 
         // get response data
         final BufferedReader input = new BufferedReader(
-                new InputStreamReader( HttpFileUploader.getInputStream( conn ), HttpFileUploader.ENCODING) );
+                new InputStreamReader( HttpFileUploader.getInputStream( conn ), StandardCharsets.UTF_8.toString()) );
         try {
             return getResultString(input, preserveNewlines);
         }
@@ -361,9 +362,9 @@ public abstract class AbstractApiRequest extends AbstractBackgroundTask {
                                 Context fragmentContext = fragment.getContext();
                                 if (null != fragmentContext) {
                                     final SharedPreferences prefs = fragmentContext
-                                            .getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+                                            .getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
                                     final SharedPreferences.Editor edit = prefs.edit();
-                                    edit.putString(ListFragment.PREF_AUTHNAME, authname);
+                                    edit.putString(PreferenceKeys.PREF_AUTHNAME, authname);
                                     edit.apply();
                                     TokenAccess.setApiToken(prefs, token);
                                     // execute ourselves, the pending task

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractBackgroundTask.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractBackgroundTask.java
@@ -6,7 +6,6 @@ import android.os.Handler;
 import android.os.Message;
 import android.os.Process;
 import androidx.fragment.app.FragmentActivity;
-import android.view.View;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.ProgressBar;
@@ -20,6 +19,7 @@ import net.wigle.wigleandroid.R;
 import net.wigle.wigleandroid.TokenAccess;
 import net.wigle.wigleandroid.WiGLEAuthException;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 import java.io.IOException;
 import java.util.Locale;
@@ -132,9 +132,9 @@ public abstract class AbstractBackgroundTask extends Thread implements AlertSett
     }
 
     public static void updateTransferringState(final boolean transferring, final FragmentActivity context) {
-        Button uploadButton = (Button) context.findViewById(R.id.upload_button);
+        Button uploadButton = context.findViewById(R.id.upload_button);
         if (null != uploadButton) uploadButton.setEnabled(!transferring);
-        Button importObservedButton = (Button) context.findViewById(R.id.import_observed_button);
+        Button importObservedButton = context.findViewById(R.id.import_observed_button);
         if (null != importObservedButton) importObservedButton.setEnabled(!transferring);
         if (transferring) {
             MainActivity.getMainActivity().setTransferring();
@@ -144,20 +144,18 @@ public abstract class AbstractBackgroundTask extends Thread implements AlertSett
     }
 
     private void activateProgressPanel(final FragmentActivity context) {
-        final LinearLayout progressLayout = (LinearLayout) context.findViewById(R.id.inline_status_bar);
-        final TextView progressLabel = (TextView) context.findViewById(R.id.inline_progress_status);
-        final ProgressBar progressBar = (ProgressBar) context.findViewById(R.id.inline_status_progress);
-        final Button taskCancelButton = (Button) context.findViewById(R.id.inline_status_cancel);
+        final LinearLayout progressLayout = context.findViewById(R.id.inline_status_bar);
+        final TextView progressLabel = context.findViewById(R.id.inline_progress_status);
+        final ProgressBar progressBar = context.findViewById(R.id.inline_status_progress);
+        final Button taskCancelButton = context.findViewById(R.id.inline_status_cancel);
 
         if ((null != progressLayout) && (null != progressLabel) && (null != progressBar)) {
             pp = new ProgressPanel(progressLayout, progressLabel, progressBar);
             pp.show();
-            taskCancelButton.setOnClickListener(new View.OnClickListener() {
-                public void onClick(View v) {
-                    latestTask.setInterrupted();
-                    clearProgressDialog();
-                    updateTransferringState(false, context);
-                }
+            taskCancelButton.setOnClickListener(v -> {
+                latestTask.setInterrupted();
+                clearProgressDialog();
+                updateTransferringState(false, context);
             });
             //ALIBI: this will get replaced as soon as the progress is set for the first time
             progressBar.setIndeterminate(true);
@@ -178,8 +176,8 @@ public abstract class AbstractBackgroundTask extends Thread implements AlertSett
     }
 
     protected final boolean validAuth() {
-        final SharedPreferences prefs = context.getSharedPreferences( ListFragment.SHARED_PREFS, 0);
-        if ( (!prefs.getString(ListFragment.PREF_AUTHNAME,"").isEmpty()) && (TokenAccess.hasApiToken(prefs))) {
+        final SharedPreferences prefs = context.getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0);
+        if ( (!prefs.getString(PreferenceKeys.PREF_AUTHNAME,"").isEmpty()) && (TokenAccess.hasApiToken(prefs))) {
             return true;
         }
         return false;
@@ -188,29 +186,29 @@ public abstract class AbstractBackgroundTask extends Thread implements AlertSett
 
 
     protected final String getUsername() {
-        final SharedPreferences prefs = context.getSharedPreferences( ListFragment.SHARED_PREFS, 0);
-        String username = prefs.getString( ListFragment.PREF_USERNAME, "" );
-        if ( prefs.getBoolean( ListFragment.PREF_BE_ANONYMOUS, false) ) {
+        final SharedPreferences prefs = context.getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0);
+        String username = prefs.getString( PreferenceKeys.PREF_USERNAME, "" );
+        if ( prefs.getBoolean( PreferenceKeys.PREF_BE_ANONYMOUS, false) ) {
             username = ListFragment.ANONYMOUS;
         }
         return username;
     }
 
     protected final String getPassword() {
-        final SharedPreferences prefs = context.getSharedPreferences( ListFragment.SHARED_PREFS, 0);
-        String password = prefs.getString( ListFragment.PREF_PASSWORD, "" );
+        final SharedPreferences prefs = context.getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0);
+        String password = prefs.getString( PreferenceKeys.PREF_PASSWORD, "" );
 
-        if ( prefs.getBoolean( ListFragment.PREF_BE_ANONYMOUS, false) ) {
+        if ( prefs.getBoolean( PreferenceKeys.PREF_BE_ANONYMOUS, false) ) {
             password = "";
         }
         return password;
     }
 
     protected final String getToken() {
-        final SharedPreferences prefs = context.getSharedPreferences( ListFragment.SHARED_PREFS, 0);
+        final SharedPreferences prefs = context.getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0);
         String token = TokenAccess.getApiToken(prefs);
 
-        if ( prefs.getBoolean( ListFragment.PREF_BE_ANONYMOUS, false) ) {
+        if ( prefs.getBoolean( PreferenceKeys.PREF_BE_ANONYMOUS, false) ) {
             token = "";
         }
         return token;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractProgressApiRequest.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractProgressApiRequest.java
@@ -45,8 +45,7 @@ public abstract class AbstractProgressApiRequest extends AbstractApiRequest {
                             final String token = json.getString("token");
                             final Context c = fragment.getContext();
                             if (null != c) {
-                                final SharedPreferences prefs = fragment.getContext()
-                                        .getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+                                final SharedPreferences prefs = c.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
                                 final SharedPreferences.Editor edit = prefs.edit();
                                 edit.putString(PreferenceKeys.PREF_AUTHNAME, authname);
                                 edit.apply();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractProgressApiRequest.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractProgressApiRequest.java
@@ -11,6 +11,7 @@ import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.TokenAccess;
 import net.wigle.wigleandroid.WiGLEAuthException;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.UrlConfig;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -36,7 +37,7 @@ public abstract class AbstractProgressApiRequest extends AbstractApiRequest {
      */
     protected void downloadTokenAndStart(final Fragment fragment) {
         final ApiDownloader task = new ApiDownloader(fragment.getActivity(), ListFragment.lameStatic.dbHelper,
-                null, MainActivity.TOKEN_URL, true, false, true, AbstractApiRequest.REQUEST_POST,
+                null, UrlConfig.TOKEN_URL, true, false, true, AbstractApiRequest.REQUEST_POST,
                 new ApiListener() {
                     @Override
                     public void requestComplete(final JSONObject json, final boolean isCache)

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractProgressApiRequest.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractProgressApiRequest.java
@@ -1,5 +1,6 @@
 package net.wigle.wigleandroid.background;
 
+import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import androidx.fragment.app.Fragment;
@@ -7,14 +8,12 @@ import androidx.fragment.app.FragmentActivity;
 
 import net.wigle.wigleandroid.db.DatabaseHelper;
 import net.wigle.wigleandroid.ListFragment;
-import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.TokenAccess;
-import net.wigle.wigleandroid.WiGLEAuthException;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 import net.wigle.wigleandroid.util.UrlConfig;
 
 import org.json.JSONException;
-import org.json.JSONObject;
 
 /**
  * downloadTokenAndStart abstract parent for API connections that have a progress dialog
@@ -32,47 +31,46 @@ public abstract class AbstractProgressApiRequest extends AbstractApiRequest {
     }
 
     @Override
-    /**
+    /*
      * need to DRY this up vs. the exception-based version in ApiDownloader
      */
     protected void downloadTokenAndStart(final Fragment fragment) {
         final ApiDownloader task = new ApiDownloader(fragment.getActivity(), ListFragment.lameStatic.dbHelper,
                 null, UrlConfig.TOKEN_URL, true, false, true, AbstractApiRequest.REQUEST_POST,
-                new ApiListener() {
-                    @Override
-                    public void requestComplete(final JSONObject json, final boolean isCache)
-                            throws WiGLEAuthException {
-                        try {
-                            // {"success": true, "authname": "AID...", "token": "..."}
-                            if (json.getBoolean("success")) {
-                                final String authname = json.getString("authname");
-                                final String token = json.getString("token");
+                (json, isCache) -> {
+                    try {
+                        // {"success": true, "authname": "AID...", "token": "..."}
+                        if (json.getBoolean("success")) {
+                            final String authname = json.getString("authname");
+                            final String token = json.getString("token");
+                            final Context c = fragment.getContext();
+                            if (null != c) {
                                 final SharedPreferences prefs = fragment.getContext()
-                                        .getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+                                        .getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
                                 final SharedPreferences.Editor edit = prefs.edit();
-                                edit.putString(ListFragment.PREF_AUTHNAME, authname);
+                                edit.putString(PreferenceKeys.PREF_AUTHNAME, authname);
                                 edit.apply();
                                 TokenAccess.setApiToken(prefs, token);
                                 // execute ourselves, the pending task
                                 start();
-                            } else if (json.has("credential_0")) {
-                                String message = "login failed for " +
-                                        json.getString("credential_0");
-                                Logging.warn(message);
-                                final Bundle bundle = new Bundle();
-                                sendBundledMessage(Status.BAD_LOGIN.ordinal(), bundle);
-                            } else {
-                                final Bundle bundle = new Bundle();
-                                sendBundledMessage(Status.BAD_LOGIN.ordinal(), bundle);
                             }
-                        } catch (final JSONException ex) {
+                        } else if (json.has("credential_0")) {
+                            String message = "login failed for " +
+                                    json.getString("credential_0");
+                            Logging.warn(message);
                             final Bundle bundle = new Bundle();
                             sendBundledMessage(Status.BAD_LOGIN.ordinal(), bundle);
-                        } catch (final Exception e) {
-                            Logging.error("Failed to log in " + e + " payload: " + json, e);
+                        } else {
                             final Bundle bundle = new Bundle();
                             sendBundledMessage(Status.BAD_LOGIN.ordinal(), bundle);
                         }
+                    } catch (final JSONException ex) {
+                        final Bundle bundle = new Bundle();
+                        sendBundledMessage(Status.BAD_LOGIN.ordinal(), bundle);
+                    } catch (final Exception e) {
+                        Logging.error("Failed to log in " + e + " payload: " + json, e);
+                        final Bundle bundle = new Bundle();
+                        sendBundledMessage(Status.BAD_LOGIN.ordinal(), bundle);
                     }
                 });
         task.start();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/CsvDownloader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/CsvDownloader.java
@@ -5,7 +5,6 @@ import android.os.Bundle;
 
 import androidx.fragment.app.FragmentActivity;
 
-import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.R;
 import net.wigle.wigleandroid.WiGLEAuthException;
 import net.wigle.wigleandroid.db.DatabaseHelper;
@@ -14,6 +13,7 @@ import net.wigle.wigleandroid.util.LocationCsv;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.NetworkCsv;
 import net.wigle.wigleandroid.util.FileUtility;
+import net.wigle.wigleandroid.util.UrlConfig;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -42,7 +42,7 @@ public class CsvDownloader extends AbstractProgressApiRequest {
 
     public CsvDownloader(final FragmentActivity context, final DatabaseHelper dbHelper,
                          final String transid, final ApiListener listener) {
-        super(context, dbHelper, "CsvDL", transid+CSV_EXT, MainActivity.CSV_TRANSID_URL_STEM+transid, false,
+        super(context, dbHelper, "CsvDL", transid+CSV_EXT, UrlConfig.CSV_TRANSID_URL_STEM+transid, false,
                 true, true, false, AbstractApiRequest.REQUEST_GET, listener, true);
         }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/HttpFileUploader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/HttpFileUploader.java
@@ -11,9 +11,9 @@ import java.nio.CharBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.channels.WritableByteChannel;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
@@ -27,7 +27,6 @@ import android.os.Handler;
  */
 @Deprecated
 final class HttpFileUploader {
-    public static final String ENCODING = "UTF-8";
     public static final String LINE_END = "\r\n";
     public static final String TWO_HYPHENS = "--";
 
@@ -53,7 +52,7 @@ final class HttpFileUploader {
                                  final Handler handler, final long filesize)
                                 throws IOException {
 
-        String retval = null;
+        String retval;
         HttpURLConnection conn = null;
 
         try {
@@ -103,7 +102,7 @@ final class HttpFileUploader {
             header.append( LINE_END );
 
             Logging.info( "About to write headers, length: " + header.length() );
-            CharsetEncoder enc = Charset.forName( ENCODING ).newEncoder();
+            CharsetEncoder enc = StandardCharsets.UTF_8.newEncoder();
             CharBuffer cbuff = CharBuffer.allocate( 1024 );
             ByteBuffer bbuff = ByteBuffer.allocate( 1024 );
             writeString( wbc, header.toString(), enc, cbuff, bbuff );
@@ -156,7 +155,7 @@ final class HttpFileUploader {
             final byte[] buffer = new byte[1024];
 
             while( ( ch = is.read( buffer ) ) != -1 ) {
-                b.append( new String( buffer, 0, ch, ENCODING ) );
+                b.append( new String( buffer, 0, ch, StandardCharsets.UTF_8 ) );
             }
             retval = b.toString();
             // MainActivity.info( "Response: " + retval );

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlDownloader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlDownloader.java
@@ -8,6 +8,7 @@ import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.WiGLEAuthException;
 import net.wigle.wigleandroid.util.FileUtility;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.UrlConfig;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -28,7 +29,7 @@ public class KmlDownloader extends AbstractProgressApiRequest {
 
     public KmlDownloader(final FragmentActivity context, final DatabaseHelper dbHelper /*TODO: not needed?*/,
                                final String transid, final ApiListener listener) {
-        super(context, dbHelper, "KmlDL", transid+KML_EXT, MainActivity.KML_TRANSID_URL_STEM+transid, false,
+        super(context, dbHelper, "KmlDL", transid+KML_EXT, UrlConfig.KML_TRANSID_URL_STEM+transid, false,
                 true, true, false, AbstractApiRequest.REQUEST_GET, listener, true);
         }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlWriter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlWriter.java
@@ -79,11 +79,14 @@ public class KmlWriter extends AbstractBackgroundTask {
             if ( this.networks == null ) {
                 cursor = dbHelper.networkIterator(DatabaseHelper.NetworkFilter.WIFI);
                 long wifiCount = writeKmlFromCursor( fos, cursor, dateFormat, 0, dbHelper.getNetworkCount(), bundle);
+                cursor.close();
                 cursor = dbHelper.networkIterator(DatabaseHelper.NetworkFilter.CELL);
                 ObservationUploader.writeFos( fos, "</Folder>\n<Folder><name>Cellular Networks</name>\n" );
+                cursor.close();
                 long cellCount = writeKmlFromCursor( fos, cursor, dateFormat, wifiCount, dbHelper.getNetworkCount(), bundle);
                 cursor = dbHelper.networkIterator(DatabaseHelper.NetworkFilter.BT);
                 ObservationUploader.writeFos( fos, "</Folder>\n<Folder><name>Bluetooth Networks</name>\n" );
+                cursor.close();
                 long btCount = writeKmlFromCursor( fos, cursor, dateFormat, wifiCount+cellCount, dbHelper.getNetworkCount(), bundle);
                 Logging.info("Full KML Export: "+dbHelper.getNetworkCount()+" per db, wrote "+(btCount+cellCount+wifiCount)+" total.");
             } else {
@@ -96,7 +99,6 @@ public class KmlWriter extends AbstractBackgroundTask {
                 for (String network : networks) {
                     // DEBUG: MainActivity.info( "network: " + network );
                     cursor = dbHelper.getSingleNetwork(network, DatabaseHelper.NetworkFilter.WIFI);
-
                     final long found = writeKmlFromCursor(fos, cursor, dateFormat, count, totalNets, bundle);
                     // ALIBI: assume this was a cell net, if it didn't match for WiFi - avoid full second iteration
                     if (0L == found) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationImporter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationImporter.java
@@ -16,6 +16,7 @@ import net.wigle.wigleandroid.WiGLEAuthException;
 import net.wigle.wigleandroid.model.Network;
 import net.wigle.wigleandroid.model.NetworkType;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.UrlConfig;
 
 
 import java.io.BufferedReader;
@@ -31,7 +32,7 @@ public class ObservationImporter extends AbstractProgressApiRequest {
 
     public ObservationImporter(final FragmentActivity context,
                                final DatabaseHelper dbHelper, final ApiListener listener) {
-        super(context, dbHelper, "HttpDL", "observed-cache.json", MainActivity.OBSERVED_URL, false,
+        super(context, dbHelper, "HttpDL", "observed-cache.json", UrlConfig.OBSERVED_URL, false,
                 true, true, false,
                 AbstractApiRequest.REQUEST_GET, listener, true);
     }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationImporter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationImporter.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.databind.MappingJsonFactory;
 
 import net.wigle.wigleandroid.db.DatabaseHelper;
 import net.wigle.wigleandroid.ListFragment;
-import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.WiGLEAuthException;
 import net.wigle.wigleandroid.model.Network;
 import net.wigle.wigleandroid.model.NetworkType;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
@@ -23,6 +23,7 @@ import net.wigle.wigleandroid.WiGLEAuthException;
 import net.wigle.wigleandroid.model.Network;
 import net.wigle.wigleandroid.util.FileUtility;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.UrlConfig;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -79,7 +80,7 @@ public class ObservationUploader extends AbstractProgressApiRequest {
     public ObservationUploader(final FragmentActivity context,
                                final DatabaseHelper dbHelper, final ApiListener listener,
                                boolean justWriteFile, boolean writeEntireDb, boolean writeRun) {
-        super(context, dbHelper, "ApiUL", null, MainActivity.FILE_POST_URL, false,
+        super(context, dbHelper, "ApiUL", null, UrlConfig.FILE_POST_URL, false,
                 true, false, false,
                 AbstractApiRequest.REQUEST_POST, listener, true);
         this.justWriteFile = justWriteFile;
@@ -227,7 +228,7 @@ public class ObservationUploader extends AbstractProgressApiRequest {
                 Logging.info("anonymous upload");
             }
 
-            final String response = OkFileUploader.upload(MainActivity.FILE_POST_URL, absolutePath,
+            final String response = OkFileUploader.upload(UrlConfig.FILE_POST_URL, absolutePath,
                     "file", params, authName, token, getHandler());
 
             if ( ! prefs.getBoolean(ListFragment.PREF_DONATE, false) ) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/OkFileUploader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/OkFileUploader.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import okhttp3.Call;
 import okhttp3.Credentials;
 import okhttp3.MediaType;
 import okhttp3.MultipartBody;
@@ -38,9 +37,8 @@ public class OkFileUploader {
     private OkFileUploader() {
     }
 
-
     /**
-     * simple upload method. Analogous to {@link net.wigle.wigleandroid.background.HttpFileUploader#upload HttpFileUploader.upload(...)}
+     * simple upload method. Replace the old to {@link net.wigle.wigleandroid.background.HttpFileUploader#upload HttpFileUploader.upload(...)}
      * @param urlString the URL string for the target
      * @param filename the file name on-device to upload
      * @param fileParamName parameter name for the file
@@ -49,7 +47,7 @@ public class OkFileUploader {
      * @param authToken password parameter for Basic authentication
      * @param handler the callback for progress or completion
      * @return string payload (JSON) from the upload POST
-     * @throws IOException
+     * @throws IOException an IOException if the upload fails
      */
     public static String upload(final String urlString, final String filename, final String fileParamName,
                                 final Map<String, String> params,
@@ -62,8 +60,7 @@ public class OkFileUploader {
         MultipartBody.Builder builder = new MultipartBody.Builder()
                 .setType(MultipartBody.FORM)
                 .addFormDataPart(fileParamName, filename,
-                        RequestBody.create(MediaType.parse("application/octet-stream"),
-                                new File(filename)));
+                        RequestBody.create(new File(filename), MediaType.parse("application/octet-stream")));
 
         // add params if present
         if (!params.isEmpty()) {
@@ -78,17 +75,14 @@ public class OkFileUploader {
 
         // progress-aware requestBody
         CountingRequestBody countingBody
-                = new CountingRequestBody(requestBody, new CountingRequestBody.UploadProgressListener() {
-            @Override
-            public void onRequestProgress(long bytesWritten, long contentLength) {
-                int progress = (int)((bytesWritten*1000) / contentLength );
-                Logging.info("progress: "+ progress + "("+bytesWritten +"/"+contentLength+")");
-                if ( handler != null && progress >= 0 ) {
-                    //TODO: we can improve this, but minimal risk dictates reuse of old technique to start
-                    handler.sendEmptyMessage( BackgroundGuiHandler.WRITING_PERCENT_START + progress );
-                }
-            }
-        });
+                = new CountingRequestBody(requestBody, (bytesWritten, contentLength) -> {
+                    int progress = (int)((bytesWritten*1000) / contentLength );
+                    Logging.info("progress: "+ progress + "("+bytesWritten +"/"+contentLength+")");
+                    if ( handler != null && progress >= 0 ) {
+                        //TODO: we can improve this, but minimal risk dictates reuse of old technique to start
+                        handler.sendEmptyMessage( BackgroundGuiHandler.WRITING_PERCENT_START + progress );
+                    }
+                });
 
         // authorization if necessary
         Request request;
@@ -109,15 +103,13 @@ public class OkFileUploader {
                 .connectTimeout(30, TimeUnit.SECONDS)
                 .writeTimeout(30, TimeUnit.SECONDS)
                 .readTimeout(30, TimeUnit.SECONDS).build();
-
-        Call call = client.newCall(request);
-        Response response = call.execute();
-
-        if (response.code() == 200) {
-            return response.body().string();
-        } else {
-            return null;
+        try (Response response = client.newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                Logging.error("Failed to upload file:"+response.code()+" "+response.message());
+                return null;
+            } else {
+                return response.body().string();
+            }
         }
-
     }
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/WiGLERegistrationInterface.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/WiGLERegistrationInterface.java
@@ -4,10 +4,10 @@ import android.app.Activity;
 import android.content.SharedPreferences;
 import android.webkit.JavascriptInterface;
 
-import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.TokenAccess;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 /**
  * Created by arkasha on 1/8/18.
@@ -23,21 +23,17 @@ public class WiGLERegistrationInterface {
 
     /**
      * update the users authentication preferences from JS running in the page
-     *
-     * @param userName
-     * @param userId
-     * @param token
      */
     @JavascriptInterface
     public void registrationComplete(final String userName, final String userId, final String token) {
 
         Logging.info("Successful registration for "+userName+ " auth ID: "+userId);
         final SharedPreferences prefs = MainActivity.getMainActivity().
-                getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+                getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
         final SharedPreferences.Editor editor = prefs.edit();
-        editor.putString(ListFragment.PREF_USERNAME, userName);
-        editor.putString(ListFragment.PREF_AUTHNAME, userId);
-        editor.putBoolean(ListFragment.PREF_BE_ANONYMOUS, false);
+        editor.putString(PreferenceKeys.PREF_USERNAME, userName);
+        editor.putString(PreferenceKeys.PREF_AUTHNAME, userId);
+        editor.putBoolean(PreferenceKeys.PREF_BE_ANONYMOUS, false);
         editor.apply();
         TokenAccess.setApiToken(prefs, token);
         activity.finish();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
@@ -649,6 +649,9 @@ public final class DatabaseHelper extends Thread {
                     if ( insertRoute != null ) {
                         insertRoute.close();
                     }
+                    if ( updateNetworkType != null ) {
+                        updateNetworkType.close();
+                    }
                     if ( db.isOpen() ) {
                         db.close();
                     }
@@ -1424,15 +1427,15 @@ public final class DatabaseHelper extends Thread {
     }
 
     public Cursor getCurrentVisibleRouteIterator(SharedPreferences prefs) throws DBException{
-        Logging.info("currentRouteIterator");
-        checkDB();
-        if (prefs == null || !prefs.getBoolean(PreferenceKeys.PREF_VISUALIZE_ROUTE, false)) {
-            return null;
-        }
-        boolean logRoutes = prefs.getBoolean(PreferenceKeys.PREF_LOG_ROUTES, false);
-        final long visibleRouteId = logRoutes?prefs.getLong(PreferenceKeys.PREF_ROUTE_DB_RUN, 0L):0L;
-        final String[] args = new String[]{String.valueOf(visibleRouteId)};
-        return db.rawQuery( "SELECT lat,lon FROM route WHERE run_id = ?", args );
+            Logging.info("currentRouteIterator");
+            checkDB();
+            if (prefs == null || !prefs.getBoolean(PreferenceKeys.PREF_VISUALIZE_ROUTE, false)) {
+                return null;
+            }
+            boolean logRoutes = prefs.getBoolean(PreferenceKeys.PREF_LOG_ROUTES, false);
+            final long visibleRouteId = logRoutes ? prefs.getLong(PreferenceKeys.PREF_ROUTE_DB_RUN, 0L) : 0L;
+            final String[] args = new String[]{String.valueOf(visibleRouteId)};
+            return db.rawQuery("SELECT lat,lon FROM route WHERE run_id = ?", args);
     }
 
     public Cursor getSingleNetwork( final String bssid ) throws DBException {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import net.wigle.wigleandroid.DataFragment.BackupTask;
 import net.wigle.wigleandroid.ErrorReportActivity;
-import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.background.QueryThread;
 import net.wigle.wigleandroid.model.ConcurrentLinkedHashMap;
@@ -39,6 +38,7 @@ import net.wigle.wigleandroid.model.NetworkType;
 import net.wigle.wigleandroid.model.Pair;
 import net.wigle.wigleandroid.util.FileUtility;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 import android.content.Context;
 import android.content.Intent;
@@ -513,7 +513,7 @@ public final class DatabaseHelper extends Thread {
                 db.execSQL(LOCATION_CREATE);
                 // new database, reset a marker, if any
                 final Editor edit = prefs.edit();
-                edit.putLong( ListFragment.PREF_DB_MARKER, 0L );
+                edit.putLong( PreferenceKeys.PREF_DB_MARKER, 0L );
                 edit.apply();
             }
             catch ( final SQLiteException ex ) {
@@ -527,7 +527,7 @@ public final class DatabaseHelper extends Thread {
                 db.execSQL(ROUTE_CREATE);
                 // new database, start with route Zero
                 final Editor edit = prefs.edit();
-                edit.putLong( ListFragment.PREF_ROUTE_DB_RUN, 0L );
+                edit.putLong( PreferenceKeys.PREF_ROUTE_DB_RUN, 0L );
                 edit.apply();
             }
             catch ( final SQLiteException ex ) {
@@ -1272,25 +1272,25 @@ public final class DatabaseHelper extends Thread {
     }
 
     private void setupMaxidDebug( final long locCount ) {
-        final SharedPreferences prefs = context.getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
-        final long maxid = prefs.getLong( ListFragment.PREF_DB_MARKER, -1L );
+        final SharedPreferences prefs = context.getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0 );
+        final long maxid = prefs.getLong( PreferenceKeys.PREF_DB_MARKER, -1L );
         final Editor edit = prefs.edit();
-        final long oldMaxDb = prefs.getLong( ListFragment.PREF_MAX_DB, locCount );
-        edit.putLong( ListFragment.PREF_MAX_DB, locCount );
+        final long oldMaxDb = prefs.getLong( PreferenceKeys.PREF_MAX_DB, locCount );
+        edit.putLong( PreferenceKeys.PREF_MAX_DB, locCount );
 
         if ( maxid == -1L ) {
             if ( locCount > 0 ) {
                 // there is no preference set, yet there are locations, this is likely
                 // a developer testing a new install on an old db, so set the pref.
                 Logging.info( "setting db marker to: " + locCount );
-                edit.putLong( ListFragment.PREF_DB_MARKER, locCount );
+                edit.putLong( PreferenceKeys.PREF_DB_MARKER, locCount );
             }
         }
         else if (maxid > locCount || (maxid == 0 && oldMaxDb == 0 && locCount > 10000)) {
             final long newMaxid = Math.max(0, locCount - 10000);
             Logging.warn("db marker: " + maxid + " greater than location count: " + locCount
                     + ", setting to: " + newMaxid);
-            edit.putLong( ListFragment.PREF_DB_MARKER, newMaxid );
+            edit.putLong( PreferenceKeys.PREF_DB_MARKER, newMaxid );
         }
         edit.apply();
     }
@@ -1426,11 +1426,11 @@ public final class DatabaseHelper extends Thread {
     public Cursor getCurrentVisibleRouteIterator(SharedPreferences prefs) throws DBException{
         Logging.info("currentRouteIterator");
         checkDB();
-        if (prefs == null || !prefs.getBoolean(ListFragment.PREF_VISUALIZE_ROUTE, false)) {
+        if (prefs == null || !prefs.getBoolean(PreferenceKeys.PREF_VISUALIZE_ROUTE, false)) {
             return null;
         }
-        boolean logRoutes = prefs.getBoolean(ListFragment.PREF_LOG_ROUTES, false);
-        final long visibleRouteId = logRoutes?prefs.getLong(ListFragment.PREF_ROUTE_DB_RUN, 0L):0L;
+        boolean logRoutes = prefs.getBoolean(PreferenceKeys.PREF_LOG_ROUTES, false);
+        final long visibleRouteId = logRoutes?prefs.getLong(PreferenceKeys.PREF_ROUTE_DB_RUN, 0L):0L;
         final String[] args = new String[]{String.valueOf(visibleRouteId)};
         return db.rawQuery( "SELECT lat,lon FROM route WHERE run_id = ?", args );
     }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/MxcDatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/MxcDatabaseHelper.java
@@ -17,7 +17,6 @@ import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.R;
 import net.wigle.wigleandroid.model.MccMncRecord;
 import net.wigle.wigleandroid.util.FileUtility;
-import net.wigle.wigleandroid.util.InsufficientSpaceException;
 import net.wigle.wigleandroid.util.Logging;
 
 import java.io.File;
@@ -70,7 +69,7 @@ public class MxcDatabaseHelper extends SQLiteOpenHelper {
 
     private boolean isPresent() {
         final File mxcFile = getMxcFile();
-        return mxcFile != null && mxcFile.exists() && mxcFile.canRead();
+        return mxcFile.exists() && mxcFile.canRead();
     }
 
     public void implantMxcDatabase(final Context context, final Boolean isFinishing){
@@ -154,7 +153,6 @@ public class MxcDatabaseHelper extends SQLiteOpenHelper {
 
     public MccMncRecord networkRecordForMccMnc(final String mcc, final String mnc) throws SQLException {
         Cursor cursor = null;
-
         // ALIBI: old, incompatible DB implementation
         if (android.os.Build.VERSION.SDK_INT <= 19) {
             return null;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/BluetoothReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/BluetoothReceiver.java
@@ -426,13 +426,11 @@ public final class BluetoothReceiver extends BroadcastReceiver {
             } catch (SecurityException se) {
                 Logging.error("No permission for bluetoothAdapter.cancelDiscovery", se);
             }
-            //if (mainActivity.get() != null) {
-                final boolean showCurrent = prefs.getBoolean(PreferenceKeys.PREF_SHOW_CURRENT, true);
-                if (listAdapter != null && showCurrent) {
-                    listAdapter.get().clearBluetoothLe();
-                    listAdapter.get().clearBluetooth();
-                }
-            //}
+            final boolean showCurrent = prefs.getBoolean(PreferenceKeys.PREF_SHOW_CURRENT, true);
+            if (listAdapter != null && showCurrent) {
+                listAdapter.get().clearBluetoothLe();
+                listAdapter.get().clearBluetooth();
+            }
 
 
             if (Build.VERSION.SDK_INT >= 21) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/BluetoothReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/BluetoothReceiver.java
@@ -167,7 +167,7 @@ public final class BluetoothReceiver extends BroadcastReceiver {
                     final MainActivity m = MainActivity.getMainActivity();
                     Location location = null;
                     if (m != null) {
-                        final GNSSListener gpsListener = MainActivity.getMainActivity().getGPSListener();
+                        final GNSSListener gpsListener = m.getGPSListener();
                         //DEBUG: Logging.info("LE scanResult: " + scanResult + " callbackType: " + callbackType);
                         if (gpsListener != null) {
                             final long gpsTimeout = prefs.getLong(PreferenceKeys.PREF_GPS_TIMEOUT, GNSSListener.GPS_TIMEOUT_DEFAULT);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/BluetoothReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/BluetoothReceiver.java
@@ -127,7 +127,7 @@ public final class BluetoothReceiver extends BroadcastReceiver {
     private final Set<String> runNetworks = Collections.synchronizedSet(unsafeRunNetworks);
 
     private SetNetworkListAdapter listAdapter;
-    private final ScanCallback scanCallback;
+    private ScanCallback scanCallback;
     private final SharedPreferences prefs;
 
     private Handler bluetoothTimer;
@@ -457,6 +457,11 @@ public final class BluetoothReceiver extends BroadcastReceiver {
                 }
             }
         }
+    }
+
+    public void close() {
+        this.listAdapter = null;
+        this.scanCallback = null;
     }
 
     /**

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/StartWigleAtBootReciever.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/StartWigleAtBootReciever.java
@@ -5,8 +5,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 
-import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.MainActivity;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 public class StartWigleAtBootReciever extends BroadcastReceiver {
 
@@ -16,8 +16,8 @@ public class StartWigleAtBootReciever extends BroadcastReceiver {
             return;
         }
         Intent serviceIntent = new Intent(context, MainActivity.class);
-        final SharedPreferences prefs = context.getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
-        final boolean mustStart = prefs.getBoolean( ListFragment.PREF_START_AT_BOOT, false );
+        final SharedPreferences prefs = context.getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0 );
+        final boolean mustStart = prefs.getBoolean( PreferenceKeys.PREF_START_AT_BOOT, false );
         if (mustStart && Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
             serviceIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             context.startActivity(serviceIntent);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
@@ -28,8 +28,8 @@ import net.wigle.wigleandroid.ui.UINumberFormat;
 import net.wigle.wigleandroid.util.CellNetworkLegend;
 import net.wigle.wigleandroid.ui.WiGLEToast;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
-import android.annotation.TargetApi;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -156,7 +156,7 @@ public class WifiReceiver extends BroadcastReceiver {
         Logging.info("wifi receive, results: " + (results == null ? null : results.size()));
 
         long nonstopScanRequestTime = Long.MIN_VALUE;
-        final SharedPreferences prefs = mainActivity.getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
+        final SharedPreferences prefs = mainActivity.getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0 );
         final long period = getScanPeriod();
         if ( period == 0 ) {
             // treat as "continuous", so request scan in here
@@ -199,7 +199,7 @@ public class WifiReceiver extends BroadcastReceiver {
             lastHaveLocationTime = now;
         }
 
-        final boolean showCurrent = prefs.getBoolean( ListFragment.PREF_SHOW_CURRENT, true );
+        final boolean showCurrent = prefs.getBoolean( PreferenceKeys.PREF_SHOW_CURRENT, true );
         if ( showCurrent && listAdapter != null ) {
             listAdapter.clearWifiAndCell();
         }
@@ -211,13 +211,13 @@ public class WifiReceiver extends BroadcastReceiver {
         int resultSize = 0;
         int newWifiForRun = 0;
 
-        final boolean ssidSpeak = prefs.getBoolean( ListFragment.PREF_SPEAK_SSID, false )
+        final boolean ssidSpeak = prefs.getBoolean( PreferenceKeys.PREF_SPEAK_SSID, false )
                 && ! mainActivity.isMuted();
 
         //TODO: should we memoize the ssidMatcher in the MainActivity state as well?
-        final Matcher ssidMatcher = FilterMatcher.getSsidFilterMatcher( prefs, ListFragment.FILTER_PREF_PREFIX );
-        final Matcher bssidMatcher = mainActivity.getBssidFilterMatcher( ListFragment.PREF_EXCLUDE_DISPLAY_ADDRS );
-        final Matcher bssidDbMatcher = mainActivity.getBssidFilterMatcher( ListFragment.PREF_EXCLUDE_LOG_ADDRS );
+        final Matcher ssidMatcher = FilterMatcher.getSsidFilterMatcher( prefs, PreferenceKeys.FILTER_PREF_PREFIX );
+        final Matcher bssidMatcher = mainActivity.getBssidFilterMatcher( PreferenceKeys.PREF_EXCLUDE_DISPLAY_ADDRS );
+        final Matcher bssidDbMatcher = mainActivity.getBssidFilterMatcher( PreferenceKeys.PREF_EXCLUDE_LOG_ADDRS );
 
         // can be null on shutdown
         if ( results != null ) {
@@ -251,7 +251,7 @@ public class WifiReceiver extends BroadcastReceiver {
 
                 // if we're showing current, or this was just added, put on the list
                 if ( showCurrent || added ) {
-                    if ( FilterMatcher.isOk( ssidMatcher, bssidMatcher, prefs, ListFragment.FILTER_PREF_PREFIX, network ) ) {
+                    if ( FilterMatcher.isOk( ssidMatcher, bssidMatcher, prefs, PreferenceKeys.FILTER_PREF_PREFIX, network ) ) {
                         if (listAdapter != null) {
                             listAdapter.addWiFi( network );
                         }
@@ -318,8 +318,8 @@ public class WifiReceiver extends BroadcastReceiver {
         prevNewNetCount = newWifiCount;
 
         if ( ! mainActivity.isMuted() ) {
-            final boolean playRun = prefs.getBoolean( ListFragment.PREF_FOUND_SOUND, true );
-            final boolean playNew = prefs.getBoolean( ListFragment.PREF_FOUND_NEW_SOUND, true );
+            final boolean playRun = prefs.getBoolean( PreferenceKeys.PREF_FOUND_SOUND, true );
+            final boolean playNew = prefs.getBoolean( PreferenceKeys.PREF_FOUND_NEW_SOUND, true );
             if ( newNetDiff > 0 && playNew ) {
                 mainActivity.playNewNetSound();
             }
@@ -343,7 +343,7 @@ public class WifiReceiver extends BroadcastReceiver {
                 final Network cellNetwork = cellNetworks.get(key);
                 if (cellNetwork != null) {
                     resultSize++;
-                    if (showCurrent && listAdapter != null && FilterMatcher.isOk(ssidMatcher, bssidMatcher, prefs, ListFragment.FILTER_PREF_PREFIX, cellNetwork)) {
+                    if (showCurrent && listAdapter != null && FilterMatcher.isOk(ssidMatcher, bssidMatcher, prefs, PreferenceKeys.FILTER_PREF_PREFIX, cellNetwork)) {
                         listAdapter.addCell(cellNetwork);
                     }
                     if (runNetworks.size() > preCellForRun) {
@@ -423,7 +423,7 @@ public class WifiReceiver extends BroadcastReceiver {
             ssidSpeaker.speak();
         }
 
-        final long speechPeriod = prefs.getLong( ListFragment.PREF_SPEECH_PERIOD, MainActivity.DEFAULT_SPEECH_PERIOD );
+        final long speechPeriod = prefs.getLong( PreferenceKeys.PREF_SPEECH_PERIOD, MainActivity.DEFAULT_SPEECH_PERIOD );
         if ( speechPeriod != 0 && now - previousTalkTime > speechPeriod * 1000L ) {
             doAnnouncement( preQueueSize, newWifiCount, newCellCount, now );
         }
@@ -500,7 +500,7 @@ public class WifiReceiver extends BroadcastReceiver {
             if (MainActivity.DEBUG_CELL_DATA) {
                 Logging.info("cell: " + cellInfo + " class: " + cellInfo.getClass().getCanonicalName());
             }
-            GsmOperator g = null;
+            GsmOperator g;
             try {
                 switch (cellInfo.getClass().getSimpleName()) {
                     case "CellInfoCdma":
@@ -715,37 +715,37 @@ public class WifiReceiver extends BroadcastReceiver {
      * Voice announcement method for scan
      */
     private void doAnnouncement( int preQueueSize, long newWifiCount, long newCellCount, long now ) {
-        final SharedPreferences prefs = mainActivity.getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
+        final SharedPreferences prefs = mainActivity.getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0 );
         StringBuilder builder = new StringBuilder();
 
-        if ( mainActivity.getGPSListener().getCurrentLocation() == null && prefs.getBoolean( ListFragment.PREF_SPEECH_GPS, true ) ) {
+        if ( mainActivity.getGPSListener().getCurrentLocation() == null && prefs.getBoolean( PreferenceKeys.PREF_SPEECH_GPS, true ) ) {
             builder.append(mainActivity.getString(R.string.tts_no_gps_fix)).append(", ");
         }
 
         // run, new, queue, miles, time, battery
-        if ( prefs.getBoolean( ListFragment.PREF_SPEAK_RUN, true ) ) {
+        if ( prefs.getBoolean( PreferenceKeys.PREF_SPEAK_RUN, true ) ) {
             builder.append(mainActivity.getString(R.string.run)).append(" ")
                     .append(runNetworks.size()).append( ", " );
         }
-        if ( prefs.getBoolean( ListFragment.PREF_SPEAK_NEW_WIFI, true ) ) {
+        if ( prefs.getBoolean( PreferenceKeys.PREF_SPEAK_NEW_WIFI, true ) ) {
             builder.append(mainActivity.getString(R.string.tts_new_wifi)).append(" ")
                     .append(newWifiCount).append( ", " );
         }
-        if ( prefs.getBoolean( ListFragment.PREF_SPEAK_NEW_CELL, true ) ) {
+        if ( prefs.getBoolean( PreferenceKeys.PREF_SPEAK_NEW_CELL, true ) ) {
             builder.append(mainActivity.getString(R.string.tts_new_cell)).append(" ")
                     .append(newCellCount).append( ", " );
         }
-        if ( preQueueSize > 0 && prefs.getBoolean( ListFragment.PREF_SPEAK_QUEUE, true ) ) {
+        if ( preQueueSize > 0 && prefs.getBoolean( PreferenceKeys.PREF_SPEAK_QUEUE, true ) ) {
             builder.append(mainActivity.getString(R.string.tts_queue)).append(" ")
                     .append(preQueueSize).append( ", " );
         }
-        if ( prefs.getBoolean( ListFragment.PREF_SPEAK_MILES, true ) ) {
-            final float dist = prefs.getFloat( ListFragment.PREF_DISTANCE_RUN, 0f );
+        if ( prefs.getBoolean( PreferenceKeys.PREF_SPEAK_MILES, true ) ) {
+            final float dist = prefs.getFloat( PreferenceKeys.PREF_DISTANCE_RUN, 0f );
             final String distString = UINumberFormat.metersToString(prefs, numberFormat1, mainActivity, dist, false );
             builder.append(mainActivity.getString(R.string.tts_from)).append(" ")
                     .append(distString).append( ", " );
         }
-        if ( prefs.getBoolean( ListFragment.PREF_SPEAK_TIME, true ) ) {
+        if ( prefs.getBoolean( PreferenceKeys.PREF_SPEAK_TIME, true ) ) {
             String time = timeFormat.format( new Date() );
             // time is hard to say.
             time = time.replace(" 00", " " + mainActivity.getString(R.string.tts_o_clock));
@@ -753,7 +753,7 @@ public class WifiReceiver extends BroadcastReceiver {
             builder.append( time ).append( ", " );
         }
         final int batteryLevel = mainActivity.getBatteryLevelReceiver().getBatteryLevel();
-        if ( batteryLevel >= 0 && prefs.getBoolean( ListFragment.PREF_SPEAK_BATTERY, true ) ) {
+        if ( batteryLevel >= 0 && prefs.getBoolean( PreferenceKeys.PREF_SPEAK_BATTERY, true ) ) {
             builder.append(mainActivity.getString(R.string.tts_battery)).append(" ").append(batteryLevel).append(" ").append(mainActivity.getString(R.string.tts_percent)).append(", ");
         }
 
@@ -816,9 +816,9 @@ public class WifiReceiver extends BroadcastReceiver {
      * get the scan period based on preferences and current speed
      */
     public long getScanPeriod() {
-        final SharedPreferences prefs = mainActivity.getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
+        final SharedPreferences prefs = mainActivity.getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0 );
 
-        String scanPref = ListFragment.PREF_SCAN_PERIOD;
+        String scanPref = PreferenceKeys.PREF_SCAN_PERIOD;
         long defaultRate = MainActivity.SCAN_DEFAULT;
         // if over 5 mph
         Location location = null;
@@ -827,11 +827,11 @@ public class WifiReceiver extends BroadcastReceiver {
             location = gpsListener.getCurrentLocation();
         }
         if ( location != null && location.getSpeed() >= 2.2352f ) {
-            scanPref = ListFragment.PREF_SCAN_PERIOD_FAST;
+            scanPref = PreferenceKeys.PREF_SCAN_PERIOD_FAST;
             defaultRate = MainActivity.SCAN_FAST_DEFAULT;
         }
         else if ( location == null || location.getSpeed() < 0.1f ) {
-            scanPref = ListFragment.PREF_SCAN_PERIOD_STILL;
+            scanPref = PreferenceKeys.PREF_SCAN_PERIOD_STILL;
             defaultRate = MainActivity.SCAN_STILL_DEFAULT;
         }
         return prefs.getLong( scanPref, defaultRate );
@@ -873,16 +873,17 @@ public class WifiReceiver extends BroadcastReceiver {
             } else {
                 final long sinceLastScan = now - lastScanResponseTime;
                 Logging.info("startScan returned " + success + ". last response seconds ago: " + sinceLastScan/1000d);
-                final SharedPreferences prefs = mainActivity.getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
+                final SharedPreferences prefs = mainActivity.getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0 );
                 final long resetWifiPeriod = prefs.getLong(
-                        ListFragment.PREF_RESET_WIFI_PERIOD, MainActivity.DEFAULT_RESET_WIFI_PERIOD );
+                        PreferenceKeys.PREF_RESET_WIFI_PERIOD, MainActivity.DEFAULT_RESET_WIFI_PERIOD );
 
                 if ( resetWifiPeriod > 0 && sinceLastScan > resetWifiPeriod ) {
                     Logging.warn("Time since last scan: " + sinceLastScan + " milliseconds");
                     if ( now - lastWifiUnjamTime > resetWifiPeriod ) {
-                        final boolean disableToast = prefs.getBoolean(ListFragment.PREF_DISABLE_TOAST, false);
+                        final boolean disableToast = prefs.getBoolean(PreferenceKeys.PREF_DISABLE_TOAST, false);
                         if (!disableToast) {
-                            WiGLEToast.showOverActivity(mainActivity, R.string.error_general, mainActivity.getString(R.string.wifi_jammed));
+                            Handler handler = new Handler(Looper.getMainLooper());
+                            handler.post(() -> WiGLEToast.showOverActivity(mainActivity, R.string.error_general, mainActivity.getString(R.string.wifi_jammed)));
                         }
                         scanInFlight = false;
                         try {
@@ -894,7 +895,7 @@ public class WifiReceiver extends BroadcastReceiver {
                             Logging.info("exception resetting wifi: " + ex, ex);
                         }
                         lastWifiUnjamTime = now;
-                        if (prefs.getBoolean(ListFragment.PREF_SPEAK_WIFI_RESTART, true)) {
+                        if (prefs.getBoolean(PreferenceKeys.PREF_SPEAK_WIFI_RESTART, true)) {
                             mainActivity.speak(mainActivity.getString(R.string.wifi_restart_1) + " "
                                     + (sinceLastScan / 1000L) + " " + mainActivity.getString(R.string.wifi_restart_2));
                         }
@@ -915,9 +916,9 @@ public class WifiReceiver extends BroadcastReceiver {
 
         // battery kill
         if ( ! mainActivity.isTransferring() ) {
-            final SharedPreferences prefs = mainActivity.getSharedPreferences( ListFragment.SHARED_PREFS, 0 );
+            final SharedPreferences prefs = mainActivity.getSharedPreferences( PreferenceKeys.SHARED_PREFS, 0 );
             long batteryKill = prefs.getLong(
-                    ListFragment.PREF_BATTERY_KILL_PERCENT, MainActivity.DEFAULT_BATTERY_KILL_PERCENT);
+                    PreferenceKeys.PREF_BATTERY_KILL_PERCENT, MainActivity.DEFAULT_BATTERY_KILL_PERCENT);
 
             if ( mainActivity.getBatteryLevelReceiver() != null ) {
                 final int batteryLevel = mainActivity.getBatteryLevelReceiver().getBatteryLevel();
@@ -930,7 +931,9 @@ public class WifiReceiver extends BroadcastReceiver {
                     if (null != mainActivity) {
                         final String text = mainActivity.getString(R.string.battery_at) + " " + batteryLevel + " "
                             + mainActivity.getString(R.string.battery_postfix);
-                        WiGLEToast.showOverActivity(mainActivity, R.string.error_general, text);
+
+                        Handler handler = new Handler(Looper.getMainLooper());
+                        handler.post(() -> WiGLEToast.showOverActivity(mainActivity, R.string.error_general, text));
                         Logging.warn("low battery, shutting down");
                         mainActivity.speak(text);
                         mainActivity.finishSoon(4000L, false);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/GsmOperator.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/GsmOperator.java
@@ -65,7 +65,6 @@ public class GsmOperator {
         }
     }
 
-    @TargetApi(android.os.Build.VERSION_CODES.JELLY_BEAN_MR1)
     public GsmOperator(final CellIdentityLte cellIdentL) throws GsmOperatorException{
         cellId = cellIdentL.getCi();
         xac = cellIdentL.getTac();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
@@ -66,7 +66,7 @@ public final class Network implements ClusterItem {
     public static final int CRYPTO_WPA3 = 4;
 
     public enum NetworkBand {
-        WIFI_2_4_GHZ, WIFI_5_GHZ, WIFI_6_GHZ, WIFI_60_GHZ, CELL_2_3_GHZ, UNDEFINED;
+        WIFI_2_4_GHZ, WIFI_5_GHZ, WIFI_6_GHZ, WIFI_60_GHZ, CELL_2_3_GHZ, UNDEFINED
     }
     /**
      * convenience constructor

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/GpxRecyclerAdapter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/GpxRecyclerAdapter.java
@@ -98,6 +98,7 @@ public class GpxRecyclerAdapter extends RecyclerView.Adapter<GpxRecyclerAdapter.
         final Cursor oldCursor = cursor;
         if (oldCursor != null && dataSetObserver != null) {
             oldCursor.unregisterDataSetObserver(dataSetObserver);
+            oldCursor.close();
         }
         cursor = newCursor;
         if (cursor != null) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/NetworkListSorter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/NetworkListSorter.java
@@ -2,15 +2,15 @@ package net.wigle.wigleandroid.ui;
 
 import android.content.SharedPreferences;
 
-import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.model.Network;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 import java.util.Comparator;
 
 /**
  * Shared UI utility to define and access comparators for {@link net.wigle.wigleandroid.model.Network} objects
- * @author: arkasha, bobzilla
+ * @author arkasha, bobzilla
  */
 public class NetworkListSorter {
 
@@ -20,40 +20,15 @@ public class NetworkListSorter {
     public static final int FIND_TIME_COMPARE = 13;
     public static final int SSID_COMPARE = 14;
 
-    public static final Comparator<Network> signalCompare = new Comparator<Network>() {
-        @Override
-        public int compare( Network a, Network b ) {
-            return b.getLevel() - a.getLevel();
-        }
-    };
+    public static final Comparator<Network> signalCompare = (a, b) -> b.getLevel() - a.getLevel();
 
-    public static final Comparator<Network> channelCompare = new Comparator<Network>() {
-        @Override
-        public int compare( Network a, Network b ) {
-            return a.getFrequency() - b.getFrequency();
-        }
-    };
+    public static final Comparator<Network> channelCompare = (a, b) -> a.getFrequency() - b.getFrequency();
 
-    public static final Comparator<Network> cryptoCompare = new Comparator<Network>() {
-        @Override
-        public int compare( Network a, Network b ) {
-            return b.getCrypto() - a.getCrypto();
-        }
-    };
+    public static final Comparator<Network> cryptoCompare = (a, b) -> b.getCrypto() - a.getCrypto();
 
-    public static final Comparator<Network> findTimeCompare = new Comparator<Network>() {
-        @Override
-        public int compare( Network a, Network b ) {
-            return (int) (b.getConstructionTime() - a.getConstructionTime());
-        }
-    };
+    public static final Comparator<Network> findTimeCompare = (a, b) -> (int) (b.getConstructionTime() - a.getConstructionTime());
 
-    public static final Comparator<Network> ssidCompare = new Comparator<Network>() {
-        @Override
-        public int compare( Network a, Network b ) {
-            return a.getSsid().compareTo( b.getSsid() );
-        }
-    };
+    public static final Comparator<Network> ssidCompare = (a, b) -> a.getSsid().compareTo( b.getSsid() );
 
     /**
      * Check preferences and return the correct comparator
@@ -66,7 +41,7 @@ public class NetworkListSorter {
             return signalCompare;
         }
 
-        final int sort = prefs.getInt(ListFragment.PREF_LIST_SORT, SIGNAL_COMPARE);
+        final int sort = prefs.getInt(PreferenceKeys.PREF_LIST_SORT, SIGNAL_COMPARE);
         switch (sort) {
             case SIGNAL_COMPARE:
                 return signalCompare;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/PrefsBackedCheckbox.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/PrefsBackedCheckbox.java
@@ -17,8 +17,10 @@ import net.wigle.wigleandroid.util.PreferenceKeys;
 public class PrefsBackedCheckbox {
     public static CheckBox prefSetCheckBox(final Context context, final View view, final int id,
                                            final String pref, final boolean def, final SharedPreferences prefs) {
-        final CheckBox checkbox = view.findViewById(id);
-        checkbox.setChecked(prefs.getBoolean(pref, def));
+            final CheckBox checkbox = view.findViewById(id);
+        if (checkbox == null) {
+            checkbox.setChecked(prefs.getBoolean(pref, def));
+        }
         return checkbox;
     }
 
@@ -43,14 +45,17 @@ public class PrefsBackedCheckbox {
         final SharedPreferences prefs = activity.getSharedPreferences(PreferenceKeys.SHARED_PREFS, Context.MODE_PRIVATE);
         final SharedPreferences.Editor editor = prefs.edit();
         final CheckBox checkbox = prefSetCheckBox(prefs, view, id, pref, def);
-        checkbox.setOnCheckedChangeListener((buttonView, isChecked) -> {
-            editor.putBoolean(pref, isChecked);
-            editor.apply();
-            if (null != listener) {
-                listener.preferenceSet(isChecked);
-            }
-        });
-
+        if (null != checkbox) {
+            checkbox.setOnCheckedChangeListener((buttonView, isChecked) -> {
+                editor.putBoolean(pref, isChecked);
+                editor.apply();
+                if (null != listener) {
+                    listener.preferenceSet(isChecked);
+                }
+            });
+        } else {
+            Logging.error("null checkbox - unable to attach listener: "+id);
+        }
         return checkbox;
     }
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/PrefsBackedCheckbox.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/PrefsBackedCheckbox.java
@@ -9,6 +9,7 @@ import android.widget.CheckBox;
 import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.listener.PrefCheckboxListener;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 /**
  * Utility class for SharedPreferences-backed checkboxes.
@@ -39,7 +40,7 @@ public class PrefsBackedCheckbox {
 
     public static CheckBox prefBackedCheckBox(final Activity activity, final View view, final int id,
                                               final String pref, final boolean def, final PrefCheckboxListener listener) {
-        final SharedPreferences prefs = activity.getSharedPreferences(ListFragment.SHARED_PREFS, Context.MODE_PRIVATE);
+        final SharedPreferences prefs = activity.getSharedPreferences(PreferenceKeys.SHARED_PREFS, Context.MODE_PRIVATE);
         final SharedPreferences.Editor editor = prefs.edit();
         final CheckBox checkbox = prefSetCheckBox(prefs, view, id, pref, def);
         checkbox.setOnCheckedChangeListener((buttonView, isChecked) -> {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/PrefsBackedCheckbox.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/PrefsBackedCheckbox.java
@@ -1,0 +1,55 @@
+package net.wigle.wigleandroid.ui;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.view.View;
+import android.widget.CheckBox;
+
+import net.wigle.wigleandroid.ListFragment;
+import net.wigle.wigleandroid.listener.PrefCheckboxListener;
+import net.wigle.wigleandroid.util.Logging;
+
+/**
+ * Utility class for SharedPreferences-backed checkboxes.
+ */
+public class PrefsBackedCheckbox {
+    public static CheckBox prefSetCheckBox(final Context context, final View view, final int id,
+                                           final String pref, final boolean def, final SharedPreferences prefs) {
+        final CheckBox checkbox = view.findViewById(id);
+        checkbox.setChecked(prefs.getBoolean(pref, def));
+        return checkbox;
+    }
+
+    private static CheckBox prefSetCheckBox(final SharedPreferences prefs, final View view, final int id, final String pref,
+                                            final boolean def) {
+        final CheckBox checkbox = view.findViewById(id);
+        if (checkbox == null) {
+            Logging.error("No checkbox for id: " + id);
+        } else {
+            checkbox.setChecked(prefs.getBoolean(pref, def));
+        }
+        return checkbox;
+    }
+
+    public static CheckBox prefBackedCheckBox(final Activity activity, final View view, final int id,
+                                              final String pref, final boolean def) {
+        return prefBackedCheckBox(activity, view, id, pref, def, null);
+    }
+
+    public static CheckBox prefBackedCheckBox(final Activity activity, final View view, final int id,
+                                              final String pref, final boolean def, final PrefCheckboxListener listener) {
+        final SharedPreferences prefs = activity.getSharedPreferences(ListFragment.SHARED_PREFS, Context.MODE_PRIVATE);
+        final SharedPreferences.Editor editor = prefs.edit();
+        final CheckBox checkbox = prefSetCheckBox(prefs, view, id, pref, def);
+        checkbox.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            editor.putBoolean(pref, isChecked);
+            editor.apply();
+            if (null != listener) {
+                listener.preferenceSet(isChecked);
+            }
+        });
+
+        return checkbox;
+    }
+}

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/ThemeUtil.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/ThemeUtil.java
@@ -15,8 +15,8 @@ import androidx.appcompat.app.AppCompatDelegate;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.MapStyleOptions;
 
-import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -27,14 +27,9 @@ public class ThemeUtil {
             ExecutorService executor = Executors.newSingleThreadExecutor();
             Handler handler = new Handler(Looper.getMainLooper());
             executor.execute(() -> {
-                final int displayMode = prefs.getInt(ListFragment.PREF_DAYNIGHT_MODE, AppCompatDelegate.MODE_NIGHT_YES);
+                final int displayMode = prefs.getInt(PreferenceKeys.PREF_DAYNIGHT_MODE, AppCompatDelegate.MODE_NIGHT_YES);
                 Logging.info("set theme called: " + displayMode);
-                handler.post(new Runnable() {
-                    @Override
-                    public void run() {
-                        AppCompatDelegate.setDefaultNightMode(displayMode);
-                    }
-                });
+                handler.post(() -> AppCompatDelegate.setDefaultNightMode(displayMode));
             });
         } else {
             //Force night mode
@@ -46,22 +41,16 @@ public class ThemeUtil {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             ExecutorService executor = Executors.newSingleThreadExecutor();
             Handler handler = new Handler(Looper.getMainLooper());
-            executor.execute(new Runnable() {
-                @Override
-                public void run() {
-                    final int displayMode = prefs.getInt(ListFragment.PREF_DAYNIGHT_MODE, AppCompatDelegate.MODE_NIGHT_YES);
-                    final int nightModeFlags = c.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
-                    handler.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            if (AppCompatDelegate.MODE_NIGHT_YES == displayMode ||
-                                    (AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM == displayMode &&
-                                            nightModeFlags == Configuration.UI_MODE_NIGHT_YES)) {
-                                w.setNavigationBarColor(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
-                            }
-                        }
-                    });
-                }
+            executor.execute(() -> {
+                final int displayMode = prefs.getInt(PreferenceKeys.PREF_DAYNIGHT_MODE, AppCompatDelegate.MODE_NIGHT_YES);
+                final int nightModeFlags = c.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+                handler.post(() -> {
+                    if (AppCompatDelegate.MODE_NIGHT_YES == displayMode ||
+                            (AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM == displayMode &&
+                                    nightModeFlags == Configuration.UI_MODE_NIGHT_YES)) {
+                        w.setNavigationBarColor(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+                    }
+                });
             });
         }
     }
@@ -78,9 +67,9 @@ public class ThemeUtil {
 
     public static boolean shouldUseMapNightMode(final Context c, final SharedPreferences prefs) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            final boolean mapsMatchMode = prefs.getBoolean(ListFragment.PREF_MAPS_FOLLOW_DAYNIGHT, false);
+            final boolean mapsMatchMode = prefs.getBoolean(PreferenceKeys.PREF_MAPS_FOLLOW_DAYNIGHT, false);
             if (mapsMatchMode) {
-                final int displayMode = prefs.getInt(ListFragment.PREF_DAYNIGHT_MODE, AppCompatDelegate.MODE_NIGHT_YES);
+                final int displayMode = prefs.getInt(PreferenceKeys.PREF_DAYNIGHT_MODE, AppCompatDelegate.MODE_NIGHT_YES);
                 final int nightModeFlags = c.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
                 return AppCompatDelegate.MODE_NIGHT_YES == displayMode ||
                         (AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM == displayMode &&

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/UINumberFormat.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/UINumberFormat.java
@@ -3,16 +3,14 @@ package net.wigle.wigleandroid.ui;
 import android.content.Context;
 import android.content.SharedPreferences;
 
-import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.R;
+import net.wigle.wigleandroid.util.PreferenceKeys;
 
 import java.text.NumberFormat;
 
 public class UINumberFormat {
     /**
      * format the topbar counters
-     * @param input
-     * @return
      */
     public static String counterFormat(long input) {
         if (input > 9999999999L) {
@@ -30,7 +28,7 @@ public class UINumberFormat {
 
     public static String metersToString(final SharedPreferences prefs, final NumberFormat numberFormat, final Context context, final float meters,
                                         final boolean useShort ) {
-        final boolean metric = prefs.getBoolean( ListFragment.PREF_METRIC, false );
+        final boolean metric = prefs.getBoolean( PreferenceKeys.PREF_METRIC, false );
         String retval;
         if ( meters > 3000f ) {
             if ( metric ) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/WiGLEConfirmationDialog.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/WiGLEConfirmationDialog.java
@@ -71,19 +71,16 @@ public class WiGLEConfirmationDialog extends DialogFragment {
         final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
         builder.setCancelable(true);
         builder.setTitle("Confirmation"); //TODO: literal string
-        final String checkboxLabel = getArguments().containsKey("checkboxLabel") ? getArguments().getString("checkboxLabel") : null;
+        final String checkboxLabel = getArguments().getString("checkboxLabel");
         if (null != checkboxLabel) {
             View checkBoxView = View.inflate(activity, R.layout.checkbox, null);
             CheckBox checkBox = checkBoxView.findViewById(R.id.checkbox);
             checkBox.setText(checkboxLabel);
             builder.setView(checkBoxView);
         }
-        final String persistPrefKey = getArguments().containsKey("persistPref") ?
-                getArguments().getString("persistPref") : null;
-        final String persistPrefAgreeValue = getArguments().containsKey("persistPrefAgreeValue") ?
-                getArguments().getString("persistPrefAgreeValue") : null;
-        final String persistPrefDisagreeValue = getArguments().containsKey("persistPrefDisagreeValue") ?
-                getArguments().getString("persistPrefDisagreeValue") : null;
+        final String persistPrefKey = getArguments().getString("persistPref");
+        final String persistPrefAgreeValue = getArguments().getString("persistPrefAgreeValue");
+        final String persistPrefDisagreeValue = getArguments().getString("persistPrefDisagreeValue");
 
         builder.setMessage(getArguments().getString("message"));
         final int tabPos = getArguments().getInt("tabPos");

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/WiGLEConfirmationDialog.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/WiGLEConfirmationDialog.java
@@ -109,7 +109,7 @@ public class WiGLEConfirmationDialog extends DialogFragment {
                     Logging.info("activity is null in dialog. tabPos: " + tabPos + " dialogId: " + dialogId);
                 } else if (activity1 instanceof MainActivity) {
                     final MainActivity mainActivity = (MainActivity) activity1;
-                    if (mainActivity.getState() != null) {
+                    if (mainActivity.getState() != null && tabPos != 0) {
                         final String maybeName = getResources().getResourceName(tabPos);
                         //DEBUG: MainActivity.info("Attempting lookup for: " + String.format("0x%08X", tabPos) + " (" + maybeName + ")");
                         FragmentManager fragmentManager = ((MainActivity) activity1).getSupportFragmentManager();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/WiGLEConfirmationDialog.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/WiGLEConfirmationDialog.java
@@ -1,0 +1,189 @@
+package net.wigle.wigleandroid.ui;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.view.View;
+import android.view.WindowManager;
+import android.widget.CheckBox;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.fragment.app.FragmentManager;
+
+import net.wigle.wigleandroid.DialogListener;
+import net.wigle.wigleandroid.MainActivity;
+import net.wigle.wigleandroid.R;
+import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.util.PreferenceKeys;
+
+/**
+ * A confirmation dialog to use throughout the app.
+ */
+public class WiGLEConfirmationDialog extends DialogFragment {
+    public static WiGLEConfirmationDialog newInstance(final String message, final int tabPos, final int dialogId) {
+        final WiGLEConfirmationDialog frag = new WiGLEConfirmationDialog();
+        Bundle args = new Bundle();
+        args.putString("message", message);
+        args.putInt("tabPos", tabPos);
+        args.putInt("dialogId", dialogId);
+        frag.setArguments(args);
+        return frag;
+    }
+
+    /**
+     * alternate instantiation with a prefs-back checkbox inline - String prefs only
+     * @param message the message to display in the dialog
+     * @param checkboxLabel the label for the checkbox in the dialog
+     * @param tabPos the tab state
+     * @param dialogId the dialog id
+     * @return a ConfirmationDialog instance
+     */
+    public static WiGLEConfirmationDialog newInstance(final String message, final String checkboxLabel,
+                                                              final String persistPrefKey,
+                                                              final String persistPrefAgreeValue,
+                                                              final String persistPrefDisagreeValue,
+                                                              final int tabPos,
+                                                              final int dialogId) {
+        final WiGLEConfirmationDialog frag = new WiGLEConfirmationDialog();
+        Bundle args = new Bundle();
+        args.putString("message", message);
+        args.putInt("tabPos", tabPos);
+        args.putInt("dialogId", dialogId);
+        args.putString("checkboxLabel", checkboxLabel);
+        args.putString("persistPref", persistPrefKey);
+        args.putString("persistPrefAgreeValue", persistPrefAgreeValue);
+        args.putString("persistPrefDisagreeValue", persistPrefDisagreeValue);
+        frag.setArguments(args);
+        return frag;
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        final Activity activity = getActivity();
+        final AlertDialog.Builder builder = new AlertDialog.Builder(activity);
+        builder.setCancelable(true);
+        builder.setTitle("Confirmation"); //TODO: literal string
+        final String checkboxLabel = getArguments().containsKey("checkboxLabel") ? getArguments().getString("checkboxLabel") : null;
+        if (null != checkboxLabel) {
+            View checkBoxView = View.inflate(activity, R.layout.checkbox, null);
+            CheckBox checkBox = checkBoxView.findViewById(R.id.checkbox);
+            checkBox.setText(checkboxLabel);
+            builder.setView(checkBoxView);
+        }
+        final String persistPrefKey = getArguments().containsKey("persistPref") ?
+                getArguments().getString("persistPref") : null;
+        final String persistPrefAgreeValue = getArguments().containsKey("persistPrefAgreeValue") ?
+                getArguments().getString("persistPrefAgreeValue") : null;
+        final String persistPrefDisagreeValue = getArguments().containsKey("persistPrefDisagreeValue") ?
+                getArguments().getString("persistPrefDisagreeValue") : null;
+
+        builder.setMessage(getArguments().getString("message"));
+        final int tabPos = getArguments().getInt("tabPos");
+        final int dialogId = getArguments().getInt("dialogId");
+        final SharedPreferences prefs = null !=
+                activity?activity.getSharedPreferences(PreferenceKeys.SHARED_PREFS, Context.MODE_PRIVATE): null;
+
+        final AlertDialog ad = builder.create();
+        // ok
+        ad.setButton(DialogInterface.BUTTON_POSITIVE, activity.getString(R.string.ok), (dialog, which) -> {
+            try {
+                if (null != persistPrefKey) {
+                    CheckBox checkBox = ((AlertDialog) dialog).findViewById(R.id.checkbox);
+                    if (checkBox.isChecked()) {
+                        final SharedPreferences.Editor editor = prefs.edit();
+                        editor.putString(persistPrefKey, persistPrefAgreeValue);
+                        editor.apply();
+                    }
+                }
+                dialog.dismiss();
+                final Activity activity1 = getActivity();
+                if (activity1 == null) {
+                    Logging.info("activity is null in dialog. tabPos: " + tabPos + " dialogId: " + dialogId);
+                } else if (activity1 instanceof MainActivity) {
+                    final MainActivity mainActivity = (MainActivity) activity1;
+                    if (mainActivity.getState() != null) {
+                        final String maybeName = getResources().getResourceName(tabPos);
+                        //DEBUG: MainActivity.info("Attempting lookup for: " + String.format("0x%08X", tabPos) + " (" + maybeName + ")");
+                        FragmentManager fragmentManager = ((MainActivity) activity1).getSupportFragmentManager();
+                        final Fragment fragment = fragmentManager.findFragmentByTag(MainActivity.FRAGMENT_TAG_PREFIX + tabPos);
+                        if (fragment == null) {
+                            Logging.error("null fragment for: " + String.format("0x%08X", tabPos) + " (" + maybeName + ")");
+                            //TODO: might behoove us to show an error here
+                        } else {
+                            ((DialogListener) fragment).handleDialog(dialogId);
+                        }
+                    }
+                } else {
+                    ((DialogListener) activity1).handleDialog(dialogId);
+                }
+            } catch (Exception ex) {
+                // guess it wasn't there anyways
+                Logging.info("exception handling fragment alert dialog: " + ex, ex);
+            }
+        });
+
+        // cancel
+        ad.setButton(DialogInterface.BUTTON_NEGATIVE, activity.getString(R.string.cancel), (dialog, which) -> {
+            try {
+                if (null != persistPrefKey) {
+                    CheckBox checkBox = ((AlertDialog) dialog).findViewById(R.id.checkbox);
+                    if (checkBox.isChecked() && prefs != null) {
+                        final SharedPreferences.Editor editor = prefs.edit();
+                        editor.putString(persistPrefKey, persistPrefDisagreeValue);
+                        editor.apply();
+                    }
+                }
+                dialog.dismiss();
+            } catch (Exception ex) {
+                // guess it wasn't there anyways
+                Logging.info("exception dismissing fragment alert dialog: ", ex);
+            }
+        });
+        return ad;
+    }
+    public static void createConfirmation(final FragmentActivity activity, final String message,
+                                          final int tabPos, final int dialogId) {
+        try {
+            final FragmentManager fm = activity.getSupportFragmentManager();
+            final WiGLEConfirmationDialog dialog = WiGLEConfirmationDialog.newInstance(message, tabPos, dialogId);
+            final String tag = tabPos + "-" + dialogId + "-" + activity.getClass().getSimpleName();
+            Logging.info("tag: " + tag + " fm: " + fm);
+            dialog.show(fm, tag);
+        } catch (WindowManager.BadTokenException ex) {
+            Logging.info("exception showing dialog, view probably changed: " + ex, ex);
+        } catch (final IllegalStateException ex) {
+            final String errorMessage = "Exception trying to show dialog: " + ex;
+            Logging.error(errorMessage, ex);
+        }
+    }
+
+    public static void createCheckboxConfirmation(final FragmentActivity activity, final String message,
+                                                  final String checkboxLabel, final String persistPrefKey,
+                                                  final String persistPrefAgreeValue,
+                                                  final String persistPrefDisagreeValue,
+                                                  final int tabPos, final int dialogId) {
+        try {
+            final FragmentManager fm = activity.getSupportFragmentManager();
+            final WiGLEConfirmationDialog dialog = WiGLEConfirmationDialog.newInstance(message, checkboxLabel,
+                    persistPrefKey, persistPrefAgreeValue, persistPrefDisagreeValue, tabPos, dialogId);
+            final String tag = tabPos + "-" + dialogId + "-" + activity.getClass().getSimpleName();
+            Logging.info("tag: " + tag + " fm: " + fm);
+            dialog.show(fm, tag);
+        } catch (WindowManager.BadTokenException ex) {
+            Logging.info("exception showing dialog, view probably changed: " + ex, ex);
+        } catch (final IllegalStateException ex) {
+            final String errorMessage = "Exception trying to show dialog: " + ex;
+            Logging.error(errorMessage, ex);
+        }
+    }
+
+
+}

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/AsyncGpxExportTask.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/AsyncGpxExportTask.java
@@ -116,6 +116,7 @@ public class AsyncGpxExportTask extends AsyncTask<Long, Integer, String> {
             writer.append(GPX_FOOTER);
             writer.flush();
             writer.close();
+            cursor.close();
             return "completed export";
         } catch (IOException | DBException | InterruptedException e) {
             Logging.error("Error writing GPX", e);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/PreferenceKeys.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/PreferenceKeys.java
@@ -1,0 +1,102 @@
+package net.wigle.wigleandroid.util;
+
+public class PreferenceKeys {
+    // preferences
+    public static final String SHARED_PREFS = "WiglePrefs";
+    public static final String PREF_USERNAME = "username";
+    public static final String PREF_PASSWORD = "password";
+    public static final String PREF_AUTHNAME = "authname";
+    public static final String PREF_TOKEN = "token";
+    public static final String PREF_TOKEN_IV = "tokenIV";
+    public static final String PREF_TOKEN_TAG_LENGTH = "tokenTagLength";
+    public static final String PREF_SHOW_CURRENT = "showCurrent";
+    public static final String PREF_BE_ANONYMOUS = "beAnonymous";
+    public static final String PREF_DONATE = "donate";
+    public static final String PREF_DB_MARKER = "dbMarker";
+    public static final String PREF_MAX_DB = "maxDbMarker";
+    public static final String PREF_ROUTE_DB_RUN = "routeDbRun";
+    public static final String PREF_NETS_UPLOADED = "netsUploaded";
+    public static final String PREF_SCAN_PERIOD_STILL = "scanPeriodStill";
+    public static final String PREF_SCAN_PERIOD = "scanPeriod";
+    public static final String PREF_SCAN_PERIOD_FAST = "scanPeriodFast";
+    public static final String PREF_OG_BT_SCAN_PERIOD_STILL = "btGeneralScanPeriodStill";
+    public static final String PREF_OG_BT_SCAN_PERIOD = "btGeneralScanPeriod";
+    public static final String PREF_OG_BT_SCAN_PERIOD_FAST = "btGeneralScanPeriodFast";
+    public static final String PREF_QUICK_PAUSE = "quickScanPause";
+    public static final String GPS_SCAN_PERIOD = "gpsPeriod";
+    public static final String PREF_FOUND_SOUND = "foundSound";
+    public static final String PREF_FOUND_NEW_SOUND = "foundNewSound";
+    public static final String PREF_LANGUAGE = "speechLanguage";
+    public static final String PREF_RESET_WIFI_PERIOD = "resetWifiPeriod";
+    public static final String PREF_BATTERY_KILL_PERCENT = "batteryKillPercent";
+    public static final String PREF_MUTED = "muted";
+    public static final String PREF_BT_WAS_OFF = "btWasOff";
+    public static final String PREF_SCAN_BT = "scanBluetooth";
+    public static final String PREF_DISTANCE_RUN = "distRun";
+    public static final String PREF_STARTTIME_RUN = "timestampRunStart";
+    public static final String PREF_CUMULATIVE_SCANTIME_RUN = "millisScannedDuringRun";
+    public static final String PREF_STARTTIME_CURRENT_SCAN = "timestampScanStart";
+    public static final String PREF_DISTANCE_TOTAL = "distTotal";
+    public static final String PREF_DISTANCE_PREV_RUN = "distPrevRun";
+    public static final String PREF_PREV_LAT = "prevLat";
+    public static final String PREF_PREV_LON = "prevLon";
+    public static final String PREF_PREV_ZOOM = "prevZoom2";
+    public static final String PREF_LIST_SORT = "listSort";
+    public static final String PREF_SCAN_RUNNING = "scanRunning";
+    public static final String PREF_METRIC = "metric";
+    public static final String PREF_USE_NETWORK_LOC = "useNetworkLoc";
+    public static final String PREF_DISABLE_TOAST = "disableToast"; // bool
+    public static final String PREF_BLOWED_UP = "blowedUp";
+    public static final String PREF_CONFIRM_UPLOAD_USER = "confirmUploadUser";
+    public static final String PREF_EXCLUDE_DISPLAY_ADDRS = "displayExcludeAddresses";
+    public static final String PREF_EXCLUDE_LOG_ADDRS = "logExcludeAddresses";
+    public static final String PREF_GPS_TIMEOUT = "gpsTimeout";
+    public static final String PREF_GPS_KALMAN_FILTER = "gpsKalmanFilter";
+    public static final String PREF_NET_LOC_TIMEOUT = "networkLocationTimeout";
+    public static final String PREF_START_AT_BOOT = "startAtBoot";
+    public static final String PREF_LOG_ROUTES = "logRoutes";
+    public static final String PREF_DAYNIGHT_MODE = "dayNightMode";
+
+    // map prefs
+    public static final String PREF_MAP_NO_TILE = "NONE";
+    public static final String PREF_MAP_ONLYMINE_TILE = "MINE";
+    public static final String PREF_MAP_NOTMINE_TILE = "NOTMINE";
+    public static final String PREF_MAP_ALL_TILE = "ALL";
+    public static final String PREF_MAP_TYPE = "mapType";
+    public static final String PREF_MAP_ONLY_NEWDB = "mapOnlyNewDB";
+    public static final String PREF_MAP_LABEL = "mapLabel";
+    public static final String PREF_MAP_CLUSTER = "mapCluster";
+    public static final String PREF_MAP_TRAFFIC = "mapTraffic";
+    public static final String PREF_CIRCLE_SIZE_MAP = "circleSizeMap";
+    public static final String PREF_MAP_HIDE_NETS = "hideNetsMap";
+    public static final String PREF_VISUALIZE_ROUTE = "visualizeRoute";
+    public static final String PREF_SHOW_DISCOVERED_SINCE = "showDiscoveredSince";
+    public static final String PREF_SHOW_DISCOVERED = "showMyDiscovered";
+    public static final String PREF_MAPS_FOLLOW_DAYNIGHT = "mapThemeMatchDayNight";
+
+    // what to speak on announcements
+    public static final String PREF_SPEECH_PERIOD = "speechPeriod";
+    public static final String PREF_SPEECH_GPS = "speechGPS";
+    public static final String PREF_SPEAK_RUN = "speakRun";
+    public static final String PREF_SPEAK_NEW_WIFI = "speakNew";
+    public static final String PREF_SPEAK_NEW_CELL = "speakNewCell";
+    public static final String PREF_SPEAK_QUEUE = "speakQueue";
+    public static final String PREF_SPEAK_MILES = "speakMiles";
+    public static final String PREF_SPEAK_TIME = "speakTime";
+    public static final String PREF_SPEAK_BATTERY = "speakBattery";
+    public static final String PREF_SPEAK_SSID = "speakSsid";
+    public static final String PREF_SPEAK_WIFI_RESTART = "speakWifiRestart";
+
+    // map ssid filter
+    public static final String PREF_MAPF_REGEX = "mapfRegex";
+    public static final String PREF_MAPF_INVERT = "mapfInvert";
+    public static final String PREF_MAPF_OPEN = "mapfOpen";
+    public static final String PREF_MAPF_WEP = "mapfWep";
+    public static final String PREF_MAPF_WPA = "mapfWpa";
+    public static final String PREF_MAPF_CELL = "mapfCell";
+    public static final String PREF_MAPF_BT = "mapfBt";
+    public static final String PREF_MAPF_BTLE = "mapfBtle";
+    public static final String PREF_MAPF_ENABLED = "mapfEnabled";
+    public static final String FILTER_PREF_PREFIX = "LA";
+
+}

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/SettingsUtil.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/SettingsUtil.java
@@ -24,13 +24,13 @@ import java.util.Arrays;
 public class SettingsUtil {
     public static String[] getMapModes(final boolean isAuthed) {
         if (isAuthed) {
-            return new String[]{ListFragment.PREF_MAP_NO_TILE,
-                    ListFragment.PREF_MAP_ONLYMINE_TILE, ListFragment.PREF_MAP_NOTMINE_TILE,
-                    ListFragment.PREF_MAP_ALL_TILE};
+            return new String[]{PreferenceKeys.PREF_MAP_NO_TILE,
+                    PreferenceKeys.PREF_MAP_ONLYMINE_TILE, PreferenceKeys.PREF_MAP_NOTMINE_TILE,
+                    PreferenceKeys.PREF_MAP_ALL_TILE};
 
         }
-        return new String[]{ListFragment.PREF_MAP_NO_TILE,
-                ListFragment.PREF_MAP_ALL_TILE};
+        return new String[]{PreferenceKeys.PREF_MAP_NO_TILE,
+                PreferenceKeys.PREF_MAP_ALL_TILE};
     }
 
     public static String[] getMapModeNames(final boolean isAuthed, final Context context) {
@@ -59,7 +59,7 @@ public class SettingsUtil {
 
     public static <V> void doSpinner(final int id, final View view, final String pref, final V spinDefault,
                                final V[] periods, final String[] periodName, final Context context) {
-        doSpinner((Spinner)view.findViewById(id), pref, spinDefault, periods, periodName, context);
+        doSpinner(view.findViewById(id), pref, spinDefault, periods, periodName, context);
     }
 
     public static <V> void doSpinner( final Spinner spinner, final String pref, final V spinDefault, final V[] periods,
@@ -70,7 +70,7 @@ public class SettingsUtil {
                     + " periodName: " + Arrays.toString(periodName));
         }
 
-        final SharedPreferences prefs = context.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+        final SharedPreferences prefs = context.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
         final SharedPreferences.Editor editor = prefs.edit();
 
         ArrayAdapter<String> adapter = new ArrayAdapter<>(
@@ -118,10 +118,10 @@ public class SettingsUtil {
                 }
                 editor.apply();
 
-                if ( pref.equals(ListFragment.PREF_LANGUAGE) ) {
+                if ( pref.equals(PreferenceKeys.PREF_LANGUAGE) ) {
                     MainActivity.setLocale( context, context.getResources().getConfiguration() );
                 }
-                if ( pref.equals(ListFragment.PREF_DAYNIGHT_MODE) ) {
+                if ( pref.equals(PreferenceKeys.PREF_DAYNIGHT_MODE) ) {
                     ThemeUtil.setTheme(prefs);
                     try {
                         ThemeUtil.setNavTheme(((Activity) v.getContext()).getWindow(), context, prefs);
@@ -143,8 +143,8 @@ public class SettingsUtil {
                     + " periodName: " + Arrays.toString(termNames));
         }
 
-        Spinner spinner = (Spinner)view.findViewById(spinnerId);
-        final SharedPreferences prefs = context.getSharedPreferences(ListFragment.SHARED_PREFS, 0);
+        Spinner spinner = view.findViewById(spinnerId);
+        final SharedPreferences prefs = context.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
         final SharedPreferences.Editor editor = prefs.edit();
 
         ArrayAdapter<String> adapter = new ArrayAdapter<>(
@@ -171,9 +171,9 @@ public class SettingsUtil {
                 Logging.info( pref + " setting map data: " + period );
                 editor.putString( pref, period );
                 editor.apply();
-                LinearLayout mainLayout = (LinearLayout) view.findViewById(R.id.show_map_discovered_since);
+                LinearLayout mainLayout = view.findViewById(R.id.show_map_discovered_since);
 
-                if (ListFragment.PREF_MAP_NO_TILE.equals(period)) {
+                if (PreferenceKeys.PREF_MAP_NO_TILE.equals(period)) {
                     mainLayout.setVisibility(View.GONE);
                 } else {
                     mainLayout.setVisibility(View.VISIBLE);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/UrlConfig.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/UrlConfig.java
@@ -1,0 +1,24 @@
+package net.wigle.wigleandroid.util;
+
+public class UrlConfig {
+    public static final String CSV_TRANSID_URL_STEM = "https://api.wigle.net/api/v2/file/csv/";
+    // form auth
+    public static final String TOKEN_URL = "https://api.wigle.net/api/v2/activate";
+    // no auth
+    public static final String SITE_STATS_URL = "https://api.wigle.net/api/v2/stats/site";
+    public static final String RANK_STATS_URL = "https://api.wigle.net/api/v2/stats/standings";
+    public static final String NEWS_URL = "https://api.wigle.net/api/v2/news/latest";
+    // api token auth
+    public static final String UPLOADS_STATS_URL = "https://api.wigle.net/api/v2/file/transactions";
+    public static final String USER_STATS_URL = "https://api.wigle.net/api/v2/stats/user";
+    public static final String OBSERVED_URL = "https://api.wigle.net/api/v2/network/mine";
+    public static final String FILE_POST_URL = "https://api.wigle.net/api/v2/file/upload";
+    public static final String KML_TRANSID_URL_STEM = "https://api.wigle.net/api/v2/file/kml/";
+    public static final String SEARCH_WIFI_URL = "https://api.wigle.net/api/v2/network/search";
+    public static final String SEARCH_CELL_URL = "https://api.wigle.net/api/v2/cell/search";
+    public static final String WIGLE_BASE_URL = "https://wigle.net";
+
+    // registration web view
+    public static final String REG_URL = "https://wigle.net/register";
+
+}

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/UrlConfig.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/UrlConfig.java
@@ -1,5 +1,8 @@
 package net.wigle.wigleandroid.util;
 
+/**
+ * Utility class that holds the WiGLE URLs used throughout the app
+ */
 public class UrlConfig {
     public static final String CSV_TRANSID_URL_STEM = "https://api.wigle.net/api/v2/file/csv/";
     // form auth

--- a/wiglewifiwardriving/src/main/res/values/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Show Bluetooth LE</string>
     <string name="settings_gps_head">GPS Settings</string>
     <string name="enable_kalman">Filter GPS noise</string>
+    <string name="gps_old_message">This device is no longer supported via the app store due to Google\'s policies. Please back-up your data and side-load the WiGLE v. 2.67 .apk (or lower) from https://github.com/wiglenet/wigle-wifi-wardriving/ . Sorry for the inconvenience!</string>
+    <string name="gps_old_title">Unable to initialize GPS</string>
 </resources>


### PR DESCRIPTION
Nuts, but the SDK upgrade has made things that worked previously stop working.
We still have some leaks, but this change is getting immense, so I'm stopping here.
- we have access to lambdas with the new MinSDK
- we have access to try (resources) with the new MinSDK
- SDK compat allowed us to upgrade some old deps
- Google SDK checks upgraded from Play checks
- the new MinSDK obviates a lot of SDK level checks
- some weird work-arounds are no-longer necessary
- MainActivity and ListFragment were immense, hindering leak detection and profiling - moved elements of preference keys, URL configuration, and our confirmation dialog wrapper to their own util classes
- we get object leaks with the net Target/MinSDKs. Many are addressed by this, some are not
  - the WiGLEService IBinder was leaking starting with recent android versions
  - TTS invoiced with MainAcitivity instead of getApplicationContext was leaking
  - BluetoothScanning was leaking based on an explicit reference to the central SetNetworkListAdapter
  
  Remaining issues:
- Toast is still leaking - unclear whether this is due to our customizations, or just the library
- BluetoothReceiver's android.bluetooth.le.ScanCallback still has a reference problem.