### PR TITLE
settings fragment npe

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
@@ -348,12 +348,16 @@ public final class SettingsFragment extends Fragment implements DialogListener {
                         @Override
                         public void onTaskFailed(int status, JSONObject error) {
                             Logging.error("Authentication: failed: " + status);
-                            final SharedPreferences prefs = SettingsFragment.this.getActivity()
-                                    .getApplicationContext()
-                                    .getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
-                            final Editor editor = prefs.edit();
-                            editor.remove(PreferenceKeys.PREF_PASSWORD);
-                            editor.apply();
+                            FragmentActivity activity = SettingsFragment.this.getActivity();
+                            if (activity == null) activity = MainActivity.getMainActivity();
+                            if (activity != null) {
+                                final SharedPreferences prefs = activity
+                                        .getApplicationContext()
+                                        .getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+                                final Editor editor = prefs.edit();
+                                editor.remove(PreferenceKeys.PREF_PASSWORD);
+                                editor.apply();
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
Saw this on 2.75, going to Try Harder

```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'android.content.Context androidx.fragment.app.FragmentActivity.getApplicationContext()' on a null object reference
  at net.wigle.wigleandroid.SettingsFragment$1.onTaskFailed (SettingsFragment.java:352)
  at net.wigle.wigleandroid.SettingsFragment$1.onTaskFailed (SettingsFragment.java:321)
  at net.wigle.wigleandroid.net.WiGLEApiManager$6.onResponse (WiGLEApiManager.java:313)
  at okhttp3.internal.connection.RealCall$AsyncCall.run (RealCall.kt:519)
  at java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1137)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:637)
  at java.lang.Thread.run (Thread.java:1012)
```