### PR TITLE
[FIX] Refactor login dialog, lint/cleanup

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DBResultActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DBResultActivity.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeMap;
 
-import android.app.Activity;
 import android.database.Cursor;
 import android.location.Address;
 import android.location.Location;
@@ -40,10 +39,8 @@ import net.wigle.wigleandroid.model.Network;
 import net.wigle.wigleandroid.model.QueryArgs;
 import net.wigle.wigleandroid.model.api.WiFiSearchResponse;
 import net.wigle.wigleandroid.net.AuthenticatedRequestCompletedListener;
-import net.wigle.wigleandroid.net.RequestCompletedListener;
 import net.wigle.wigleandroid.ui.SetNetworkListAdapter;
 import net.wigle.wigleandroid.ui.WiGLEAuthDialog;
-import net.wigle.wigleandroid.ui.WiGLEConfirmationDialog;
 import net.wigle.wigleandroid.ui.WiGLEToast;
 import net.wigle.wigleandroid.util.Logging;
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -1314,7 +1314,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         final State state = getStaticState();
         return () -> {
             // Collections.emptyIterator() requires api 19, but this works.
-            if (state == null) return Collections.<String>emptySet().iterator();
+            if (state == null) return Collections.emptyIterator();
 
             return new Iterator<String>() {
                 int currentPointer = state.logPointer;
@@ -1967,12 +1967,8 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         if (state.GNSSListener != null) {
             // remove any old requests
             locationManager.removeUpdates(state.GNSSListener);
-            if (Build.VERSION.SDK_INT >= 24) {
-                if (gnssStatusCallback != null) {
-                    locationManager.unregisterGnssStatusCallback(gnssStatusCallback);
-                }
-            } else {
-                locationManager.removeGpsStatusListener(state.GNSSListener);
+            if (gnssStatusCallback != null) {
+                locationManager.unregisterGnssStatusCallback(gnssStatusCallback);
             }
         }
 
@@ -1980,48 +1976,31 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         state.GNSSListener = new GNSSListener(this, state.dbHelper);
         state.GNSSListener.setMapListener(MappingFragment.STATIC_LOCATION_LISTENER);
 
-        if (Build.VERSION.SDK_INT >= 24) {
-            try {
-                gnssStatusCallback = new GnssStatus.Callback() {
-                    @Override
-                    public void onStarted() {
-                    }
-
-                    @Override
-                    public void onStopped() {
-                        state.GNSSListener.handleScanStop();
-                    }
-
-                    @Override
-                    public void onFirstFix(int ttffMillis) {
-                    }
-
-                    @Override
-                    public void onSatelliteStatusChanged(GnssStatus status) {
-                        state.GNSSListener.onGnssStatusChanged(status);
-                    }
-                };
-                locationManager.registerGnssStatusCallback(gnssStatusCallback);
-            } catch (final SecurityException ex) {
-                Logging.info("\tSecurity exception adding status listener: " + ex, ex);
-            } catch (final Exception ex) {
-                Logging.error("Error registering for gnss: " + ex, ex);
-            }
-        } else {
-            Logging.error("Failed to setup GPS - SDK < 24 ("+Build.VERSION.SDK_INT+")");
-            Handler handler = new Handler(Looper.getMainLooper());
-            handler.post(() -> {
-                AlertDialog.Builder iseDlgBuilder = new AlertDialog.Builder(this);
-                iseDlgBuilder.setMessage(R.string.gps_old_message)
-                        .setTitle(getString(R.string.gps_old_title))
-                        .setCancelable(true)
-                        .setPositiveButton(R.string.ok, (dialog, which) -> dialog.dismiss());
-                final Dialog dialog = iseDlgBuilder.create();
-                if (!isFinishing()) {
-                    dialog.show();
+        try {
+            gnssStatusCallback = new GnssStatus.Callback() {
+                @Override
+                public void onStarted() {
                 }
-            });
 
+                @Override
+                public void onStopped() {
+                    state.GNSSListener.handleScanStop();
+                }
+
+                @Override
+                public void onFirstFix(int ttffMillis) {
+                }
+
+                @Override
+                public void onSatelliteStatusChanged(GnssStatus status) {
+                    state.GNSSListener.onGnssStatusChanged(status);
+                }
+            };
+            locationManager.registerGnssStatusCallback(gnssStatusCallback);
+        } catch (final SecurityException ex) {
+            Logging.info("\tSecurity exception adding status listener: " + ex, ex);
+        } catch (final Exception ex) {
+            Logging.error("Error registering for gnss: " + ex, ex);
         }
 
         final SharedPreferences prefs = getSharedPreferences(PreferenceKeys.SHARED_PREFS, Context.MODE_PRIVATE);
@@ -2049,12 +2028,8 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                 Logging.info("removing location listener: " + state.GNSSListener);
                 try {
                     locationManager.removeUpdates(state.GNSSListener);
-                    if (Build.VERSION.SDK_INT >= 24) {
-                        if (gnssStatusCallback != null) {
-                            locationManager.unregisterGnssStatusCallback(gnssStatusCallback);
-                        }
-                    } else {
-                        locationManager.removeGpsStatusListener(state.GNSSListener);
+                    if (gnssStatusCallback != null) {
+                        locationManager.unregisterGnssStatusCallback(gnssStatusCallback);
                     }
                     locationManager.removeUpdates(state.GNSSListener);
                 } catch (final SecurityException ex) {
@@ -2250,10 +2225,8 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             final LocationManager locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
             if (state.GNSSListener != null && locationManager != null) {
                 try {
-                    if (Build.VERSION.SDK_INT >= 24) {
-                        if (gnssStatusCallback != null) {
-                            locationManager.unregisterGnssStatusCallback(gnssStatusCallback);
-                        }
+                    if (gnssStatusCallback != null) {
+                        locationManager.unregisterGnssStatusCallback(gnssStatusCallback);
                     }
                     locationManager.removeUpdates(state.GNSSListener);
                 } catch (final SecurityException ex) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MapRender.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MapRender.java
@@ -1,6 +1,5 @@
 package net.wigle.wigleandroid;
 
-import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.AsyncTask;
@@ -9,8 +8,9 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
 
+import androidx.annotation.NonNull;
+
 import com.google.android.gms.maps.GoogleMap;
-import com.google.android.gms.maps.GoogleMap.OnCameraMoveListener;
 import com.google.android.gms.maps.GoogleMap.OnCameraIdleListener;
 import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.BitmapDescriptorFactory;
@@ -67,7 +67,7 @@ public class MapRender implements ClusterManager.OnClusterClickListener<Network>
         }
 
         @Override
-        protected void onBeforeClusterItemRendered(Network network, MarkerOptions markerOptions) {
+        protected void onBeforeClusterItemRendered(@NonNull Network network, MarkerOptions markerOptions) {
             // Draw a single network.
             final BitmapDescriptor icon = getIcon(network);
             markerOptions.icon(icon);
@@ -113,7 +113,7 @@ public class MapRender implements ClusterManager.OnClusterClickListener<Network>
         }
 
         @Override
-        protected void onBeforeClusterRendered(Cluster<Network> cluster, MarkerOptions markerOptions) {
+        protected void onBeforeClusterRendered(@NonNull Cluster<Network> cluster, @NonNull MarkerOptions markerOptions) {
             // Draw a cluster
             super.onBeforeClusterRendered(cluster, markerOptions);
             markerOptions.title(cluster.getSize() + " Networks");
@@ -136,7 +136,7 @@ public class MapRender implements ClusterManager.OnClusterClickListener<Network>
         }
 
         @Override
-        protected boolean shouldRenderAsCluster(Cluster<Network> cluster) {
+        protected boolean shouldRenderAsCluster(@NonNull Cluster<Network> cluster) {
             return (prefs.getBoolean( PreferenceKeys.PREF_MAP_CLUSTER, true ) && cluster.getSize() > 4)
                     || cluster.getSize() >= 100;
         }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ProgressPanel.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ProgressPanel.java
@@ -5,8 +5,6 @@ import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import org.w3c.dom.Text;
-
 /**
  * Created by arkasha on 5/22/17.
  */

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RankStatsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RankStatsFragment.java
@@ -30,7 +30,6 @@ import net.wigle.wigleandroid.net.AuthenticatedRequestCompletedListener;
 import net.wigle.wigleandroid.net.RequestCompletedListener;
 import net.wigle.wigleandroid.ui.EndlessScrollListener;
 import net.wigle.wigleandroid.ui.ProgressThrobberFragment;
-import net.wigle.wigleandroid.ui.WiGLEAuthDialog;
 import net.wigle.wigleandroid.ui.WiGLEToast;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.MenuUtil;
@@ -119,12 +118,7 @@ public class RankStatsFragment extends ProgressThrobberFragment {
                 s.apiManager.getUserStats(new AuthenticatedRequestCompletedListener<UserStats, JSONObject>() {
                     @Override
                     public void onAuthenticationRequired() {
-                        final FragmentActivity fa = getActivity();
-                        if (null != fa) {
-                            WiGLEAuthDialog.createDialog(fa, getString(R.string.login_title),
-                                    getString(R.string.login_required), getString(R.string.login),
-                                    getString(R.string.cancel));
-                        }
+                        showAuthDialog();
                     }
 
                     @Override

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RegistrationActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RegistrationActivity.java
@@ -1,11 +1,10 @@
 package net.wigle.wigleandroid;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
-import android.os.Build;
 import android.os.Bundle;
 import androidx.appcompat.app.AppCompatActivity;
 import android.webkit.CookieManager;
-import android.webkit.CookieSyncManager;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -21,11 +20,12 @@ public class RegistrationActivity extends AppCompatActivity {
 
     public static final String AGENT = "WiGLE WiFi Registrant";
 
+    @SuppressLint("SetJavaScriptEnabled")
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_registration);
-        WebView regWebView = (WebView) findViewById(R.id.wigle_registration_container);
+        WebView regWebView = findViewById(R.id.wigle_registration_container);
         WebSettings webSettings = regWebView.getSettings();
         webSettings.setJavaScriptEnabled(true);
         regWebView.clearCache(true);
@@ -35,9 +35,7 @@ public class RegistrationActivity extends AppCompatActivity {
         }
         regWebView.setWebChromeClient(new WebChromeClient());
         regWebView.getSettings().setUserAgentString(AGENT);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-            WebView.setWebContentsDebuggingEnabled(true);
-        }
+        WebView.setWebContentsDebuggingEnabled(true);
         regWebView.addJavascriptInterface(new WiGLERegistrationInterface(this),
                 "WiGLEWiFi");
         regWebView.loadUrl(UrlConfig.REG_URL);
@@ -47,19 +45,8 @@ public class RegistrationActivity extends AppCompatActivity {
      * dammit, android. stolen from:
      * https://stackoverflow.com/questions/28998241/how-to-clear-cookies-and-cache-of-webview-on-android-when-not-in-webview
      */
-    @SuppressWarnings("deprecation")
     protected void clearCookies(Context context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
-            CookieManager.getInstance().removeAllCookies(null);
-            CookieManager.getInstance().flush();
-        } else  {
-            CookieSyncManager cookieSyncMngr=CookieSyncManager.createInstance(context);
-            cookieSyncMngr.startSync();
-            CookieManager cookieManager=CookieManager.getInstance();
-            cookieManager.removeAllCookie();
-            cookieManager.removeSessionCookie();
-            cookieSyncMngr.stopSync();
-            cookieSyncMngr.sync();
-        }
+        CookieManager.getInstance().removeAllCookies(null);
+        CookieManager.getInstance().flush();
     }
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UploadsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UploadsFragment.java
@@ -28,7 +28,6 @@ import net.wigle.wigleandroid.model.api.UploadsResponse;
 import net.wigle.wigleandroid.net.AuthenticatedRequestCompletedListener;
 import net.wigle.wigleandroid.ui.EndlessScrollListener;
 import net.wigle.wigleandroid.ui.ProgressThrobberFragment;
-import net.wigle.wigleandroid.ui.WiGLEAuthDialog;
 import net.wigle.wigleandroid.util.FileUtility;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.MenuUtil;
@@ -203,12 +202,7 @@ public class UploadsFragment extends ProgressThrobberFragment {
 
                         @Override
                         public void onAuthenticationRequired() {
-                            final FragmentActivity fa = getActivity();
-                            if (null != fa) {
-                                WiGLEAuthDialog.createDialog(fa, getString(R.string.login_title),
-                                        getString(R.string.login_required), getString(R.string.login),
-                                        getString(R.string.cancel));
-                            }
+                            showAuthDialog();
                         }
                     }
                 );

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UserStatsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/UserStatsFragment.java
@@ -2,7 +2,6 @@ package net.wigle.wigleandroid;
 
 import android.annotation.SuppressLint;
 import android.app.Activity;
-import android.content.DialogInterface;
 import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
@@ -13,7 +12,6 @@ import android.os.AsyncTask;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
 import androidx.core.view.MenuItemCompat;
 import androidx.fragment.app.FragmentActivity;
@@ -32,9 +30,7 @@ import com.google.android.material.navigation.NavigationView;
 
 import net.wigle.wigleandroid.model.api.UserStats;
 import net.wigle.wigleandroid.net.AuthenticatedRequestCompletedListener;
-import net.wigle.wigleandroid.net.RequestCompletedListener;
-import net.wigle.wigleandroid.ui.WiGLEAuthDialog;
-import net.wigle.wigleandroid.ui.WiGLEConfirmationDialog;
+import net.wigle.wigleandroid.ui.AuthenticatedFragment;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.MenuUtil;
 import net.wigle.wigleandroid.util.UrlConfig;
@@ -47,7 +43,7 @@ import java.text.NumberFormat;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-public class UserStatsFragment extends Fragment {
+public class UserStatsFragment extends AuthenticatedFragment {
     public static final int MSG_USER_DONE = 101;
     private static final int MENU_SITE_STATS = 201;
     private static final int MENU_RANK_STATS = 202;
@@ -114,9 +110,7 @@ public class UserStatsFragment extends Fragment {
                 public void onAuthenticationRequired() {
                     final FragmentActivity fa = getActivity();
                     if (null != fa) {
-                        WiGLEAuthDialog.createDialog(fa, getString(R.string.login_title),
-                                getString(R.string.login_required), getString(R.string.login),
-                                getString(R.string.cancel));
+                        showAuthDialog();
                     }
                 }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/net/BasicAuthInterceptor.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/net/BasicAuthInterceptor.java
@@ -5,6 +5,8 @@ import android.content.SharedPreferences;
 import net.wigle.wigleandroid.TokenAccess;
 import net.wigle.wigleandroid.util.PreferenceKeys;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.io.IOException;
 
 import okhttp3.Credentials;
@@ -22,7 +24,7 @@ public class BasicAuthInterceptor implements Interceptor {
     }
 
     @Override
-    public Response intercept(Interceptor.Chain chain) throws IOException {
+    public Response intercept(@NotNull Interceptor.Chain chain) throws IOException {
         Request request = chain.request();
         Request authenticatedRequest = request.newBuilder()
                 .header("Authorization", credentials).build();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/AuthenticatedFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/AuthenticatedFragment.java
@@ -1,0 +1,17 @@
+package net.wigle.wigleandroid.ui;
+
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+
+import net.wigle.wigleandroid.R;
+
+public class AuthenticatedFragment extends Fragment {
+    public void showAuthDialog() {
+        final FragmentActivity fa = getActivity();
+        if (null != fa) {
+            WiGLEAuthDialog.createDialog(fa, getString(R.string.login_title),
+                    getString(R.string.login_required), getString(R.string.login),
+                    getString(R.string.cancel));
+        }
+    }
+}

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/GpxRecyclerAdapter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/GpxRecyclerAdapter.java
@@ -17,7 +17,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.google.android.gms.maps.GoogleMap;
 
 import net.wigle.wigleandroid.ListFragment;
-import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.R;
 import net.wigle.wigleandroid.model.PolylineRoute;
 import net.wigle.wigleandroid.util.Logging;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/PrefsBackedCheckbox.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/PrefsBackedCheckbox.java
@@ -6,7 +6,6 @@ import android.content.SharedPreferences;
 import android.view.View;
 import android.widget.CheckBox;
 
-import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.listener.PrefCheckboxListener;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.PreferenceKeys;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/ProgressThrobberFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/ProgressThrobberFragment.java
@@ -13,7 +13,7 @@ import net.wigle.wigleandroid.util.Logging;
 /**
  * Loading "throbber" image parent class for network-based fragments.
  */
-public abstract class ProgressThrobberFragment extends Fragment {
+public abstract class ProgressThrobberFragment extends AuthenticatedFragment {
     protected ImageView loadingImage;
     protected ImageView errorImage;
     protected boolean animating = false;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/ThemeUtil.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/ThemeUtil.java
@@ -38,21 +38,19 @@ public class ThemeUtil {
     }
 
     public static void setNavTheme(final Window w, final Context c, final SharedPreferences prefs) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            ExecutorService executor = Executors.newSingleThreadExecutor();
-            Handler handler = new Handler(Looper.getMainLooper());
-            executor.execute(() -> {
-                final int displayMode = prefs.getInt(PreferenceKeys.PREF_DAYNIGHT_MODE, AppCompatDelegate.MODE_NIGHT_YES);
-                final int nightModeFlags = c.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
-                handler.post(() -> {
-                    if (AppCompatDelegate.MODE_NIGHT_YES == displayMode ||
-                            (AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM == displayMode &&
-                                    nightModeFlags == Configuration.UI_MODE_NIGHT_YES)) {
-                        w.setNavigationBarColor(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
-                    }
-                });
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        Handler handler = new Handler(Looper.getMainLooper());
+        executor.execute(() -> {
+            final int displayMode = prefs.getInt(PreferenceKeys.PREF_DAYNIGHT_MODE, AppCompatDelegate.MODE_NIGHT_YES);
+            final int nightModeFlags = c.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+            handler.post(() -> {
+                if (AppCompatDelegate.MODE_NIGHT_YES == displayMode ||
+                        (AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM == displayMode &&
+                                nightModeFlags == Configuration.UI_MODE_NIGHT_YES)) {
+                    w.setNavigationBarColor(WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION);
+                }
             });
-        }
+        });
     }
 
     public static void setMapTheme(final GoogleMap googleMap, final Context c, final SharedPreferences prefs, final int mapNightThemeId) {
@@ -66,15 +64,13 @@ public class ThemeUtil {
     }
 
     public static boolean shouldUseMapNightMode(final Context c, final SharedPreferences prefs) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            final boolean mapsMatchMode = prefs.getBoolean(PreferenceKeys.PREF_MAPS_FOLLOW_DAYNIGHT, false);
-            if (mapsMatchMode) {
-                final int displayMode = prefs.getInt(PreferenceKeys.PREF_DAYNIGHT_MODE, AppCompatDelegate.MODE_NIGHT_YES);
-                final int nightModeFlags = c.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
-                return AppCompatDelegate.MODE_NIGHT_YES == displayMode ||
-                        (AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM == displayMode &&
-                                nightModeFlags == Configuration.UI_MODE_NIGHT_YES);
-            }
+        final boolean mapsMatchMode = prefs.getBoolean(PreferenceKeys.PREF_MAPS_FOLLOW_DAYNIGHT, false);
+        if (mapsMatchMode) {
+            final int displayMode = prefs.getInt(PreferenceKeys.PREF_DAYNIGHT_MODE, AppCompatDelegate.MODE_NIGHT_YES);
+            final int nightModeFlags = c.getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
+            return AppCompatDelegate.MODE_NIGHT_YES == displayMode ||
+                    (AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM == displayMode &&
+                            nightModeFlags == Configuration.UI_MODE_NIGHT_YES);
         }
         return false;
     }


### PR DESCRIPTION
Able to condense all but one of the authentication dialog calls.
Also sacrificing unused includes and unreachable version checks to the lint gods./
The remaining `AppCompatActivity` superclass used in `DBResultActivity` doesn't appear easily reconcilable with `FragmentActivity` (we actually use a lot of the functionality in the child class)