### PR TITLE
[FIX] trying to eliminate on-shutdown LocationListener leaks

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -157,8 +157,6 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
 
     private State state;
     // *** end of state that is retained ***
-
-    @RequiresApi(24)
     private GnssStatus.Callback gnssStatusCallback = null;
 
     static Locale ORIG_LOCALE = Locale.getDefault();
@@ -1838,7 +1836,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
     }
 
     private void setupLocation(final SharedPreferences prefs) {
-        final LocationManager locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
+        final LocationManager locationManager = (LocationManager) getApplicationContext().getSystemService(Context.LOCATION_SERVICE);
 
         try {
             // check if there is a gps
@@ -1967,7 +1965,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
 
     private void internalSetLocationUpdates(final long updateIntervalMillis, final float updateMeters)
             throws SecurityException {
-        final LocationManager locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
+        final LocationManager locationManager = (LocationManager) getApplicationContext().getSystemService(Context.LOCATION_SERVICE);
 
         if (state.GNSSListener != null) {
             // remove any old requests
@@ -1998,7 +1996,9 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
 
                 @Override
                 public void onSatelliteStatusChanged(GnssStatus status) {
-                    state.GNSSListener.onGnssStatusChanged(status);
+                    if (null != state && null != state.GNSSListener && !isFinishing()) {
+                        state.GNSSListener.onGnssStatusChanged(status);
+                    }
                 }
             };
             locationManager.registerGnssStatusCallback(gnssStatusCallback);
@@ -2227,7 +2227,7 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             if (state.dbHelper != null) state.dbHelper.close();
             if (state.mxcDbHelper != null) state.mxcDbHelper.close();
 
-            final LocationManager locationManager = (LocationManager) getSystemService(Context.LOCATION_SERVICE);
+            final LocationManager locationManager = (LocationManager) this.getApplicationContext().getSystemService(Context.LOCATION_SERVICE); //ALIBI: avoid activity context-based leaks
             if (state.GNSSListener != null && locationManager != null) {
                 try {
                     if (gnssStatusCallback != null) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
@@ -236,6 +236,7 @@ public final class MappingFragment extends Fragment {
         return view;
     }
 
+    @SuppressLint("MissingPermission")
     private void setupMapView(final View view, final LatLng oldCenter, final int oldZoom) {
         // view
         final RelativeLayout rlView = view.findViewById(R.id.map_rl);
@@ -557,10 +558,11 @@ public final class MappingFragment extends Fragment {
         return centerPoint;
     }
 
-    private static Location safelyGetLast( final Context context, final String provider ) {
+    @SuppressLint("MissingPermission")
+    private static Location safelyGetLast(final Context context, final String provider ) {
         Location retval = null;
         try {
-            final LocationManager locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+            final LocationManager locationManager = (LocationManager) context.getApplicationContext().getSystemService(Context.LOCATION_SERVICE);
             retval = locationManager.getLastKnownLocation( provider );
         }
         catch ( final IllegalArgumentException | SecurityException ex ) {


### PR DESCRIPTION
common problem during DeadSystemExceptions when the OS is killing things off, as well as a non-serious leak in LeakCanary. Two canaries with one stone?

swaps global application contexts for Activity contexts to avoid race condition (and stops trying to process status updates during shutdown)

