### PR TITLE
[FIX] Preventing KML injection via crafted SSID

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlWriter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/KmlWriter.java
@@ -14,7 +14,6 @@ import java.util.regex.Pattern;
 import net.wigle.wigleandroid.db.DBException;
 import net.wigle.wigleandroid.db.DatabaseHelper;
 import net.wigle.wigleandroid.MainActivity;
-import net.wigle.wigleandroid.model.Network;
 import net.wigle.wigleandroid.model.NetworkType;
 import net.wigle.wigleandroid.util.FileAccess;
 import net.wigle.wigleandroid.util.FileUtility;
@@ -248,7 +247,9 @@ public class KmlWriter extends AbstractBackgroundTask {
                 sanitizedSsid = NO_SSID.getBytes(MainActivity.ENCODING);
             }
 
-            if (type.equals(NetworkType.WIFI)) {
+            if (type == null) {
+                Logging.warn("uninitialized network type for network: "+bssid);
+            } else if (type.equals(NetworkType.WIFI)) {
 
                 final String encStatus = "Encryption: " + encryptionStringForCapabilities(capabilities) + "\n";
 


### PR DESCRIPTION
The current approach to filtering the SSID values before appending it to the KML file is to replace certain ranges of the charset. The usage of CDATA can filter most of the [XXE](https://portswigger.net/web-security/xxe) paylods which consist of `<`, `>` and `&` based tags. I found out, that there is still a posibility to inject a payload by escaping from the CDATA tag and then inserting XML/KML tags. To make things clear, this bug **IS NOT** a security vulnerability, but still a bug, which is able to generate a corrupted KML file, what can potentialy lead to *full*/*run* data loss. There is also a small propability that a corrupted KML file can cause problems with third-party applications (very old example: [CVE-2006-7157](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2006-7157)), but that's not really our concern.

The implementation still needs to be refined which characters should be additionally removed, and which implemented rules should be removed. The implementation itself is very simple and the best practice would be to use a *battle-tested* XML sanitization library.

PoC:
Test home-router `SSID` set to: `]]>test<![CDATA[`, after performing a scan and generating the KML file we can see the test network:
```xml
<!-- more data... -->
<Placemark>
    <name><![CDATA[]]>test<![CDATA[]]></name>
    <description><![CDATA[ more data... ]]></description>
    <styleUrl>more data...</styleUrl>
    <Point><coordinates>more data...</coordinates></Point>
</Placemark>
<!-- more data... -->
```
The fact that the `test` string is outside of the CDATA means that all type of XML/KML tags can be injected inside.