### PR TITLE
Support Roaming Consortium OI

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/NetworkActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/NetworkActivity.java
@@ -194,6 +194,15 @@ public class NetworkActivity extends AppCompatActivity implements DialogListener
             tv = findViewById( R.id.na_cap );
             tv.setText( network.getCapabilities().replace("][", "]  [") );
 
+            tv = findViewById( R.id.na_rcois );
+            if (network.getRcois() != null) {
+                tv.setText( network.getRcois() );
+            }
+            else {
+                TextView row = findViewById(R.id.na_rcoi_label);
+                row.setVisibility(View.INVISIBLE);
+            }
+
             if ( NetworkType.isGsmLike(network.getType())) { // cell net types  with advanced data
                 if ((bssid != null) && (bssid.length() > 5) && (bssid.indexOf('_') >= 5)) {
                     final String operatorCode = bssid.substring(0, bssid.indexOf("_"));

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
@@ -64,7 +64,7 @@ public class ObservationUploader extends AbstractProgressApiRequest {
     private final boolean writeEntireDb;
     private final boolean writeRun;
 
-    public final static String CSV_COLUMN_HEADERS = "MAC,SSID,AuthMode,FirstSeen,Channel,RSSI,CurrentLatitude,CurrentLongitude,AltitudeMeters,AccuracyMeters,Type";
+    public final static String CSV_COLUMN_HEADERS = "MAC,SSID,AuthMode,FirstSeen,Channel,RSSI,CurrentLatitude,CurrentLongitude,AltitudeMeters,AccuracyMeters,Type,RCOIs";
 
     private static class CountStats {
         int byteCount;
@@ -469,6 +469,8 @@ public class ObservationUploader extends AbstractProgressApiRequest {
                     FileAccess.singleCopyNumberFormat( numberFormat, stringBuffer, charBuffer, fp, cursor.getDouble(6) );
                     charBuffer.append( COMMA );
                     charBuffer.append( network.getType().name() );
+                    charBuffer.append( COMMA );
+                    charBuffer.append( network.getRcois() );
                     charBuffer.append( NEWLINE );
                 }
                 catch ( BufferOverflowException ex ) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
@@ -64,7 +64,7 @@ public class ObservationUploader extends AbstractProgressApiRequest {
     private final boolean writeEntireDb;
     private final boolean writeRun;
 
-    public final static String CSV_COLUMN_HEADERS = "MAC,SSID,AuthMode,FirstSeen,Channel,RSSI,CurrentLatitude,CurrentLongitude,AltitudeMeters,AccuracyMeters,Type,RCOIs";
+    public final static String CSV_COLUMN_HEADERS = "MAC,SSID,AuthMode,FirstSeen,Channel,RSSI,CurrentLatitude,CurrentLongitude,AltitudeMeters,AccuracyMeters,Type";
 
     private static class CountStats {
         int byteCount;
@@ -469,8 +469,6 @@ public class ObservationUploader extends AbstractProgressApiRequest {
                     FileAccess.singleCopyNumberFormat( numberFormat, stringBuffer, charBuffer, fp, cursor.getDouble(6) );
                     charBuffer.append( COMMA );
                     charBuffer.append( network.getType().name() );
-                    charBuffer.append( COMMA );
-                    charBuffer.append( network.getRcois() );
                     charBuffer.append( NEWLINE );
                 }
                 catch ( BufferOverflowException ex ) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
@@ -451,6 +451,7 @@ public class WifiReceiver extends BroadcastReceiver {
         int anqpOICount = 0;
         long[] roamingConsortiums = null;
         String concatenatedRcois = null;
+        String rcoiString = null;
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             if (ie.getId() != EID_ROAMING_CONSORTIUM) {
@@ -482,20 +483,38 @@ public class WifiReceiver extends BroadcastReceiver {
             if (oi1Length > 0 && roamingConsortiums.length > 0) {
                 roamingConsortiums[0] =
                         getInteger(data, ByteOrder.BIG_ENDIAN, oi1Length, 0);
-                concatenatedRcois =  Long.toHexString(getInteger(data, ByteOrder.BIG_ENDIAN, oi1Length, 0)).toUpperCase();
+                long rcoiInteger = getInteger(data, ByteOrder.BIG_ENDIAN, oi1Length, 0);
+                if (rcoiInteger < 16777216) {
+                    rcoiString = String.format("%1$06X",rcoiInteger);
+                }
+                else {
+                    rcoiString = String.format("%1$010X",rcoiInteger);
+                }
+                concatenatedRcois =  rcoiString;
             }
             if (oi2Length > 0 && roamingConsortiums.length > 1) {
                 roamingConsortiums[1] =
                         getInteger(data, ByteOrder.BIG_ENDIAN, oi2Length, oi1Length);
-                concatenatedRcois += " " + Long.toHexString(getInteger(data, ByteOrder.BIG_ENDIAN, oi2Length, oi1Length)).toUpperCase();
-
+                long rcoiInteger = getInteger(data, ByteOrder.BIG_ENDIAN, oi2Length, oi1Length);
+                if (rcoiInteger < 16777216) {
+                    rcoiString = String.format("%1$06X",rcoiInteger);
+                }
+                else {
+                    rcoiString = String.format("%1$010X",rcoiInteger);
+                }
+                concatenatedRcois += " " + rcoiString;
             }
             if (oi3Length > 0 && roamingConsortiums.length > 2) {
                 roamingConsortiums[2] =
                         getInteger(data, ByteOrder.BIG_ENDIAN, oi3Length, oi2Length + oi1Length);
-                concatenatedRcois += " " + Long.toHexString(getInteger(data, ByteOrder.BIG_ENDIAN, oi3Length, oi1Length+oi2Length)).toUpperCase();
-            }
-
+                long rcoiInteger = getInteger(data, ByteOrder.BIG_ENDIAN, oi3Length, oi2Length + oi1Length);
+                if (rcoiInteger < 16777216) {
+                    rcoiString = String.format("%1$06X",rcoiInteger);
+                }
+                else {
+                    rcoiString = String.format("%1$010X",rcoiInteger);
+                }
+                concatenatedRcois += " " + rcoiString;            }
         }
 // OpenRoaming example "5A03BA0000 BAA2D00000 BAA2D02000"
         return concatenatedRcois;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
@@ -457,12 +457,16 @@ public class WifiReceiver extends BroadcastReceiver {
                 throw new IllegalArgumentException("Element id is not ROAMING_CONSORTIUM, : "
                         + ie.getId());
             }
+            // RCOI length handling from https://android.googlesource.com/platform/frameworks/opt/net/wifi/+/6f5af9b7f69b15369238bd2642c46638ba1f0255/service/java/com/android/server/wifi/util/InformationElementUtil.java#206
+            
+            // Roaming Consortium (OI) element format defined in IEEE 802.11 clause 9.4.2.95
+            // ElementID (1 Octet), Length (1 Octet), Number of OIs (1 Octet), OI #1 and #2 Lengths (1 Octet), OI#1 (variable), OI#2 (variable), OI#3 (variable)
+            // where 1 octet "OI #1 and #2 Length" comprises: OI#1 Length [B0-B3], OI#2 Length [B4-B7]
             ByteBuffer data = ie.getBytes().order(ByteOrder.LITTLE_ENDIAN);
             anqpOICount = data.get() & BYTE_MASK;
             int oi12Length = data.get() & BYTE_MASK;
             int oi1Length = oi12Length & NIBBLE_MASK;
             int oi2Length = (oi12Length >>> 4) & NIBBLE_MASK;
-            // https://android.googlesource.com/platform/frameworks/opt/net/wifi/+/6f5af9b7f69b15369238bd2642c46638ba1f0255/service/java/com/android/server/wifi/util/InformationElementUtil.java#212
             int oi3Length = ie.getBytes().limit() - 2 - oi1Length - oi2Length;
             int oiCount = 0;
             if (oi1Length > 0) {
@@ -493,7 +497,7 @@ public class WifiReceiver extends BroadcastReceiver {
             }
 
         }
-// OpenRoaming example "5A03BA0000/BAA2D00000/BAA2D02000"
+// OpenRoaming example "5A03BA0000 BAA2D00000 BAA2D02000"
         return concatenatedRcois;
     }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
@@ -8,6 +8,7 @@ import java.util.Locale;
 import android.annotation.SuppressLint;
 import android.net.wifi.ScanResult;
 import android.os.ParcelUuid;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
 
@@ -16,6 +17,7 @@ import com.google.maps.android.clustering.ClusterItem;
 
 import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.util.Logging;
+import net.wigle.wigleandroid.listener.WifiReceiver;
 
 /**
  * network data. not thread-safe.
@@ -81,17 +83,30 @@ public final class Network implements ClusterItem {
     public enum NetworkBand {
         WIFI_2_4_GHZ, WIFI_5_GHZ, WIFI_6_GHZ, WIFI_60_GHZ, CELL_2_3_GHZ, UNDEFINED
     }
+
+    private String concatenatedRcois;
+
     /**
      * convenience constructor
      * @param scanResult a result from a wifi scan
      */
     public Network( final ScanResult scanResult ) {
         this( scanResult.BSSID, scanResult.SSID, scanResult.frequency, scanResult.capabilities,
-                scanResult.level,  NetworkType.WIFI, null, null);
+                scanResult.level,  NetworkType.WIFI, null, null, null);
+
+        String rcois = null;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            for ( ScanResult.InformationElement info : scanResult.getInformationElements()) {
+                if (info.getId() == net.wigle.wigleandroid.listener.WifiReceiver.EID_ROAMING_CONSORTIUM) {
+                    rcois = net.wigle.wigleandroid.listener.WifiReceiver.getConcatenatedRcois(info);
+                }
+            }
+        }
+        this.concatenatedRcois = rcois;
     }
     public Network( final String bssid, final String ssid, final int frequency, final String capabilities,
                     final int level, final NetworkType type) {
-        this(bssid, ssid, frequency, capabilities, level, type, null, null);
+        this(bssid, ssid, frequency, capabilities, level, type, null, null, null);
     }
 
     public Network( final String bssid, final String ssid, final int frequency, final String capabilities,
@@ -101,11 +116,16 @@ public final class Network implements ClusterItem {
 
     public Network( final String bssid, final String ssid, final int frequency, final String capabilities,
         final int level, final NetworkType type, final LatLng latLng ) {
-        this(bssid, ssid, frequency, capabilities, level, type, null, null, latLng);
+        this(bssid, ssid, frequency, capabilities, level, type, null, null, latLng, null);
     }
 
     public Network( final String bssid, final String ssid, final int frequency, final String capabilities,
-        final int level, final NetworkType type, final List<String> bleServiceUuid16s, Integer bleMfgrId, final LatLng latLng ) {
+                    final int level, final NetworkType type, final List<String> bleServiceUuid16s, Integer bleMfgrId, final LatLng latLng) {
+        this(bssid, ssid, frequency, capabilities, level, type, null, null, latLng, null);
+    }
+
+    public Network( final String bssid, final String ssid, final int frequency, final String capabilities,
+        final int level, final NetworkType type, final List<String> bleServiceUuid16s, Integer bleMfgrId, final LatLng latLng, final String concatenatedRcois ) {
         this.bssid = ( bssid == null ) ? "" : bssid.toLowerCase(Locale.US);
         this.ssid = ( ssid == null ) ? "" : ssid;
         this.frequency = frequency;
@@ -113,6 +133,7 @@ public final class Network implements ClusterItem {
         this.level = level;
         this.type = type;
         this.bleMfgrId = bleMfgrId;
+        this.concatenatedRcois = concatenatedRcois;
         if (NetworkType.WIFI.equals(this.type)) {
             this.channel = channelForWiFiFrequencyMhz(frequency);
         } else if (NetworkType.BLE.equals(this.type) || NetworkType.BT.equals(this.type)) {
@@ -218,6 +239,10 @@ public final class Network implements ClusterItem {
     }
     public void setCapabilities( final String capabilities ) {
         this.capabilities = capabilities;
+    }
+
+    public String getRcois() {
+        return concatenatedRcois;
     }
 
     // Overloading for *FCN in GSM-derived networks for now. a subclass is probably more correct.

--- a/wiglewifiwardriving/src/main/res/layout/network.xml
+++ b/wiglewifiwardriving/src/main/res/layout/network.xml
@@ -205,6 +205,32 @@
             </RelativeLayout>
 
             <RelativeLayout
+                android:id="@+id/passpoint_row"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@+id/channel_row"
+                android:orientation="horizontal"
+                android:paddingHorizontal="1dp"
+                android:paddingBottom="2dp">
+                <TextView
+                    android:id="@+id/na_rcoi_label"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_toEndOf="@+id/na_rcoi"
+                    android:paddingStart="1dp"
+                    android:paddingEnd="1dp"
+                    android:text="@string/network_rcois"
+                    android:textStyle="bold" />
+                <TextView
+                    android:id="@+id/na_rcois"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_toEndOf="@+id/na_rcoi_label"
+                    android:paddingStart="5dp"
+                    android:paddingEnd="5dp" />
+            </RelativeLayout>
+
+            <RelativeLayout
                 android:id="@+id/cell_info"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/wiglewifiwardriving/src/main/res/values-ar/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ar/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Channel:</string>
     <string name="network_observations">Observations:</string>
     <string name="network_querying">(querying&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Show password</string>
     <string name="setting_db_marker">DB Marker (where uploads start from):</string>
     <string name="setting_high_up">Highest uploaded id:</string>

--- a/wiglewifiwardriving/src/main/res/values-cs-rCZ/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-cs-rCZ/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Kanál:</string>
     <string name="network_observations">Počet spatření:</string>
     <string name="network_querying">(dotazování&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Ukázat heslo</string>
     <string name="setting_db_marker">Značka DB (odkud začínají záznamy):</string>
     <string name="setting_high_up">Nejvyšší nahrané id:</string>

--- a/wiglewifiwardriving/src/main/res/values-da/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-da/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Kanal:</string>
     <string name="network_observations">Observationer:</string>
     <string name="network_querying">(Forspøger)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Vis adgangskode</string>
     <string name="setting_db_marker">DB Marker (hvor uploads starter fra):</string>
     <string name="setting_high_up">Højeste uploadet id:</string>

--- a/wiglewifiwardriving/src/main/res/values-de/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-de/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Kanal:</string>
     <string name="network_observations">Bemerkungen:</string>
     <string name="network_querying">(frage ab&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Passwort anzeigen</string>
     <string name="setting_db_marker">DB Marker (Uploads ab …):</string>
     <string name="setting_high_up">Hochgeladen bis ID:</string>

--- a/wiglewifiwardriving/src/main/res/values-es-rES/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-es-rES/strings.xml
@@ -94,6 +94,7 @@
     <string name="network_channel">Canal:</string>
     <string name="network_observations">Observaciones:</string>
     <string name="network_querying">(preguntando…)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Mostrar contraseña</string>
     <string name="setting_db_marker">Marcador de base de datos (desde donde comienzan las cargas):</string>
     <string name="setting_high_up">Identificación más alta cargado:</string>

--- a/wiglewifiwardriving/src/main/res/values-fi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fi/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Kanava:</string>
     <string name="network_observations">Havainnot:</string>
     <string name="network_querying">(Querying&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Näytä salasana</string>
     <string name="setting_db_marker">DB Marker (jossa kuvat alkavat):</string>
     <string name="setting_high_up">Korkein ladataan id:</string>

--- a/wiglewifiwardriving/src/main/res/values-fr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fr/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Canal :</string>
     <string name="network_observations">Observations :</string>
     <string name="network_querying">(Requête en cours&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Montrer le mot de passe</string>
     <string name="setting_db_marker">Marqueur de BDD (où commencer le téléchargement):</string>
     <string name="setting_high_up">ID uploadé le plus élevé :</string>

--- a/wiglewifiwardriving/src/main/res/values-fy/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fy/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Kanaal:</string>
     <string name="network_observations">Oantal kearen sjoen:</string>
     <string name="network_querying">(query uitvoeren&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Wachtwurd weergeven</string>
     <string name="setting_db_marker">DB Marker (de upload start by):</string>
     <string name="setting_high_up">Heechste upload ID:</string>

--- a/wiglewifiwardriving/src/main/res/values-he/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-he/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">ערוץ:</string>
     <string name="network_observations">תוכן:</string>
     <string name="network_querying">(Querying&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">הצג סיסמה</string>
     <string name="setting_db_marker">DB מרקר (שם שנוספו להתחיל):</string>
     <string name="setting_high_up">Id נטען גבוהה ביותר:</string>

--- a/wiglewifiwardriving/src/main/res/values-hi-rIN/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hi-rIN/strings.xml
@@ -94,6 +94,7 @@
     <string name="network_channel">चैनल:</string>
     <string name="network_observations">अवलोकन:</string>
     <string name="network_querying">(क्वेरी उठाना...)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">पासवर्ड दिखाएँ</string>
     <string name="setting_db_marker">DB मार्कर (जहाँ से अपलोड शुरू होते हैं):</string>
     <string name="setting_high_up">उच्चतम अपलोड की गई ID:</string>

--- a/wiglewifiwardriving/src/main/res/values-hu-rHU/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hu-rHU/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Csatorna:</string>
     <string name="network_observations">Megfigyelések:</string>
     <string name="network_querying">(lekérés&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Jelszó megjelenítése</string>
     <string name="setting_db_marker">Adatbázis-jelölő (ahol a feltöltés kezdődik):</string>
     <string name="setting_high_up">Legmagasabb feltöltésazonosító:</string>

--- a/wiglewifiwardriving/src/main/res/values-it-rIT/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-it-rIT/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Canale:</string>
     <string name="network_observations">Osservazioni:</string>
     <string name="network_querying">(ricerca&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Mostra Password</string>
     <string name="setting_db_marker">Segnalibro del database (da cui inizia il caricamento):</string>
     <string name="setting_high_up">Più alto ID caricato:</string>

--- a/wiglewifiwardriving/src/main/res/values-iw/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-iw/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">ערוץ:</string>
     <string name="network_observations">תוכן:</string>
     <string name="network_querying">(Querying&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">הצג סיסמה</string>
     <string name="setting_db_marker">DB מרקר (שם שנוספו להתחיל):</string>
     <string name="setting_high_up">Id נטען גבוהה ביותר:</string>

--- a/wiglewifiwardriving/src/main/res/values-ja-rJP/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ja-rJP/strings.xml
@@ -94,6 +94,7 @@
     <string name="network_channel">チャネル：</string>
     <string name="network_observations">観察：</string>
     <string name="network_querying">（クエリ…）</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">パスワードを表示</string>
     <string name="setting_db_marker">DB マーカー（アップロードの開始元）：</string>
     <string name="setting_high_up">アップロードされた最高の ID：</string>

--- a/wiglewifiwardriving/src/main/res/values-ko/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ko/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">채널 :</string>
     <string name="network_observations">관찰 :</string>
     <string name="network_querying">(querying&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">비밀 번호를 표시</string>
     <string name="setting_db_marker">DB 마커 (여기서 업로드부터 시작) :</string>
     <string name="setting_high_up">최고 업로드 ID :</string>

--- a/wiglewifiwardriving/src/main/res/values-nl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nl/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Kanaal:</string>
     <string name="network_observations">Aantal keren gezien:</string>
     <string name="network_querying">(query uitvoeren&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Wachtwoord weergeven</string>
     <string name="setting_db_marker">DB Marker (de upload start bij):</string>
     <string name="setting_high_up">Hoogste upload ID:</string>

--- a/wiglewifiwardriving/src/main/res/values-nn/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nn/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Channel:</string>
     <string name="network_observations">Observations:</string>
     <string name="network_querying">(querying&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Show Password</string>
     <string name="setting_db_marker">DB Marker (where uploads start from):</string>
     <string name="setting_high_up">Highest uploaded id:</string>

--- a/wiglewifiwardriving/src/main/res/values-no/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-no/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Channel:</string>
     <string name="network_observations">Observasjoner:</string>
     <string name="network_querying">(Querying&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Vis passord</string>
     <string name="setting_db_marker">DB Marker (hvor opplastninger start fra):</string>
     <string name="setting_high_up">Høyeste lastet id:</string>

--- a/wiglewifiwardriving/src/main/res/values-pl-rPL/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pl-rPL/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Kanał:</string>
     <string name="network_observations">Il. obserwacji:</string>
     <string name="network_querying">(Zapytanie&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Pokaż hasło</string>
     <string name="setting_db_marker">Znacznik bazy (odkąd rozpocząć przesyłanie):</string>
     <string name="setting_high_up">Najwyższe przesłane id:</string>

--- a/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Canal:</string>
     <string name="network_observations">Observações:</string>
     <string name="network_querying">(buscando&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Mostrar Senha</string>
     <string name="setting_db_marker">Marcador do BD (Da onde os envios começam):</string>
     <string name="setting_high_up">ID mais alto enviado:</string>

--- a/wiglewifiwardriving/src/main/res/values-pt-rPT/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rPT/strings.xml
@@ -94,6 +94,7 @@
     <string name="network_channel">Canal:</string>
     <string name="network_observations">Observações:</string>
     <string name="network_querying">(a questionar...)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Mostrar palavra-passe</string>
     <string name="setting_db_marker">Marcador de base de dados (de onde começam os uploads):</string>
     <string name="setting_high_up">ID mais alto carregado:</string>

--- a/wiglewifiwardriving/src/main/res/values-ro-rRO/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ro-rRO/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Canal:</string>
     <string name="network_observations">Observatii:</string>
     <string name="network_querying">(interogarea&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Arata parola</string>
     <string name="setting_db_marker">BD Marker (de unde încep încărcările):</string>
     <string name="setting_high_up">Cel mai mare ID încărcat:</string>

--- a/wiglewifiwardriving/src/main/res/values-ru/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ru/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Канал:</string>
     <string name="network_observations">Наблюдения:</string>
     <string name="network_querying">(осуществляется запрос&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Показывать пароль</string>
     <string name="setting_db_marker">Настройки ID маркера в БД (там, где начинаются добавления):</string>
     <string name="setting_high_up">Текущий ID в БД:</string>

--- a/wiglewifiwardriving/src/main/res/values-sv-rSE/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-sv-rSE/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Kanal:</string>
     <string name="network_observations">Observationer:</string>
     <string name="network_querying">(söker&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Visa lösenord</string>
     <string name="setting_db_marker">DB Marker (uppladdningar startar från):</string>
     <string name="setting_high_up">Högsta upp-id:</string>

--- a/wiglewifiwardriving/src/main/res/values-sw/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-sw/strings.xml
@@ -94,6 +94,7 @@
     <string name="network_channel">Mkondo:</string>
     <string name="network_observations">Uchunguzi:</string>
     <string name="network_querying">(Kuuliza…)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Onyesha Nywila</string>
     <string name="setting_db_marker">Alama ya DB (ambapo upakiaji unaanzia):</string>
     <string name="setting_high_up">Kitambulisho cha juu kabisa kilichopakiwa:</string>

--- a/wiglewifiwardriving/src/main/res/values-tr-rTR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-tr-rTR/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Kanal:</string>
     <string name="network_observations">Gözlemler:</string>
     <string name="network_querying">(sorgulama&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Parolayı Göster</string>
     <string name="setting_db_marker">DB Marker (yükleme nerede başlıyor):</string>
     <string name="setting_high_up">En çok yüklenen:</string>

--- a/wiglewifiwardriving/src/main/res/values-zh-rCN/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rCN/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">信道：</string>
     <string name="network_observations">观察：</string>
     <string name="network_querying">（querying&#8230;）</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">显示密码</string>
     <string name="setting_db_marker">数据库标记（开始上传从）：</string>
     <string name="setting_high_up">最高上传ID：</string>

--- a/wiglewifiwardriving/src/main/res/values-zh-rHK/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rHK/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">頻道：</string>
     <string name="network_observations">觀察：</string>
     <string name="network_querying">（querying&#8230;）</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">顯示密碼</string>
     <string name="setting_db_marker">DB標記（上傳從）：</string>
     <string name="setting_high_up">最高上傳 ID：</string>

--- a/wiglewifiwardriving/src/main/res/values-zh-rTW/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rTW/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">頻道：</string>
     <string name="network_observations">觀察：</string>
     <string name="network_querying">（querying&#8230;）</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">顯示密碼</string>
     <string name="setting_db_marker">DB標記（上傳從）：</string>
     <string name="setting_high_up">最高上傳 ID：</string>

--- a/wiglewifiwardriving/src/main/res/values-zh/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">信道：</string>
     <string name="network_observations">观察：</string>
     <string name="network_querying">（querying&#8230;）</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">显示密码</string>
     <string name="setting_db_marker">数据库标记（开始上传从）：</string>
     <string name="setting_high_up">最高上传ID：</string>

--- a/wiglewifiwardriving/src/main/res/values/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values/strings.xml
@@ -95,6 +95,7 @@
     <string name="network_channel">Channel:</string>
     <string name="network_observations">Observations:</string>
     <string name="network_querying">(querying&#8230;)</string>
+    <string name="network_rcois">RCOIs:</string>
     <string name="setting_show_password">Show Password</string>
     <string name="setting_db_marker">DB Marker (where uploads start from):</string>
     <string name="setting_high_up">Highest uploaded id:</string>


### PR DESCRIPTION
RCOIs are used by WFA Passpoint networks for network selection purposes and have been defined for use in roaming confederations, e.g., WBA's OpenRoaming. 

Adding RCOI to the network class allows configured RCOIs to be presented in the UI as well as enabling recording of RCOIs with the eventual aim of being able to query back end systems to be able to recover the geolocation of networks with particular configured RCOIs. 