### PR TITLE
users love approving things, give them POST_NOTIFICATIONS for api33

### DIFF
--- a/wiglewifiwardriving/src/main/AndroidManifest.xml
+++ b/wiglewifiwardriving/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
     <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <!-- permission for start-on-boot -->
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -504,6 +504,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             addPermission(permissionsList, Manifest.permission.READ_PHONE_STATE);
             addPermission(permissionsList, Manifest.permission.BLUETOOTH_SCAN);
             addPermission(permissionsList, Manifest.permission.BLUETOOTH_CONNECT);
+            addPermission(permissionsList, Manifest.permission.POST_NOTIFICATIONS);
             if (!permissionsList.isEmpty()) {
                 // The permission is NOT already granted.
                 // Check if the user has been asked about this permission already and denied


### PR DESCRIPTION
https://developer.android.com/reference/android/Manifest.permission#POST_NOTIFICATIONS

This seems to make our notifications work again on api33. Irony that they were so strict about having services have notifications, but now make you opt in to showing them.