### PR TITLE
[FIX] fixes for pre-release report issues

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/AddressFilterAdapter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/AddressFilterAdapter.java
@@ -14,7 +14,6 @@ import com.google.gson.Gson;
 
 import net.wigle.wigleandroid.util.Logging;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -25,8 +24,8 @@ import java.util.List;
 public class AddressFilterAdapter extends BaseAdapter implements ListAdapter {
 
     //enough to make a list and update prefs from it.
-    private List<String> list = new ArrayList<String>();
-    private Context context;
+    private final List<String> list;
+    private final Context context;
     private final SharedPreferences prefs;
     private final String filterKey;
 
@@ -68,27 +67,23 @@ public class AddressFilterAdapter extends BaseAdapter implements ListAdapter {
             view = inflater.inflate(R.layout.address_filter_list_item, null);
         }
 
-        TextView listItemText = (TextView)view.findViewById(R.id.list_item_string);
+        TextView listItemText = view.findViewById(R.id.list_item_string);
         listItemText.setText(list.get(position));
 
-        ImageButton deleteBtn = (ImageButton)view.findViewById(R.id.delete_btn);
+        ImageButton deleteBtn = view.findViewById(R.id.delete_btn);
 
-        deleteBtn.setOnClickListener(new View.OnClickListener(){
-            @Override
-            public void onClick(View v) {
-                if (position < list.size()) list.remove(position);
-                Gson gson = new Gson();
-                String serialized = gson.toJson(list.toArray());
-                Logging.info(serialized);
-                final SharedPreferences.Editor editor = prefs.edit();
-                editor.putString(filterKey,serialized);
-                editor.apply();
-                notifyDataSetChanged();
-                MainActivity m = MainActivity.getMainActivity();
-                if (null != m) {
-                    m.updateAddressFilter(filterKey);
-                }
-                //ALIBI: if there's no mainactivity, we can't very well log the error.
+        deleteBtn.setOnClickListener(v -> {
+            if (position < list.size()) list.remove(position);
+            Gson gson = new Gson();
+            String serialized = gson.toJson(list.toArray());
+            Logging.info(serialized);
+            final SharedPreferences.Editor editor = prefs.edit();
+            editor.putString(filterKey,serialized);
+            editor.apply();
+            notifyDataSetChanged();
+            MainActivity m = MainActivity.getMainActivity();
+            if (null != m) {
+                m.updateAddressFilter(filterKey);
             }
         });
         return view;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MacFilterActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MacFilterActivity.java
@@ -51,8 +51,9 @@ public class MacFilterActivity extends AppCompatActivity {
         //DEBUG: MainActivity.info(filterKey);
         Gson gson = new Gson();
         String[] values = gson.fromJson(prefs.getString(filterKey, "[]"), String[].class);
-        if(values.length>0) {
-            listItems = Arrays.asList(values);
+        if (values.length > 0) {
+            //ALIBI: the java.util.Arrays.ArrayList version is immutable, so a new ArrayList must be made from it.
+            listItems = new ArrayList<>(Arrays.asList(values));
         }
 
         ListView lv = findViewById(R.id.addr_filter_list_view);
@@ -64,7 +65,7 @@ public class MacFilterActivity extends AppCompatActivity {
 
     public void addOui(View v) {
         final MaskedEditText ouiInput = findViewById(R.id.oui_input);
-        final String input = ouiInput.getRawText().toString();
+        final String input = ouiInput.getRawText();
         if (input.length() == 6) {
             final SharedPreferences prefs = this.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
             if (addEntry(listItems, prefs, input, filterKey)) {


### PR DESCRIPTION
Subtle: you must make a mutable `java.util.ArrayList` from the `java.util.Arrays.ArrayList` before using it in a context where `.remove()` can be called on it!
(per [this post](https://stackoverflow.com/questions/6260113/unsupportedoperationexception-in-abstractlist-remove-when-operating-on-arrayli) )
Some incidental linting.