### PR TITLE
[ENH] layout cleanup.

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
@@ -230,18 +230,11 @@ public final class Network implements ClusterItem {
 
     public String getDetail() {
         if ( detail == null ) {
-            final Integer chan = channel != null ? channel : frequency;
             final StringBuilder detailBuild = new StringBuilder( 40 );
-            detailBuild.append( BAR_STRING ).append( bssid );
-            detailBuild.append( DASH_STRING );
-            if ( NetworkType.WIFI.equals(type) ) {
-                detailBuild.append( chan );
+            if (!NetworkType.WIFI.equals(type)) {
+                detailBuild.append(type).append(BAR_STRING);
             }
-            else {
-                detailBuild.append( type );
-            }
-
-            detailBuild.append( DASH_STRING ).append( getShowCapabilities() );
+            detailBuild.append( getShowCapabilities() );
             detail = detailBuild.toString();
         }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/SetNetworkListAdapter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/SetNetworkListAdapter.java
@@ -234,6 +234,18 @@ public final class SetNetworkListAdapter extends AbstractListAdapter<Network> {
         }
         tv.setText(Integer.toString(level));
 
+        tv = row.findViewById(R.id.mac_string);
+        tv.setText(network.getBssid());
+
+        tv = row.findViewById(R.id.chan_freq_string);
+        if (NetworkType.WIFI.equals(network.getType())) {
+            tv.setText(network.getFrequency()+"MHz");
+        } else if (NetworkType.BLE.equals(network.getType())) {
+            tv.setText(network.getType().toString());
+        } else {
+            tv.setText("");
+        }
+
         tv = row.findViewById(R.id.detail);
         String det = network.getDetail();
         tv.setText(det);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/CellNetworkLegend.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/CellNetworkLegend.java
@@ -1,6 +1,5 @@
 package net.wigle.wigleandroid.util;
 
-import android.content.Context;
 import android.telephony.TelephonyManager;
 
 import java.util.Collections;

--- a/wiglewifiwardriving/src/main/res/layout-v29/row.xml
+++ b/wiglewifiwardriving/src/main/res/layout-v29/row.xml
@@ -61,7 +61,7 @@
 	<LinearLayout
 		android:orientation="horizontal"
 		android:layout_width="match_parent"
-		android:layout_height="fill_parent">
+		android:layout_height="wrap_content">
 		<!-- Second row -->
 		<TextView
 			android:id="@+id/level_string"
@@ -84,8 +84,8 @@
 		<TextView
 			android:id="@+id/chan_freq_string"
 			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:gravity="start"
+			android:layout_height="match_parent"
+			android:gravity="start|bottom"
 			android:textSize="13sp"
 			style="@style/ListFreq"
 			tools:text="5888MHz" />

--- a/wiglewifiwardriving/src/main/res/layout-v29/row.xml
+++ b/wiglewifiwardriving/src/main/res/layout-v29/row.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" android:orientation="vertical"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools" android:orientation="vertical"
 	    android:layout_width="fill_parent" android:layout_height="fill_parent">
 	<LinearLayout
 		android:orientation="horizontal"
 		android:layout_width="fill_parent"
-		android:layout_height="fill_parent"
+		android:layout_height="wrap_content"
 		android:paddingTop="1sp">
 		<!-- First row -->
 		<ImageView
@@ -14,7 +15,8 @@
 			android:contentDescription="wep icon"
 			android:paddingLeft="2dp"
 			android:paddingRight="10dp"
-			android:text="wepicon" />
+			android:text="wepicon"
+			tools:src="@drawable/wep_ico"/>
 		<ImageView
 			android:id="@+id/bticon"
 			android:layout_width="wrap_content"
@@ -30,6 +32,7 @@
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
 			android:textColor="@color/colorListSsidText"
+			tools:text="WiFi Network"
 			/>
 		<LinearLayout
 			android:orientation="horizontal"
@@ -40,28 +43,59 @@
 				android:id="@+id/oui"
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"
-				style="@style/ListOui"/>
+				android:paddingEnd="3dp"
+				android:scrollHorizontally="true"
+				android:ellipsize="end"
+				android:maxLines="1"
+				style="@style/ListOui"
+				tools:text="WiGLE NIC, Inc"
+				/>
 			<TextView
 				android:id="@+id/time"
 				android:layout_width="wrap_content"
 				android:layout_height="wrap_content"
-				style="@style/ListTimestamp"/>
+				style="@style/ListTimestamp"
+				tools:text="12:34:56"/>
 		</LinearLayout>
 	</LinearLayout>
 	<LinearLayout
 		android:orientation="horizontal"
-		android:layout_width="fill_parent"
+		android:layout_width="match_parent"
 		android:layout_height="fill_parent">
 		<!-- Second row -->
 		<TextView
 			android:id="@+id/level_string"
 			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"/>
-		<TextView android:id="@+id/detail"
+			android:layout_height="wrap_content"
+			tools:text="-69"
+			android:minWidth="24dp"
+			android:paddingEnd="0dp"
+			android:textSize="12sp" />
+		<TextView
+			android:id="@+id/mac_string"
 			android:layout_width="wrap_content"
 			android:layout_height="wrap_content"
-			android:layout_weight="5"
-			style="@style/ListDetail"/>
+			android:layout_gravity="start"
+			android:gravity="start"
+			android:paddingStart="2dp"
+			android:paddingEnd="8dp"
+			style="@style/ListDetail"
+			tools:text="00:00:00:00:00:00"/>
+		<TextView
+			android:id="@+id/chan_freq_string"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:gravity="start"
+			android:textSize="13sp"
+			style="@style/ListFreq"
+			tools:text="5888MHz" />
+		<TextView android:id="@+id/detail"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_gravity="end"
+			android:gravity="end"
+			android:textAlignment="viewEnd"
+			style="@style/ListDetail"
+			tools:text="[WPA2][RSN][ESS][WPS]"/>
 	</LinearLayout>
 </LinearLayout>
-

--- a/wiglewifiwardriving/src/main/res/layout/row.xml
+++ b/wiglewifiwardriving/src/main/res/layout/row.xml
@@ -61,7 +61,8 @@
 	<LinearLayout
 		android:orientation="horizontal"
 		android:layout_width="match_parent"
-		android:layout_height="fill_parent">
+		android:layout_height="wrap_content"
+		android:layout_alignParentBottom="true">
 		<!-- Second row -->
 		<TextView
 			android:id="@+id/level_string"
@@ -84,8 +85,8 @@
 		<TextView
 			android:id="@+id/chan_freq_string"
 			android:layout_width="wrap_content"
-			android:layout_height="wrap_content"
-			android:gravity="start"
+			android:layout_height="match_parent"
+			android:gravity="start|bottom"
 			android:textSize="13sp"
 			style="@style/ListFreq"
 			tools:text="5888MHz" />

--- a/wiglewifiwardriving/src/main/res/layout/row.xml
+++ b/wiglewifiwardriving/src/main/res/layout/row.xml
@@ -1,60 +1,101 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android" android:orientation="vertical"
-	    android:layout_width="fill_parent" android:layout_height="fill_parent">
-
-<LinearLayout android:orientation="horizontal"
-	    android:layout_width="fill_parent" android:layout_height="fill_parent"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:tools="http://schemas.android.com/tools" android:orientation="vertical"
+	android:layout_width="fill_parent" android:layout_height="fill_parent">
+	<LinearLayout
+		android:orientation="horizontal"
+		android:layout_width="fill_parent"
+		android:layout_height="wrap_content"
 		android:paddingTop="1sp">
-	<!-- First row -->
-    <ImageView
-        android:id="@+id/wepicon"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:contentDescription="wep icon"
-        android:paddingLeft="2dp"
-        android:paddingRight="10dp"
-        android:text="wepicon" />
-
-	<ImageView
-		android:id="@+id/bticon"
-		android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
-		android:contentDescription="wep icon"
-		android:paddingTop="1dp"
-		android:paddingLeft="0dp"
-		android:paddingRight="4dp"
-		android:text="bticon"
-		android:visibility="gone"/>
-
-	<TextView android:id="@+id/ssid"
-		android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
-	    android:textColor="#eeeeee"/>
-    <LinearLayout android:orientation="horizontal"
-                  android:layout_width="fill_parent" android:layout_height="fill_parent"
-                  android:gravity="right">
-        <TextView android:id="@+id/oui" android:layout_width="wrap_content"
-                  android:layout_height="wrap_content"
-                  android:textColor="#808080"
-                  style="@android:style/TextAppearance.Small"/>
-        <TextView android:id="@+id/time" android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            style="@android:style/TextAppearance.Small"
-            android:textColor="#B0B0B0"/>
-    </LinearLayout>
+		<!-- First row -->
+		<ImageView
+			android:id="@+id/wepicon"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:contentDescription="wep icon"
+			android:paddingLeft="2dp"
+			android:paddingRight="10dp"
+			android:text="wepicon"
+			tools:src="@drawable/wep_ico"/>
+		<ImageView
+			android:id="@+id/bticon"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:contentDescription="wep icon"
+			android:paddingTop="1dp"
+			android:paddingLeft="0dp"
+			android:paddingRight="4dp"
+			android:text="bticon"
+			android:visibility="gone"/>
+		<TextView
+			android:id="@+id/ssid"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:textColor="@color/colorListSsidText"
+			tools:text="WiFi Network"
+			/>
+		<LinearLayout
+			android:orientation="horizontal"
+			android:layout_width="fill_parent"
+			android:layout_height="fill_parent"
+			android:gravity="right">
+			<TextView
+				android:id="@+id/oui"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				android:paddingEnd="3dp"
+				android:scrollHorizontally="true"
+				android:ellipsize="end"
+				android:maxLines="1"
+				style="@style/ListOui"
+				tools:text="WiGLE NIC, Inc"
+				/>
+			<TextView
+				android:id="@+id/time"
+				android:layout_width="wrap_content"
+				android:layout_height="wrap_content"
+				style="@style/ListTimestamp"
+				tools:text="12:34:56"/>
+		</LinearLayout>
+	</LinearLayout>
+	<LinearLayout
+		android:orientation="horizontal"
+		android:layout_width="match_parent"
+		android:layout_height="fill_parent">
+		<!-- Second row -->
+		<TextView
+			android:id="@+id/level_string"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			tools:text="-69"
+			android:minWidth="24dp"
+			android:paddingEnd="0dp"
+			android:textSize="12sp" />
+		<TextView
+			android:id="@+id/mac_string"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:layout_gravity="start"
+			android:gravity="start"
+			android:paddingStart="2dp"
+			android:paddingEnd="8dp"
+			style="@style/ListDetail"
+			tools:text="00:00:00:00:00:00"/>
+		<TextView
+			android:id="@+id/chan_freq_string"
+			android:layout_width="wrap_content"
+			android:layout_height="wrap_content"
+			android:gravity="start"
+			android:textSize="13sp"
+			style="@style/ListFreq"
+			tools:text="5888MHz" />
+		<TextView android:id="@+id/detail"
+			android:layout_width="match_parent"
+			android:layout_height="wrap_content"
+			android:layout_gravity="end"
+			android:gravity="end"
+			android:textAlignment="viewEnd"
+			style="@style/ListDetail"
+			tools:text="[WPA2][RSN][ESS][WPS]"/>
+	</LinearLayout>
 </LinearLayout>
-
-<LinearLayout android:orientation="horizontal"
-	    android:layout_width="fill_parent" android:layout_height="fill_parent">
-	<!-- Second row -->
-	<TextView android:id="@+id/level_string" android:layout_width="wrap_content"
-		android:layout_height="wrap_content"/>
-	<TextView android:id="@+id/detail" android:layout_width="wrap_content"
-		android:layout_height="wrap_content" android:layout_weight="5"
-		style="@android:style/TextAppearance.Small"
-        android:textColor="#B0B0B0"/>
-</LinearLayout>
-
-</LinearLayout>
-

--- a/wiglewifiwardriving/src/main/res/values-night-v29/styles.xml
+++ b/wiglewifiwardriving/src/main/res/values-night-v29/styles.xml
@@ -83,6 +83,9 @@
     <style name="ListSsid" parent="TextAppearance.AppCompat">
         <item name="android:textColor">@color/colorListSsidText</item>
     </style>
+    <style name="ListFreq" parent="TextAppearance.AppCompat.Small">
+        <item name="android:textColor">#808080</item>
+    </style>
     <style name="ButtonBackground">
         <item name="android:startColor">#444</item>
         <item name="android:endColor">#323232</item>

--- a/wiglewifiwardriving/src/main/res/values-v29/styles.xml
+++ b/wiglewifiwardriving/src/main/res/values-v29/styles.xml
@@ -83,6 +83,9 @@
     <style name="ListSsid" parent="TextAppearance.AppCompat">
         <item name="android:textColor">@color/colorListSsidText</item>
     </style>
+    <style name="ListFreq" parent="TextAppearance.AppCompat.Small">
+        <item name="android:textColor">#405050</item>
+    </style>
     <style name="NewsTitleStyle" parent="TextAppearance.AppCompat">
         <item name="android:textSize">22sp</item>
         <item name="android:textColor">#306060</item>

--- a/wiglewifiwardriving/src/main/res/values/styles.xml
+++ b/wiglewifiwardriving/src/main/res/values/styles.xml
@@ -83,6 +83,9 @@
     <style name="ListSsid" parent="TextAppearance.AppCompat">
         <item name="android:textColor">@color/colorListSsidText</item>
     </style>
+    <style name="ListFreq" parent="TextAppearance.AppCompat.Small">
+        <item name="android:textColor">#808080</item>
+    </style>
     <style name="NewsTitleStyle" parent="TextAppearance.AppCompat">
         <item name="android:textSize">22sp</item>
         <item name="android:textColor">#60f0f0</item>


### PR DESCRIPTION
Now that we're free of some of the older APIs/quirks, we can fix the layout in our list view. This partitions the elements of a row into their own layout cells, rather than pre-composing a long string and putting it into a single second-row cell.

I would prefer that this work in even columss, but the length of WiFi capabilities (building from the "end" of the row) and Cell NetIDs (building from the start) makes  columnar spacing too challenging.

```
+--------------------------------------------------- +
| 310260_14553_21139798   ...                        |
+--------------------------------------------------- +
```
vs wifi, which fills the line completely (and sometimes further)
```
+--------------------------------------------------- +
| 88:00:00:12:00:00  5888MHz  [WPA2][RSN][ESS][WPS]  |   
+--------------------------------------------------- +

```

Channels have become almost meaningless with so many 802.11<whatever> standards defining overlapping numbers, so we're squeezing in center frequency in MHz for WiFi- this is quite tight but works even on narrow aspect-ratio devices in testing.

making signal numbers fit under icons a little better.
doing less text-character formatting, more spacing/color-differentiation

Partitioning the layout as follows:
```
+--------------------------------------------------------- +
| ICO | NAME           | MFGR                  | time      |
+--------------------------------------------------------- +
| sig |  NETID             | FREQ |           CAPABILITIES |
+--------------------------------------------------------- +
```

including `tools:` namepsace sample text to help understand layout