### PR TITLE
[ENH] Upload status <> human readable

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UploadsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UploadsFragment.java
@@ -62,18 +62,18 @@ public class UploadsFragment extends Fragment {
     private TextView queueDepth;
     private UploadsResponse latestResponse;
 
-    private static final Map<String, String> uploadStatusMap;
+    private static final Map<Upload.Status, String> uploadStatusMap;
     static {
-        Map<String, String> statusMap = new HashMap<>();
-        statusMap.put("W", "upload_queued");
-        statusMap.put("I", "upload_parsing");
-        statusMap.put("T", "upload_trilaterating");
-        statusMap.put("S", "upload_stats");
-        statusMap.put("D", "upload_success");
-        statusMap.put("E", "upload_failed");
-        statusMap.put("A", "upload_archive");
-        statusMap.put("C", "upload_catalog");
-        statusMap.put("G", "upload_geoindex");
+        Map<Upload.Status, String> statusMap = new HashMap<>();
+        statusMap.put(Upload.Status.QUEUED, "upload_queued");
+        statusMap.put(Upload.Status.PARSING, "upload_parsing");
+        statusMap.put(Upload.Status.TRILATERATING, "upload_trilaterating");
+        statusMap.put(Upload.Status.STATS, "upload_stats");
+        statusMap.put(Upload.Status.SUCCESS, "upload_success");
+        statusMap.put(Upload.Status.FAILED, "upload_failed");
+        statusMap.put(Upload.Status.ARCHIVE, "upload_archive");
+        statusMap.put(Upload.Status.CATALOG, "upload_catalog");
+        statusMap.put(Upload.Status.GEOINDEX, "upload_geoindex");
 
         uploadStatusMap = Collections.unmodifiableMap(statusMap);
     }
@@ -178,7 +178,7 @@ public class UploadsFragment extends Fragment {
                                         u.setUploadedFromLocal(false);
                                         u.setDownloadedToLocal(false);
                                     }
-                                    u.setStatus(statusValue(u.getStatus()));
+                                    u.setHumanReadableStatus(statusValue(u.getStatus()));
                                 }
                             } catch (Exception e) {
                                 Logging.error("Uploads download error: ", e);
@@ -228,7 +228,7 @@ public class UploadsFragment extends Fragment {
 
     }
 //TODO: apply to JSON object
-    private String statusValue(String statusCode) {
+    private String statusValue(Upload.Status statusCode) {
         String packageName = "net.wigle.wigleandroid";
         int stringId =  getResources().getIdentifier("upload_unknown", "string", packageName);
         if (uploadStatusMap.containsKey(statusCode)) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UploadsListAdapter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UploadsListAdapter.java
@@ -72,23 +72,24 @@ public final class UploadsListAdapter extends AbstractListAdapter<Upload> {
         if (null != upload) {
             TextView tv = row.findViewById(R.id.transid);
             final String transId = upload.getTransid();
-
             tv.setText(transId);
 
+            final boolean completed = Upload.Status.SUCCESS.equals(upload.getStatus());
+            final boolean preTrilateration = Upload.Status.TRILATERATING.equals(upload.getStatus()) || Upload.Status.PARSING.equals(upload.getStatus());
+
             tv = row.findViewById(R.id.total_wifi_gps);
-            tv.setText(numberFormat.format(upload.getTotalWifiGps()));
+            tv.setText(!preTrilateration?numberFormat.format(upload.getTotalWifiGps()):"("+numberFormat.format(upload.getTotalWifi())+")");
 
             tv = row.findViewById(R.id.total_bt_gps);
-            tv.setText(numberFormat.format(upload.getTotalBtGps()));
+            tv.setText(!preTrilateration?numberFormat.format(upload.getTotalBtGps()):"("+numberFormat.format(upload.getTotalBt())+")");
 
             tv = row.findViewById(R.id.total_cell_gps);
-            tv.setText(numberFormat.format(upload.getTotalCellGps()));
+            tv.setText(!preTrilateration?numberFormat.format(upload.getTotalCellGps()):"("+numberFormat.format(upload.getTotalCell())+")");
 
             tv = row.findViewById(R.id.file_size);
             tv.setText(context.getString(R.string.bytes) + ": "
                     + numberFormat.format(upload.getFileSize()));
 
-            final String status = upload.getStatus();
             final String userId = prefs.getString(PreferenceKeys.PREF_AUTHNAME, "");
             final boolean isAnonymous = prefs.getBoolean(PreferenceKeys.PREF_BE_ANONYMOUS, false);
 
@@ -104,7 +105,7 @@ public final class UploadsListAdapter extends AbstractListAdapter<Upload> {
                 } else if (upload.getUploadedFromLocal()) {
                     final String fName = upload.getFileName();
                     final String fileName = fName.substring(fName.indexOf("_") + 1) + FileUtility.GZ_EXT;
-                    if ("Completed".equals(status)) {
+                    if (completed) {
                         message += context.getString(R.string.uploaded) + context.getString(R.string.click_access);
                         ib.setImageResource(R.drawable.ic_ulstatus_uled);
                         if (fName.contains("_")) {
@@ -118,7 +119,7 @@ public final class UploadsListAdapter extends AbstractListAdapter<Upload> {
                         ib.setOnClickListener(v -> handleCsvShare(transId, fileName, fragment));
                     }
                 } else {
-                    if ("Completed".equals(status)) {
+                    if (completed) {
                         message += context.getString(R.string.uploaded) + context.getString(R.string.click_download);
                         ib.setImageResource(R.drawable.ic_ulstatus_nolocal);
                         ib.setOnClickListener(v -> {
@@ -174,7 +175,7 @@ public final class UploadsListAdapter extends AbstractListAdapter<Upload> {
 
             ImageButton share = row.findViewById(R.id.share_upload);
             ImageButton view = row.findViewById(R.id.view_upload);
-            if (!userId.isEmpty() && (!isAnonymous) && ("Completed".equals(status))) {
+            if (!userId.isEmpty() && (!isAnonymous) && (completed)) {
                 share.setVisibility(View.VISIBLE);
                 share.setOnClickListener(v -> {
                     Logging.info("Sharing transId: " + transId);
@@ -254,7 +255,7 @@ public final class UploadsListAdapter extends AbstractListAdapter<Upload> {
 
             String percentDonePrefix = "";
             String percentDoneSuffix = "%";
-            if ("Queued for Processing".equals(status)) {
+            if (Upload.Status.QUEUED.equals(upload.getStatus())) {
                 percentDonePrefix = "#";
                 percentDoneSuffix = "";
             }
@@ -262,7 +263,7 @@ public final class UploadsListAdapter extends AbstractListAdapter<Upload> {
             tv.setText(percentDonePrefix + upload.getPercentDone() + percentDoneSuffix);
 
             tv = row.findViewById(R.id.status);
-            tv.setText(upload.getStatus());
+            tv.setText(upload.getHumanReadableStatus());
         }
 
         return row;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Upload.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Upload.java
@@ -9,24 +9,33 @@ public final class Upload {
     private final String transid;
     @SerializedName("totalGps")
     private final long totalWifiGps;
+    @SerializedName("total")
+    private final long totalWifi;
     @SerializedName("btTotalGps")
     private final long totalBtGps;
+    @SerializedName("btTotal")
+    private final long totalBt;
     @SerializedName("genTotalGps")
     private final long totalCellGps;
+    @SerializedName("genTotal")
+    private final long totalCell;
     private final int percentDone;
-    private String status;
+    private String humanReadableStatus;
     private final long fileSize;
     private final String fileName;
     private Boolean uploadedFromLocal;
     private Boolean downloadedToLocal;
+    private final Status status;
 
-    public Upload(final String transid, final long totalWifiGps, final long totalBtGps, final long totalCellGps,
-                  final int percentDone, final String status, final long fileSize, final String fileName, final Boolean uploadedFromLocal, final Boolean downloadedToLocal) {
-
+    public Upload(final String transid, final long totalWifiGps, final long totalBtGps, final long totalCellGps, final long totalWifi, final long totalBt, final long totalCell,
+                  final int percentDone, final Status status, final long fileSize, final String fileName, final Boolean uploadedFromLocal, final Boolean downloadedToLocal) {
         this.transid = transid;
         this.totalWifiGps = totalWifiGps;
         this.totalBtGps = totalBtGps;
         this.totalCellGps = totalCellGps;
+        this.totalWifi = totalWifi;
+        this.totalBt = totalBt;
+        this.totalCell = totalCell;
         this.percentDone = percentDone;
         this.status = status;
         this.fileSize = fileSize;
@@ -51,16 +60,28 @@ public final class Upload {
         return totalCellGps;
     }
 
+    public long getTotalWifi() {
+        return totalWifi;
+    }
+
+    public long getTotalBt() {
+        return totalBt;
+    }
+
+    public long getTotalCell() {
+        return totalCell;
+    }
+
     public int getPercentDone() {
         return percentDone;
     }
 
-    public String getStatus() {
-        return status;
+    public String getHumanReadableStatus() {
+        return humanReadableStatus;
     }
 
-    public void setStatus(final String status) {
-        this.status = status;
+    public void setHumanReadableStatus(final String humanReadableStatus) {
+        this.humanReadableStatus = humanReadableStatus;
     }
 
     public long getFileSize() {
@@ -85,5 +106,39 @@ public final class Upload {
 
     public void setDownloadedToLocal(Boolean downloadedToLocal) {
         this.downloadedToLocal = downloadedToLocal;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public enum Status {
+        @SerializedName("W")
+        QUEUED("W"),
+        @SerializedName("I")
+        PARSING("I"),
+        @SerializedName("T")
+        TRILATERATING("T"),
+        @SerializedName("S")
+        STATS("S"),
+        @SerializedName("D")
+        SUCCESS("D"),
+        @SerializedName("E")
+        FAILED("E"),
+        @SerializedName("A")
+        ARCHIVE("A"),
+        @SerializedName("C")
+        CATALOG("C"),
+        @SerializedName("G")
+        GEOINDEX("G"),
+        //TODO: handoff type
+        @SerializedName("?")
+        UNKNOWN("?");
+
+        private final String stringStatus;
+
+        Status(final String status) {
+            this.stringStatus = status;
+        }
     }
 }


### PR DESCRIPTION
taking some feedback from previous code review, only to find a bug that needed fixing
 - Upload status now uses an enum.
 - Previous upload list row behavior hinged on human-readable strings, which was... broken.
 - Not sure if there's a more elegant way to translate to human readable but at least this isn't broken.