### PR TITLE
Only move camera if there were results

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DBResultActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DBResultActivity.java
@@ -245,10 +245,12 @@ public class DBResultActivity extends AppCompatActivity {
                 }
             }
         }
-        try {
-            mapView.getMapAsync(googleMap -> googleMap.moveCamera(CameraUpdateFactory.newLatLngBounds(builder.build(), 0)));
-        } catch (IllegalStateException ise) {
-            Logging.error("Illegal state exception on map move: ",ise);
+        if (!listAdapter.isEmpty()) {
+            try {
+                mapView.getMapAsync(googleMap -> googleMap.moveCamera(CameraUpdateFactory.newLatLngBounds(builder.build(), 0)));
+            } catch (IllegalStateException ise) {
+                Logging.error("Illegal state exception on map move: ", ise);
+            }
         }
         resultList.clear();
     }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DBResultActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DBResultActivity.java
@@ -214,7 +214,9 @@ public class DBResultActivity extends AppCompatActivity {
                         for (Network n: resultList) {
                             listAdapter.add(n);
                             mapRender.addItem(n);
-                            builder.include(n.getPosition());
+                            final LatLng ll = n.getPosition();
+                            //noinspection ConstantConditions
+                            if (ll != null) builder.include(ll);
                         }
                         mapView.getMapAsync(googleMap -> googleMap.moveCamera(CameraUpdateFactory.newLatLngBounds(builder.build(), 0)));
                         resultList.clear();


### PR DESCRIPTION
Somehow had an IllegalStateException get out of that catch. Might as well check that there is anything to move to and ignore the move entirely.