### PR TITLE
[FIX] screen on behavior inconsistent in child activities

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DashboardFragment.java
@@ -60,7 +60,7 @@ public class DashboardFragment extends Fragment {
     finishing = new AtomicBoolean( false );
     final Configuration conf = getResources().getConfiguration();
     Locale locale = null;
-    if (null != conf && null != conf.getLocales()) {
+    if (null != conf) {
         locale = conf.getLocales().get(0);
     }
     if (null == locale) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DebugActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DebugActivity.java
@@ -4,11 +4,11 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
-import android.widget.LinearLayout;
 import android.widget.TextView;
 
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
+import net.wigle.wigleandroid.ui.ScreenChildActivity;
 
 /**
  * display latest logs.
@@ -16,7 +16,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
  * @author bobzilla
  *
  */
-public class DebugActivity extends AppCompatActivity {
+public class DebugActivity extends ScreenChildActivity {
     private static final int MENU_EXIT = 11;
     private static final int MENU_EMAIL = 12;
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/FilterActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/FilterActivity.java
@@ -3,13 +3,13 @@ package net.wigle.wigleandroid;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import androidx.appcompat.app.AppCompatActivity;
 
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 
 import net.wigle.wigleandroid.ui.PrefsBackedCheckbox;
+import net.wigle.wigleandroid.ui.ScreenChildActivity;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.PreferenceKeys;
 
@@ -17,7 +17,7 @@ import net.wigle.wigleandroid.util.PreferenceKeys;
  * Building a filter activity for the network list
  * Created by arkasha on 20170801.
  */
-public class FilterActivity extends AppCompatActivity {
+public class FilterActivity extends ScreenChildActivity {
 
     public static final String ADDR_FILTER_MESSAGE = "net.wigle.wigleandroid.filter.MESSAGE";
     public static final String INTENT_DISPLAY_FILTER = "displayFilter";

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/GpxManagementActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/GpxManagementActivity.java
@@ -8,7 +8,6 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -24,6 +23,7 @@ import net.wigle.wigleandroid.db.DBException;
 import net.wigle.wigleandroid.db.DatabaseHelper;
 import net.wigle.wigleandroid.model.PolylineRoute;
 import net.wigle.wigleandroid.ui.GpxRecyclerAdapter;
+import net.wigle.wigleandroid.ui.ScreenChildActivity;
 import net.wigle.wigleandroid.ui.ThemeUtil;
 import net.wigle.wigleandroid.ui.UINumberFormat;
 import net.wigle.wigleandroid.ui.WiGLEToast;
@@ -40,7 +40,7 @@ import java.util.Locale;
 import static android.view.View.GONE;
 import static net.wigle.wigleandroid.util.AsyncGpxExportTask.EXPORT_GPX_DIALOG;
 
-public class GpxManagementActivity extends AppCompatActivity implements PolyRouteConfigurable, RouteExportSelector, DialogListener {
+public class GpxManagementActivity extends ScreenChildActivity implements PolyRouteConfigurable, RouteExportSelector, DialogListener {
 
     private final NumberFormat numberFormat;
     private final int DEFAULT_MAP_PADDING = 25;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MacFilterActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MacFilterActivity.java
@@ -3,12 +3,12 @@ package net.wigle.wigleandroid;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import androidx.appcompat.app.AppCompatActivity;
 import android.view.View;
 import android.widget.ListView;
 
 import com.google.gson.Gson;
 
+import net.wigle.wigleandroid.ui.ScreenChildActivity;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.PreferenceKeys;
 
@@ -22,12 +22,11 @@ import br.com.sapereaude.maskedEditText.MaskedEditText;
  * Created by arkasha on 8/31/17.
  */
 
-public class MacFilterActivity extends AppCompatActivity {
+public class MacFilterActivity extends ScreenChildActivity {
 
     private String filterKey;
     List<String> listItems=new ArrayList<>();
     AddressFilterAdapter filtersAdapter;
-
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -2542,4 +2542,10 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         return state.btMfgrIds.get(i);
     }
 
+    public boolean hasWakeLock() {
+        if (null != state) {
+            return state.screenLocked;
+        }
+        return false;
+    }
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MapFilterActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MapFilterActivity.java
@@ -3,13 +3,12 @@ package net.wigle.wigleandroid;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 
-import androidx.appcompat.app.AppCompatActivity;
-
 import android.view.View;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 
 import net.wigle.wigleandroid.ui.PrefsBackedCheckbox;
+import net.wigle.wigleandroid.ui.ScreenChildActivity;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.PreferenceKeys;
 import net.wigle.wigleandroid.util.SettingsUtil;
@@ -23,7 +22,7 @@ import java.util.List;
  * Created by arkasha on 8/1/17.
  */
 
-public class MapFilterActivity extends AppCompatActivity {
+public class MapFilterActivity extends ScreenChildActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/NetworkActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/NetworkActivity.java
@@ -27,7 +27,6 @@ import android.os.Message;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
 import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
 import android.text.ClipboardManager;
 import android.text.InputType;
 import android.view.LayoutInflater;
@@ -60,12 +59,13 @@ import net.wigle.wigleandroid.model.Network;
 import net.wigle.wigleandroid.model.NetworkType;
 import net.wigle.wigleandroid.model.OUI;
 import net.wigle.wigleandroid.ui.NetworkListUtil;
+import net.wigle.wigleandroid.ui.ScreenChildActivity;
 import net.wigle.wigleandroid.ui.ThemeUtil;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.PreferenceKeys;
 
 @SuppressWarnings("deprecation")
-public class NetworkActivity extends AppCompatActivity implements DialogListener {
+public class NetworkActivity extends ScreenChildActivity implements DialogListener {
     private static final int MENU_RETURN = 11;
     private static final int MENU_COPY = 12;
     private static final int NON_CRYPTO_DIALOG = 130;
@@ -101,13 +101,11 @@ public class NetworkActivity extends AppCompatActivity implements DialogListener
         }
 
         // set language
-        MainActivity.setLocale(this);
         numberFormat = NumberFormat.getNumberInstance(MainActivity.getLocale(this, this.getResources().getConfiguration()));
         if (numberFormat instanceof DecimalFormat) {
             numberFormat.setMinimumFractionDigits(0);
             numberFormat.setMaximumFractionDigits(2);
         }
-
         MainActivity.setLocale( this );
         setContentView(R.layout.network);
         networkActivity = this;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RegistrationActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/RegistrationActivity.java
@@ -3,20 +3,20 @@ package net.wigle.wigleandroid;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.os.Bundle;
-import androidx.appcompat.app.AppCompatActivity;
 import android.webkit.CookieManager;
 import android.webkit.WebChromeClient;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
 
 import net.wigle.wigleandroid.background.WiGLERegistrationInterface;
+import net.wigle.wigleandroid.ui.ScreenChildActivity;
 import net.wigle.wigleandroid.util.UrlConfig;
 
 /**
  * Created by arkasha on 1/8/18.
  */
 
-public class RegistrationActivity extends AppCompatActivity {
+public class RegistrationActivity extends ScreenChildActivity {
 
     public static final String AGENT = "WiGLE WiFi Registrant";
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SpeechActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SpeechActivity.java
@@ -5,19 +5,19 @@ import android.content.SharedPreferences.Editor;
 import android.media.AudioManager;
 import android.os.Bundle;
 import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.widget.CheckBox;
 import android.widget.Spinner;
 import android.widget.TextView;
 
+import net.wigle.wigleandroid.ui.ScreenChildActivity;
 import net.wigle.wigleandroid.util.PreferenceKeys;
 import net.wigle.wigleandroid.util.SettingsUtil;
 
 import java.util.Objects;
 
-public class SpeechActivity extends AppCompatActivity {
+public class SpeechActivity extends ScreenChildActivity {
     private static final int MENU_RETURN = 12;
 
     // used for shutting extraneous activities down on an error

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/ProgressThrobberActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/ProgressThrobberActivity.java
@@ -1,10 +1,8 @@
 package net.wigle.wigleandroid.ui;
 
-import android.app.Activity;
 import android.view.View;
 import android.widget.ImageView;
 
-import androidx.appcompat.app.AppCompatActivity;
 import androidx.vectordrawable.graphics.drawable.AnimatedVectorDrawableCompat;
 
 import net.wigle.wigleandroid.R;
@@ -13,7 +11,7 @@ import net.wigle.wigleandroid.util.Logging;
 /**
  * Loading "throbber" image parent class for network-based fragments.
  */
-public abstract class ProgressThrobberActivity extends AppCompatActivity {
+public abstract class ProgressThrobberActivity extends ScreenChildActivity {
     protected ImageView loadingImage;
     protected ImageView errorImage;
     protected boolean animating = false;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/ScreenChildActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/ScreenChildActivity.java
@@ -1,0 +1,27 @@
+package net.wigle.wigleandroid.ui;
+
+import android.os.Bundle;
+import android.view.WindowManager;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import net.wigle.wigleandroid.MainActivity;
+
+/**
+ * A child AppCompatActivity that follows WiGLE's MainActivity.state.screenLocked behavior while the MainActivity is paused.
+ * Created by arkasha on 20231017.
+ */
+public class ScreenChildActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        final MainActivity ma = MainActivity.getMainActivity();
+        if (null != ma) {
+            if (ma.hasWakeLock()) {
+                //NB: chances to the parent activity state won't be reflected here.
+                getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+            }
+        }
+    }
+
+}

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/ScreenChildActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/ScreenChildActivity.java
@@ -18,7 +18,7 @@ public class ScreenChildActivity extends AppCompatActivity {
         final MainActivity ma = MainActivity.getMainActivity();
         if (null != ma) {
             if (ma.hasWakeLock()) {
-                //NB: chances to the parent activity state won't be reflected here.
+                //NB: changes to the parent activity state won't be reflected here.
                 getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
             }
         }

--- a/wiglewifiwardriving/src/main/res/layout/dashbottom.xml
+++ b/wiglewifiwardriving/src/main/res/layout/dashbottom.xml
@@ -3,8 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:keepScreenOn="true" >
+    android:layout_height="fill_parent">
     <TextView
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"

--- a/wiglewifiwardriving/src/main/res/layout/dashlandscape.xml
+++ b/wiglewifiwardriving/src/main/res/layout/dashlandscape.xml
@@ -3,7 +3,6 @@
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:keepScreenOn="true"
     android:weightSum="2">
     
     <LinearLayout
@@ -11,7 +10,6 @@
         android:layout_weight="1"
         android:layout_height="match_parent"
         android:layout_width="0dp"
-        android:keepScreenOn="true"
         android:paddingRight="10dp">
         <include layout="@layout/dashtop"/>
     </LinearLayout>
@@ -19,8 +17,7 @@
         android:orientation="horizontal"
         android:layout_weight="1"
         android:layout_height="fill_parent"
-        android:layout_width="0dp"
-        android:keepScreenOn="true" >
+        android:layout_width="0dp">
         <include layout="@layout/dashbottom"/>
     </LinearLayout>
 </LinearLayout>

--- a/wiglewifiwardriving/src/main/res/layout/dashportrait.xml
+++ b/wiglewifiwardriving/src/main/res/layout/dashportrait.xml
@@ -2,8 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:keepScreenOn="true" >
+    android:layout_height="fill_parent">
 
     <include layout="@layout/dashtop"/>
 

--- a/wiglewifiwardriving/src/main/res/layout/dashtop.xml
+++ b/wiglewifiwardriving/src/main/res/layout/dashtop.xml
@@ -4,8 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_width="fill_parent"
-    android:layout_height="wrap_content"
-    android:keepScreenOn="true" >
+    android:layout_height="wrap_content">
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/wiglewifiwardriving/src/main/res/layout/sitestatslandscape.xml
+++ b/wiglewifiwardriving/src/main/res/layout/sitestatslandscape.xml
@@ -3,7 +3,6 @@
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:keepScreenOn="true"
     android:weightSum="5">
 
     <LinearLayout
@@ -11,7 +10,6 @@
         android:layout_weight="3"
         android:layout_height="match_parent"
         android:layout_width="0dp"
-        android:keepScreenOn="true"
         android:paddingRight="10dp">
         <include layout="@layout/sitestatstop"/>
     </LinearLayout>
@@ -19,8 +17,7 @@
         android:orientation="horizontal"
         android:layout_weight="2"
         android:layout_height="fill_parent"
-        android:layout_width="0dp"
-        android:keepScreenOn="true" >
+        android:layout_width="0dp">
         <include layout="@layout/sitestatsbottom"/>
     </LinearLayout>
 </LinearLayout>

--- a/wiglewifiwardriving/src/main/res/layout/sitestatsportrait.xml
+++ b/wiglewifiwardriving/src/main/res/layout/sitestatsportrait.xml
@@ -2,8 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:keepScreenOn="true" >
+    android:layout_height="fill_parent">
 
     <include layout="@layout/sitestatstop"/>
 

--- a/wiglewifiwardriving/src/main/res/layout/userstats.xml
+++ b/wiglewifiwardriving/src/main/res/layout/userstats.xml
@@ -4,16 +4,13 @@
     android:id="@+id/stats_scrolllayout"
     android:orientation="vertical"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:keepScreenOn="true">
-
+    android:layout_height="fill_parent">
     <LinearLayout
         android:id="@+id/linearlayout"
         android:orientation="vertical"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:padding="4dp"
-        >
+        android:padding="4dp">
         <ImageView
             android:id="@+id/badgeImage"
             android:layout_width="match_parent"
@@ -23,7 +20,8 @@
             android:layout_marginTop="10dp"
             android:layout_marginBottom="10dp"
             android:paddingRight="60dp"
-            android:paddingLeft="60dp"/>
+            android:paddingLeft="60dp"
+            android:contentDescription="@string/rank_stats_app_name" />
         <LinearLayout
             android:id="@+id/linearlayout2"
             android:orientation="horizontal"


### PR DESCRIPTION
getting child activities to follow the MainActivity keep-screen-on state setting.

Addresses https://github.com/wiglenet/wigle-wifi-wardriving/issues/433 - although we should consider making "keep screen on"/"keep screen on while powered" a preference" as a feature request, possibly also allowing intent-based updates.

cleans up redundant/erroneous keepScreenOn XML layout declarations.