### PR TITLE
Add [HS2.0] to capabilities

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
@@ -120,7 +120,7 @@ public final class Network implements ClusterItem {
      * @param scanResult a result from a wifi scan
      */
     public Network( final ScanResult scanResult ) {
-        this( scanResult.BSSID, scanResult.SSID, scanResult.frequency, scanResult.isPasspointNetwork() ? (scanResult.capabilities + "[HS2.0]",
+        this( scanResult.BSSID, scanResult.SSID, scanResult.frequency, scanResult.isPasspointNetwork() ? (scanResult.capabilities + "[HS2.0]") : scanResult.capabilities,
                 scanResult.level,  NetworkType.WIFI, null, null, null);
 
         String rcois = null;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/Network.java
@@ -120,7 +120,7 @@ public final class Network implements ClusterItem {
      * @param scanResult a result from a wifi scan
      */
     public Network( final ScanResult scanResult ) {
-        this( scanResult.BSSID, scanResult.SSID, scanResult.frequency, scanResult.capabilities,
+        this( scanResult.BSSID, scanResult.SSID, scanResult.frequency, scanResult.isPasspointNetwork() ? (scanResult.capabilities + "[HS2.0]",
                 scanResult.level,  NetworkType.WIFI, null, null, null);
 
         String rcois = null;


### PR DESCRIPTION
Add "[HS2.0]" to list of capabilities for Passpoint networks to allow easy indication of which networks may have RCOIs configured