### PR TITLE
[BUG] prevent auto-upgrade of phones on Android APIs 19-23 to non-working GNSS

### DIFF
--- a/wiglewifiwardriving/build.gradle
+++ b/wiglewifiwardriving/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 31
     defaultConfig {
         applicationId "net.wigle.wigleandroid"
-        minSdkVersion 19
+        minSdkVersion 24
         targetSdkVersion 31
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true

--- a/wiglewifiwardriving/src/main/res/values-ar/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ar/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">عرض Bluetooth LE</string>
     <string name="settings_gps_head">إعدادات GPS</string>
     <string name="enable_kalman">تصفية ضوضاء GPS</string>
+    <string name="gps_old_message">لم يعد هذا الجهاز مدعومًا عبر متجر التطبيقات بسبب سياسات Google. يرجى نسخ بياناتك احتياطيًا وتحميل WiGLE v. 2.67 .apk (أو أقل) من https://github.com/wiglenet/wigle-wifi-wardriving/. نأسف للإزعاج!</string>
+    <string name="gps_old_title">تعذر تهيئة GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-cs-rCZ/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-cs-rCZ/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Zobrazit Bluetooth LE</string>
     <string name="settings_gps_head">Nastavení GPS</string>
     <string name="enable_kalman">Filtrujte šum GPS</string>
+    <string name="gps_old_message">Toto zařízení již není podporováno prostřednictvím obchodu s aplikacemi kvůli zásadám společnosti Google. Zálohujte si prosím svá data a stáhněte si WiGLE v. 2.67 .apk (nebo nižší) z https://github.com/wiglenet/wigle-wifi-wardriving/ . Omluvám se za nepříjemnost!</string>
+    <string name="gps_old_title">Nelze inicializovat GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-da/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-da/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Vis Bluetooth LE</string>
     <string name="enable_kalman">"Filtrer GPS-støj "</string>
     <string name="settings_gps_head">GPS instillinger</string>
+    <string name="gps_old_message">Denne enhed understøttes ikke længere via appbutikken på grund af Googles politikker. Sikkerhedskopier dine data og sideindlæs WiGLE v. 2.67 .apk (eller lavere) fra https://github.com/wiglenet/wigle-wifi-wardriving/ . Beklager ulejligheden!</string>
+    <string name="gps_old_title">Kan ikke initialisere GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-de/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-de/strings.xml
@@ -438,4 +438,6 @@
     <string name="settings_gps_head">GPS-Einstellungen</string>
     <string name="enable_kalman">GPS-Rauschen filtern</string>
     <string name="queue_depth">WiGLE-Warteschlange: %1$s Tri: %2$s Geo: %3$s</string>
+    <string name="gps_old_message">Dieses Gerät wird aufgrund der Richtlinien von Google nicht mehr über den App Store unterstützt. Bitte sichern Sie Ihre Daten und laden Sie die WiGLE v. 2.67 .apk (oder niedriger) von https://github.com/wiglenet/wigle-wifi-wardriving/ herunter. Entschuldigung für die Unannehmlichkeiten!</string>
+    <string name="gps_old_title">GPS kann nicht initialisiert werden</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-es-rES/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-es-rES/strings.xml
@@ -437,4 +437,6 @@
     <string name="filter_show_btle">Mostrar Bluetooth LE</string>
     <string name="settings_gps_head">Configuración GPS</string>
     <string name="enable_kalman">Filtrar el ruido del GPS</string>
+    <string name="gps_old_message">Este dispositivo ya no es compatible a través de la tienda de aplicaciones debido a las políticas de Google. Realice una copia de seguridad de sus datos y descargue WiGLE v. 2.67 .apk (o inferior) desde https://github.com/wiglenet/wigle-wifi-wardriving/ . ¡Lo siento por los inconvenientes ocasionados!</string>
+    <string name="gps_old_title">No se puede inicializar el GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fi/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Näytä Bluetooth LE</string>
     <string name="settings_gps_head">GPS-asetukset</string>
     <string name="enable_kalman">Suodata GPS-kohinaa</string>
+    <string name="gps_old_message">Tätä laitetta ei enää tueta sovelluskaupassa Googlen käytäntöjen vuoksi. Varmuuskopioi tietosi ja lataa WiGLE v. 2.67 .apk (tai vanhempi) osoitteesta https://github.com/wiglenet/wigle-wifi-wardriving/ . Anteeksi häiriö!</string>
+    <string name="gps_old_title">GPS:n alustus epäonnistui</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fr/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Afficher Bluetooth LE</string>
     <string name="settings_gps_head">Paramètres GPS</string>
     <string name="enable_kalman">Filtrer le bruit GPS</string>
+    <string name="gps_old_message">Cet appareil n\'est plus pris en charge via l\'App Store en raison des règles de Google. Veuillez sauvegarder vos données et charger le WiGLE v. 2.67 .apk (ou une version antérieure) depuis https://github.com/wiglenet/wigle-wifi-wardriving/ . Désolé pour le dérangement!</string>
+    <string name="gps_old_title">Impossible d\'initialiser le GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fy/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fy/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Toon Bluetooth LE</string>
     <string name="settings_gps_head">GPS-instellingen</string>
     <string name="enable_kalman">GPS-ruis filteren</string>
+    <string name="gps_old_message">Dit apparaat wordt niet langer ondersteund via de app store vanwege het beleid van Google. Maak een back-up van uw gegevens en laad de WiGLE v. 2.67 .apk (of lager) vanaf https://github.com/wiglenet/wigle-wifi-wardriving/. Excuses voor het ongemak!</string>
+    <string name="gps_old_title">GPS kan niet worden geïnitialiseerd</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-he/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-he/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">הצג Bluetooth LE</string>
     <string name="settings_gps_head">הגדרות GPS</string>
     <string name="enable_kalman">סינון רעשי GPS</string>
+    <string name="gps_old_message">מכשיר זה אינו נתמך עוד דרך חנות האפליקציות עקב המדיניות של Google. אנא גבה את הנתונים שלך וטען בצד את WiGLE v. 2.67 .apk (או נמוך יותר) מ-https://github.com/wiglenet/wigle-wifi-wardriving/ . מצטער על אי הנוחות!</string>
+    <string name="gps_old_title">לא ניתן לאתחל את ה-GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hi-rIN/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hi-rIN/strings.xml
@@ -437,4 +437,6 @@
     <string name="filter_show_btle">ब्लूटूथ ले दिखाएँ</string>
     <string name="settings_gps_head">जीपीएस सेटिंग्स</string>
     <string name="enable_kalman">GPS शोर फ़िल्टर करें</string>
+    <string name="gps_old_message">Google की नीतियों के कारण यह डिवाइस अब ऐप स्टोर द्वारा समर्थित नहीं है। कृपया अपने डेटा का बैकअप लें और https://github.com/wiglenet/wigle-wifi-wardriving/ से WiGLE v. 2.67 .apk (या निचला) साइड-लोड करें। असुविधा के लिए खेद है!</string>
+    <string name="gps_old_title">GPS प्रारंभ करने में असमर्थ</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hu-rHU/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hu-rHU/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Bluetooth LE megjelenítése</string>
     <string name="settings_gps_head">GPS beállítások</string>
     <string name="enable_kalman">GPS-zaj szűrése</string>
+    <string name="gps_old_message">Ezt az eszközt a Google irányelvei miatt már nem támogatja az App Store. Kérjük, készítsen biztonsági másolatot adatairól, és töltse be oldalra a WiGLE v. 2.67 .apk (vagy régebbi) verzióját a https://github.com/wiglenet/wigle-wifi-wardriving/ webhelyről. Elnézést a kellemetlenségért!</string>
+    <string name="gps_old_title">Nem sikerült inicializálni a GPS-t</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-it-rIT/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-it-rIT/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Mostra Bluetooth LE</string>
     <string name="settings_gps_head">Impostazioni GPS</string>
     <string name="enable_kalman">Filtra il rumore GPS</string>
+    <string name="gps_old_message">Questo dispositivo non è più supportato tramite l\'app store a causa delle norme di Google. Eseguire il backup dei dati e caricare lateralmente WiGLE v. 2.67 .apk (o precedente) da https://github.com/wiglenet/wigle-wifi-wardriving/ . Ci dispiace per l\'inconvenienza!</string>
+    <string name="gps_old_title">Impossibile inizializzare il GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ja-rJP/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ja-rJP/strings.xml
@@ -437,4 +437,6 @@
     <string name="filter_show_btle">BluetoothLEを表示する</string>
     <string name="enable_kalman">GPSノイズをフィルターする</string>
     <string name="settings_gps_head">GPS フィルタリング</string>
+    <string name="gps_old_message">Google のポリシーにより、このデバイスは App Store でサポートされなくなりました。データをバックアップし、https://github.com/wiglenet/wigle-wifi-wardriving/ から WiGLE v. 2.67 .apk (またはそれ以下) をサイドロードしてください。ご不便おかけしてすみません！</string>
+    <string name="gps_old_title">GPS を初期化できません</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ko/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ko/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">블루투스 LE 표시</string>
     <string name="settings_gps_head">GPS 설정</string>
     <string name="enable_kalman">GPS 노이즈 필터링</string>
+    <string name="gps_old_message">이 기기는 Google 정책으로 인해 더 이상 앱 스토어를 통해 지원되지 않습니다. 데이터를 백업하고 https://github.com/wiglenet/wigle-wifi-wardriving/에서 WiGLE v. 2.67 .apk(또는 그 이하)를 사이드로드하십시오. 불편을 드려 죄송합니다!</string>
+    <string name="gps_old_title">GPS를 초기화할 수 없습니다.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-nl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nl/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Toon Bluetooth LE</string>
     <string name="settings_gps_head">GPS-indstillinger</string>
     <string name="enable_kalman">GPS-ruis filteren</string>
+    <string name="gps_old_message">Dit apparaat wordt niet langer ondersteund via de app store vanwege het beleid van Google. Maak een back-up van uw gegevens en laad de WiGLE v. 2.67 .apk (of lager) vanaf https://github.com/wiglenet/wigle-wifi-wardriving/. Excuses voor het ongemak!</string>
+    <string name="gps_old_title">GPS kan niet worden geïnitialiseerd</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-nn/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nn/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Vis Bluetooth LE</string>
     <string name="settings_gps_head">GPS-innstillinger</string>
     <string name="enable_kalman">Filtrer GPS-støy</string>
+    <string name="gps_old_message">Denne enheten støttes ikke lenger via appbutikken på grunn av Googles retningslinjer. Ta sikkerhetskopi av dataene dine og sidelast inn WiGLE v. 2.67 .apk (eller lavere) fra https://github.com/wiglenet/wigle-wifi-wardriving/ . Beklager bryet!</string>
+    <string name="gps_old_title">Kan ikke initialisere GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-no/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-no/strings.xml
@@ -440,4 +440,6 @@
     <string name="filter_show_btle">Vis Bluetooth LE</string>
     <string name="settings_gps_head">GPS-innstillinger</string>
     <string name="enable_kalman">Filtrer GPS-støy</string>
+    <string name="gps_old_message">Denne enheten støttes ikke lenger via appbutikken på grunn av Googles retningslinjer. Ta sikkerhetskopi av dataene dine og sidelast inn WiGLE v. 2.67 .apk (eller lavere) fra https://github.com/wiglenet/wigle-wifi-wardriving/ . Beklager bryet!</string>
+    <string name="gps_old_title">Kan ikke initialisere GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pl-rPL/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pl-rPL/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Pokaż Bluetooth LE</string>
     <string name="settings_gps_head">Ustawienia GPS</string>
     <string name="enable_kalman">Filtruj szum GPS</string>
+    <string name="gps_old_message">To urządzenie nie jest już obsługiwane w sklepie z aplikacjami ze względu na zasady Google. Wykonaj kopię zapasową danych i załaduj WiGLE w wersji 2.67 .apk (lub starszej) z https://github.com/wiglenet/wigle-wifi-wardriving/. Przepraszam za niedogodności!</string>
+    <string name="gps_old_title">Nie można zainicjować GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Mostrar Bluetooth LE</string>
     <string name="settings_gps_head">Configurações de GPS</string>
     <string name="enable_kalman">Filtrar ruído do GPS</string>
+    <string name="gps_old_message">Este dispositivo não é mais suportado pela loja de aplicativos devido às políticas do Google. Faça backup de seus dados e carregue o WiGLE v. 2.67 .apk (ou inferior) em https://github.com/wiglenet/wigle-wifi-wardriving/. Desculpe pela inconveniência!</string>
+    <string name="gps_old_title">Não foi possível inicializar o GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt-rPT/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rPT/strings.xml
@@ -437,4 +437,6 @@
     <string name="filter_show_btle">Mostrar Bluetooth LE</string>
     <string name="settings_gps_head">Configurações de GPS</string>
     <string name="enable_kalman">Filtrar ruído do GPS</string>
+    <string name="gps_old_message">Este dispositivo não é mais suportado pela loja de aplicativos devido às políticas do Google. Faça backup de seus dados e carregue o WiGLE v. 2.67 .apk (ou inferior) em https://github.com/wiglenet/wigle-wifi-wardriving/. Desculpe pela inconveniência!</string>
+    <string name="gps_old_title">Não foi possível inicializar o GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ro-rRO/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ro-rRO/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Afișați Bluetooth LE</string>
     <string name="settings_gps_head">Setări GPS</string>
     <string name="enable_kalman">Filtrați zgomotul GPS</string>
+    <string name="gps_old_message">Acest dispozitiv nu mai este acceptat prin magazinul de aplicații din cauza politicilor Google. Vă rugăm să faceți o copie de rezervă a datelor și să încărcați lateral WiGLE v. 2.67 .apk (sau mai mic) de la https://github.com/wiglenet/wigle-wifi-wardriving/ . Îmi pare rău pentru neplăcerile create!</string>
+    <string name="gps_old_title">Imposibil de inițializat GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ru/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ru/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Показать Bluetooth LE</string>
     <string name="settings_gps_head">Настройки GPS</string>
     <string name="enable_kalman">Фильтр шума GPS</string>
+    <string name="gps_old_message">Это устройство больше не поддерживается через магазин приложений из-за политики Google. Создайте резервную копию своих данных и загрузите WiGLE v. 2.67 .apk (или более раннюю версию) с https://github.com/wiglenet/wigle-wifi-wardriving/. Простите за неудобства!</string>
+    <string name="gps_old_title">Не удалось инициализировать GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-sv-rSE/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-sv-rSE/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Visa Bluetooth LE</string>
     <string name="settings_gps_head">GPS-inställningar</string>
     <string name="enable_kalman">Filtrera GPS-brus</string>
+    <string name="gps_old_message">Den här enheten stöds inte längre via appbutiken på grund av Googles policyer. Säkerhetskopiera dina data och sidladda WiGLE v. 2.67 .apk (eller lägre) från https://github.com/wiglenet/wigle-wifi-wardriving/ . Beklagar olägenheten!</string>
+    <string name="gps_old_title">Det gick inte att initiera GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-sw/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-sw/strings.xml
@@ -437,4 +437,6 @@
     <string name="filter_show_btle">Onyesha Bluetooth LE</string>
     <string name="settings_gps_head">Mipangilio ya GPS</string>
     <string name="enable_kalman">Chuja kelele ya GPS</string>
+    <string name="gps_old_message">Kifaa hiki hakitumiki tena kupitia duka la programu kwa sababu ya sera za Google. Tafadhali hifadhi nakala ya data yako na upakie WiGLE v. 2.67 .apk (au chini) kutoka https://github.com/wiglenet/wigle-wifi-wardriving/ . Pole kwa usumbufu!</string>
+    <string name="gps_old_title">Haijaweza kuanzisha GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-tr-rTR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-tr-rTR/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">Bluetooth LE\'yi göster</string>
     <string name="settings_gps_head">GPS Ayarları</string>
     <string name="enable_kalman">GPS gürültüsünü filtrele</string>
+    <string name="gps_old_message">Bu cihaz, Google politikaları nedeniyle artık uygulama mağazası aracılığıyla desteklenmemektedir. Lütfen verilerinizi yedekleyin ve https://github.com/wiglenet/wigle-wifi-wardriving/ adresinden WiGLE v. 2.67 .apk\'yi (veya daha düşük) yandan yükleyin. Rahatsızlıktan dolayı özür dileriz!</string>
+    <string name="gps_old_title">GPS başlatılamıyor</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rCN/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rCN/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">显示蓝牙 LE</string>
     <string name="settings_gps_head">GPS 设置</string>
     <string name="enable_kalman">过滤 GPS 噪声</string>
+    <string name="gps_old_message">由于 Google 的政策，应用商店不再支持此设备。请备份您的数据并从 https://github.com/wiglenet/wigle-wifi-wardriving/ 旁加载 WiGLE v. 2.67 .apk（或更低版本）。带来不便敬请谅解！</string>
+    <string name="gps_old_title">无法初始化 GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rHK/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rHK/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">顯示藍牙 LE</string>
     <string name="settings_gps_head">GPS 設置</string>
     <string name="enable_kalman">過濾 GPS 噪聲</string>
+    <string name="gps_old_message">由於 Google 的政策，應用商店不再支持此設備。請備份您的數據並從 https://github.com/wiglenet/wigle-wifi-wardriving/ 旁加載 WiGLE v. 2.67 .apk（或更低版本）。帶來不便敬請諒解！</string>
+    <string name="gps_old_title">無法初始化 GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rTW/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rTW/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">顯示藍牙 LE</string>
     <string name="settings_gps_head">GPS 設置</string>
     <string name="enable_kalman">過濾 GPS 噪聲</string>
+    <string name="gps_old_message">由於 Google 的政策，應用商店不再支持此設備。請備份您的數據並從 https://github.com/wiglenet/wigle-wifi-wardriving/ 旁加載 WiGLE v. 2.67 .apk（或更低版本）。帶來不便敬請諒解！</string>
+    <string name="gps_old_title">無法初始化 GPS</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh/strings.xml
@@ -438,4 +438,6 @@
     <string name="filter_show_btle">显示蓝牙 LE</string>
     <string name="settings_gps_head">GPS 设置</string>
     <string name="enable_kalman">过滤 GPS 噪声</string>
+    <string name="gps_old_message">由于 Google 的政策，应用商店不再支持此设备。请备份您的数据并从 https://github.com/wiglenet/wigle-wifi-wardriving/ 旁加载 WiGLE v. 2.67 .apk（或更低版本）。带来不便敬请谅解！</string>
+    <string name="gps_old_title">无法初始化 GPS</string>
 </resources>


### PR DESCRIPTION

hate to do this, but it looks like we're forced to use minSdk 24 to list in the app store with working GNSS support now. RIP, some of my favorite old WiGLE-ing phones. :(

These phones would otherwise receive an app upgrade with no path to working GNSS on play store release.