### PR TITLE
[ENH] Map fragment enhancements

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MapRender.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MapRender.java
@@ -22,6 +22,7 @@ import com.google.maps.android.collections.MarkerManager;
 import com.google.maps.android.ui.IconGenerator;
 
 import net.wigle.wigleandroid.model.Network;
+import net.wigle.wigleandroid.ui.NetworkIconGenerator;
 import net.wigle.wigleandroid.util.Logging;
 import net.wigle.wigleandroid.util.PreferenceKeys;
 
@@ -59,11 +60,11 @@ public class MapRender {
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     private class NetworkRenderer extends DefaultClusterRenderer<Network> {
-        final IconGenerator iconFactory;
+        final NetworkIconGenerator iconFactory;
 
         public NetworkRenderer(Context context, GoogleMap map, ClusterManager<Network> clusterManager) {
             super(context, map, clusterManager);
-            iconFactory = new IconGenerator(context);
+            iconFactory = new NetworkIconGenerator(context);
         }
 
         @Override
@@ -96,7 +97,7 @@ public class MapRender {
             else {
                 iconFactory.setStyle(IconGenerator.STYLE_BLUE);
             }
-            return BitmapDescriptorFactory.fromBitmap(iconFactory.makeIcon(network.getSsid()));
+            return BitmapDescriptorFactory.fromBitmap(iconFactory.makeIcon(network));
         }
 
         private boolean showDefaultIcon(final Network network) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MapRender.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MapRender.java
@@ -53,14 +53,14 @@ public class MapRender {
     private static final String MESSAGE_BSSID = "messageBssid";
     private static final String MESSAGE_BSSID_LIST = "messageBssidList";
     //ALIBI: placeholder while we sort out "bubble" icons for BT, BLE, Cell, Cell NR, WiFi encryption types.
-    private static final BitmapDescriptor DEFAULT_ICON = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_VIOLET);
-    private static final BitmapDescriptor DEFAULT_ICON_NEW = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_MAGENTA);
-    private static final BitmapDescriptor CELL_ICON = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_RED);
-    private static final BitmapDescriptor CELL_ICON_NEW = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_ROSE);
-    private static final BitmapDescriptor BT_ICON = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_AZURE);
-    private static final BitmapDescriptor BT_ICON_NEW = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_CYAN);
-    private static final BitmapDescriptor WIFI_ICON = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_GREEN);
-    private static final BitmapDescriptor WIFI_ICON_NEW = BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_YELLOW);
+    private static final BitmapDescriptor DEFAULT_ICON = BitmapDescriptorFactory.defaultMarker(NetworkHues.DEFAULT);
+    private static final BitmapDescriptor DEFAULT_ICON_NEW = BitmapDescriptorFactory.defaultMarker(NetworkHues.NEW);
+    private static final BitmapDescriptor CELL_ICON = BitmapDescriptorFactory.defaultMarker(NetworkHues.CELL);
+    private static final BitmapDescriptor CELL_ICON_NEW = BitmapDescriptorFactory.defaultMarker(NetworkHues.CELL_NEW);
+    private static final BitmapDescriptor BT_ICON = BitmapDescriptorFactory.defaultMarker(NetworkHues.BT);
+    private static final BitmapDescriptor BT_ICON_NEW = BitmapDescriptorFactory.defaultMarker(NetworkHues.BT_NEW);
+    private static final BitmapDescriptor WIFI_ICON = BitmapDescriptorFactory.defaultMarker(NetworkHues.WIFI);
+    private static final BitmapDescriptor WIFI_ICON_NEW = BitmapDescriptorFactory.defaultMarker(NetworkHues.WIFI_NEW);
 
     private static final float DEFAULT_ICON_ALPHA = 0.7f;
     private static final float CUSTOM_ICON_ALPHA = 0.75f;
@@ -97,39 +97,42 @@ public class MapRender {
         private BitmapDescriptor getIcon(final Network network) {
             if (showDefaultIcon(network)) {
                 MapRender.this.labeledNetworks.remove(network);
-                switch (network.getType()) {
-                    case CDMA:
-                    case GSM:
-                    case WCDMA:
-                    case LTE:
-                    case NR:
-                        if (network.isNew()) {
-                            return CELL_ICON_NEW;
-                        }
-                        return CELL_ICON;
-                    case BT:
-                    case BLE:
-                        if (network.isNew()) {
-                            return BT_ICON_NEW;
-                        }
-                        return BT_ICON;
-                    case WIFI:
-                        if (network.isNew()) {
-                            return WIFI_ICON_NEW;
-                        }
-                        return WIFI_ICON;
-                    default:
-                        if (network.isNew()) {
-                            return WIFI_ICON_NEW;
-                        }
-                        return DEFAULT_ICON;
-                }
+                return getPinDescriptor(network);
             }
 
             MapRender.this.labeledNetworks.add(network);
             return BitmapDescriptorFactory.fromBitmap(iconFactory.makeIcon(network, network.isNew()));
         }
 
+        private BitmapDescriptor getPinDescriptor(final Network network) {
+            switch (network.getType()) {
+                case CDMA:
+                case GSM:
+                case WCDMA:
+                case LTE:
+                case NR:
+                    if (network.isNew()) {
+                        return CELL_ICON_NEW;
+                    }
+                    return CELL_ICON;
+                case BT:
+                case BLE:
+                    if (network.isNew()) {
+                        return BT_ICON_NEW;
+                    }
+                    return BT_ICON;
+                case WIFI:
+                    if (network.isNew()) {
+                        return WIFI_ICON_NEW;
+                    }
+                    return WIFI_ICON;
+                default:
+                    if (network.isNew()) {
+                        return WIFI_ICON_NEW;
+                    }
+                    return DEFAULT_ICON;
+            }
+        }
         private boolean showDefaultIcon(final Network network) {
             final boolean showLabel = prefs.getBoolean( PreferenceKeys.PREF_MAP_LABEL, true );
             if (showLabel) {
@@ -365,4 +368,14 @@ public class MapRender {
         }
     };
 
+    private static final class NetworkHues {
+        public static final float WIFI = 92.90f;     // #87A96B
+        public static final float WIFI_NEW = 97.67f; // #85BB65
+        public static final float BT = 220.9f;        // #4682B
+        public static final float BT_NEW = 210.88f;  // #99BADD
+        public static final float CELL = 0.0f;       // #B22222
+        public static final float CELL_NEW = 4.8f;   // #E34234
+        public static final float DEFAULT = 110.0f;  // TODO: establish a better default
+        public static final float NEW = 120.0f;      // TODO: ""
+    }
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/NetworkBubbleDrawable.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/NetworkBubbleDrawable.java
@@ -1,0 +1,65 @@
+package net.wigle.wigleandroid.ui;
+
+import android.content.res.Resources;
+import android.graphics.Canvas;
+import android.graphics.ColorFilter;
+import android.graphics.PixelFormat;
+import android.graphics.PorterDuff;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+
+import androidx.annotation.NonNull;
+
+import net.wigle.wigleandroid.R;
+
+/**
+ * Based entirely on MapUtils com.google.maps.android.ui.BubbleDrawable - but because that's inaccessible outside the package, we're stuck making our own copy.
+ * TODO: It would be great to ween ourselves off of the 9patch bubble mask/drop shadow, but there doesn't appear to be a vector equivalent at the time of implementation.
+ * @see <a href="https://github.com/googlemaps/android-maps-utils">MapUtils</a>
+ */
+public class NetworkBubbleDrawable extends Drawable {
+
+    private final Drawable mShadow;
+    private final Drawable mMask;
+    private int mColor = -1;
+
+    public NetworkBubbleDrawable(Resources res) {
+        this.mMask = res.getDrawable(R.drawable.amu_bubble_mask);
+        this.mShadow = res.getDrawable(R.drawable.amu_bubble_shadow);
+    }
+    public void setColor(int color) {
+        this.mColor = color;
+    }
+
+    public void draw(@NonNull Canvas canvas) {
+        this.mMask.draw(canvas);
+        canvas.drawColor(this.mColor, PorterDuff.Mode.SRC_IN);
+        this.mShadow.draw(canvas);
+    }
+
+    public void setAlpha(int alpha) {
+        throw new UnsupportedOperationException();
+    }
+
+    public void setColorFilter(ColorFilter cf) {
+        throw new UnsupportedOperationException();
+    }
+
+    public int getOpacity() {
+        return PixelFormat.TRANSLUCENT;
+    }
+
+    public void setBounds(int left, int top, int right, int bottom) {
+        this.mMask.setBounds(left, top, right, bottom);
+        this.mShadow.setBounds(left, top, right, bottom);
+    }
+
+    public void setBounds(@NonNull Rect bounds) {
+        this.mMask.setBounds(bounds);
+        this.mShadow.setBounds(bounds);
+    }
+
+    public boolean getPadding(@NonNull Rect padding) {
+        return this.mMask.getPadding(padding);
+    }
+}

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/NetworkIconGenerator.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/NetworkIconGenerator.java
@@ -1,0 +1,260 @@
+package net.wigle.wigleandroid.ui;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Rect;
+import android.graphics.drawable.Drawable;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+
+import com.google.maps.android.ui.RotationLayout;
+
+import net.wigle.wigleandroid.R;
+import net.wigle.wigleandroid.model.Network;
+import net.wigle.wigleandroid.model.NetworkType;
+
+/**
+ * Based extensively on MapUtils {@link com.google.maps.android.ui.IconGenerator} - but retooled specifically for WiGLE's wireless network use case.
+ * - provides network-specific icons
+ * - color-codes background bubbles (still uses google 9patch images)
+ * - offers BSSID labels for null/empty SSIDs networks
+ * @see <a href="https://github.com/googlemaps/android-maps-utils">MapUtils</a>
+ * @author arkasha
+ */
+public class NetworkIconGenerator {
+    private final Context mContext;
+    private TextView mTextView;
+    private final ViewGroup mContainer;
+    private final RotationLayout mRotationLayout;
+    private final NetworkBubbleDrawable mBackground;
+    private int mRotation;
+    private View mContentView;
+    private float mAnchorU = 0.5F;
+    private float mAnchorV = 1.0F;
+
+
+    public static final int STYLE_DEFAULT = 1;
+    public static final int STYLE_WHITE = 2;
+    public static final int STYLE_CELL = 3;
+    public static final int STYLE_BT = 4;
+    public static final int STYLE_WIFI = 5;
+
+    /**
+     * Creates a new IconGenerator with the default style.
+     *
+     * @param context the context for the NetworkIconGenerator
+     */
+    public NetworkIconGenerator(Context context) {
+        mContext = context;
+        mBackground = new NetworkBubbleDrawable(this.mContext.getResources());
+        mContainer = (ViewGroup) LayoutInflater.from(mContext).inflate(R.layout.amu_text_bubble, null);
+        mRotationLayout = (RotationLayout) mContainer.getChildAt(0);
+        mContentView = mTextView = (TextView) mRotationLayout.findViewById(R.id.amu_text);
+        setStyle(STYLE_DEFAULT);
+    }
+
+    public Bitmap makeIcon(@NonNull Network network) {
+        if (this.mTextView != null) {
+            final String ssid = network.getSsid();
+            if (null != ssid && !ssid.isEmpty()) {
+                this.mTextView.setText(ssid);
+            } else {
+                this.mTextView.setText(network.getBssid());
+            };
+            mTextView.setGravity(Gravity.CENTER_HORIZONTAL);
+            mTextView.setCompoundDrawablePadding(mContext.getResources().getDimensionPixelSize(R.dimen.map_label_image_padding));
+            mTextView.setCompoundDrawablesWithIntrinsicBounds(getIconId(network.getType(), network.getCrypto()), 0, 0, 0);
+            setStyle(styleForNetworkType(network.getType()));
+        }
+        return this.makeIcon();
+    }
+
+    public Bitmap makeIcon() {
+        int measureSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
+        mContainer.measure(measureSpec, measureSpec);
+
+        int measuredWidth = mContainer.getMeasuredWidth();
+        int measuredHeight = mContainer.getMeasuredHeight();
+
+        mContainer.layout(0, 0, measuredWidth, measuredHeight);
+
+        if (mRotation == 1 || mRotation == 3) {
+            measuredHeight = mContainer.getMeasuredWidth();
+            measuredWidth = mContainer.getMeasuredHeight();
+        }
+
+        Bitmap r = Bitmap.createBitmap(measuredWidth, measuredHeight, Bitmap.Config.ARGB_8888);
+        r.eraseColor(Color.TRANSPARENT);
+
+        Canvas canvas = new Canvas(r);
+        switch (mRotation) {
+            case 0:
+                // do nothing
+                break;
+            case 1:
+                canvas.translate(measuredWidth, 0);
+                canvas.rotate(90);
+                break;
+            case 2:
+                canvas.rotate(180, measuredWidth / 2.0f, measuredHeight / 2.0f);
+                break;
+            case 3:
+                canvas.translate(0, measuredHeight);
+                canvas.rotate(270);
+                break;
+        }
+        mContainer.draw(canvas);
+        return r;
+    }
+
+    public void setContentView(View contentView) {
+        mRotationLayout.removeAllViews();
+        mRotationLayout.addView(contentView);
+        mContentView = contentView;
+        final View view = mRotationLayout.findViewById(R.id.amu_text);
+        mTextView = view instanceof TextView ? (TextView) view : null;
+    }
+
+    public void setContentRotation(int degrees) {
+        mRotationLayout.setViewRotation(degrees);
+    }
+
+    private float rotateAnchor(float u, float v) {
+        switch (this.mRotation) {
+            case 0:
+                return u;
+            case 1:
+                return 1.0F - v;
+            case 2:
+                return 1.0F - u;
+            case 3:
+                return v;
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    public float getAnchorU() {
+        float mAnchorU = 0.5f;
+        float mAnchorV = 1f;
+        return rotateAnchor(mAnchorU, mAnchorV);
+    }
+
+    public void setStyle(int style) {
+        this.setColor(getStyleColor(style));
+        this.setTextAppearance(this.mContext, getTextStyle(style));
+    }
+
+    public void setTextAppearance(Context context, int resid) {
+        if (this.mTextView != null) {
+            this.mTextView.setTextAppearance(context, resid);
+        }
+    }
+
+    public void setColor(int color) {
+        this.mBackground.setColor(color);
+        this.setBackground(this.mBackground);
+    }
+
+    public void setBackground(Drawable background) {
+        this.mContainer.setBackgroundDrawable(background);
+        if (background != null) {
+            Rect rect = new Rect();
+            background.getPadding(rect);
+            this.mContainer.setPadding(rect.left, rect.top, rect.right, rect.bottom);
+        } else {
+            this.mContainer.setPadding(0, 0, 0, 0);
+        }
+
+    }
+
+    public void setContentPadding(int left, int top, int right, int bottom) {
+        this.mContentView.setPadding(left, top, right, bottom);
+    }
+
+    private static int getStyleColor(int style) {
+        switch (style) {
+            case STYLE_CELL:
+                return -866844672; //CC550000
+            case STYLE_BT:
+                return -872406443; //CC002255
+            case STYLE_WIFI:
+                return -870165248; //CC225500
+            case STYLE_DEFAULT:
+            case STYLE_WHITE:
+            default:
+                return -1;
+        }
+    }
+
+    private static int getTextStyle(int style) {
+        switch (style) {
+            case 1:
+            case 2:
+            default:
+                return R.style.amu_Bubble_TextAppearance_Dark; //style.amu_Bubble_TextAppearance_Dark;
+            case 3:
+            case 4:
+            case 5:
+                return R.style.amu_Bubble_TextAppearance_Light;//style.amu_Bubble_TextAppearance_Light;
+        }
+    }
+
+
+    private int getIconId(NetworkType type, int crypto) {
+        switch (type) {
+            case BT:
+                return R.drawable.ic_bt;
+            case BLE:
+                return R.drawable.ic_btle;
+            case GSM:
+            case LTE:
+            case CDMA:
+            case WCDMA:
+                return R.drawable.cell;
+            case NR:
+                return R.drawable.cell_5g;
+            case WIFI:
+                switch (crypto) {
+                    case Network.CRYPTO_NONE:
+                        return R.drawable.no_ico;
+                    case Network.CRYPTO_WEP:
+                        return R.drawable.wep_ico;
+                    case Network.CRYPTO_WPA:
+                        return R.drawable.wpa_ico;
+                    case Network.CRYPTO_WPA2:
+                        return R.drawable.wpa2_ico;
+                    case Network.CRYPTO_WPA3:
+                        return R.drawable.wpa3_ico;
+                }
+                return R.drawable.cell_5g;
+            default:
+                return R.drawable.ic_wifi_sm;
+        }
+    }
+
+    private int styleForNetworkType(NetworkType t) {
+        switch (t) {
+            case BT:
+            case BLE:
+                return STYLE_BT;
+            case CDMA:
+            case GSM:
+            case WCDMA:
+            case LTE:
+            case NR:
+                return STYLE_CELL;
+            case WIFI:
+                return STYLE_WIFI;
+            default:
+                return STYLE_DEFAULT;
+        }
+    }
+}

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/NetworkIconGenerator.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/NetworkIconGenerator.java
@@ -45,6 +45,10 @@ public class NetworkIconGenerator {
     public static final int STYLE_CELL = 3;
     public static final int STYLE_BT = 4;
     public static final int STYLE_WIFI = 5;
+    public static final int STYLE_CELL_NEW = 6;
+    public static final int STYLE_BT_NEW = 7;
+    public static final int STYLE_WIFI_NEW = 8;
+
 
     /**
      * Creates a new IconGenerator with the default style.
@@ -60,7 +64,7 @@ public class NetworkIconGenerator {
         setStyle(STYLE_DEFAULT);
     }
 
-    public Bitmap makeIcon(@NonNull Network network) {
+    public Bitmap makeIcon(@NonNull Network network, final boolean isNew) {
         if (this.mTextView != null) {
             final String ssid = network.getSsid();
             if (null != ssid && !ssid.isEmpty()) {
@@ -71,7 +75,7 @@ public class NetworkIconGenerator {
             mTextView.setGravity(Gravity.CENTER_HORIZONTAL);
             mTextView.setCompoundDrawablePadding(mContext.getResources().getDimensionPixelSize(R.dimen.map_label_image_padding));
             mTextView.setCompoundDrawablesWithIntrinsicBounds(getIconId(network.getType(), network.getCrypto()), 0, 0, 0);
-            setStyle(styleForNetworkType(network.getType()));
+            setStyle(styleForNetworkType(network.getType(), isNew));
         }
         return this.makeIcon();
     }
@@ -182,10 +186,16 @@ public class NetworkIconGenerator {
     private static int getStyleColor(int style) {
         switch (style) {
             case STYLE_CELL:
+                return -869072896; //CC330000
+            case STYLE_CELL_NEW:
                 return -866844672; //CC550000
             case STYLE_BT:
+                return -872410829; //CC001133
+            case STYLE_BT_NEW:
                 return -872406443; //CC002255
             case STYLE_WIFI:
+                return -871288064; //CC113300
+            case STYLE_WIFI_NEW:
                 return -870165248; //CC225500
             case STYLE_DEFAULT:
             case STYLE_WHITE:
@@ -203,6 +213,9 @@ public class NetworkIconGenerator {
             case 3:
             case 4:
             case 5:
+            case 6:
+            case 7:
+            case 8:
                 return R.style.amu_Bubble_TextAppearance_Light;//style.amu_Bubble_TextAppearance_Light;
         }
     }
@@ -240,18 +253,27 @@ public class NetworkIconGenerator {
         }
     }
 
-    private int styleForNetworkType(NetworkType t) {
+    private int styleForNetworkType(NetworkType t, final boolean isNew) {
         switch (t) {
             case BT:
             case BLE:
+                if (isNew) {
+                    return STYLE_BT_NEW;
+                }
                 return STYLE_BT;
             case CDMA:
             case GSM:
             case WCDMA:
             case LTE:
             case NR:
+                if (isNew) {
+                    return STYLE_CELL_NEW;
+                }
                 return STYLE_CELL;
             case WIFI:
+                if (isNew) {
+                    return STYLE_WIFI_NEW;
+                }
                 return STYLE_WIFI;
             default:
                 return STYLE_DEFAULT;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/NetworkIconGenerator.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/NetworkIconGenerator.java
@@ -224,9 +224,9 @@ public class NetworkIconGenerator {
     private int getIconId(NetworkType type, int crypto) {
         switch (type) {
             case BT:
-                return R.drawable.ic_bt;
+                return R.drawable.bt_white;
             case BLE:
-                return R.drawable.ic_btle;
+                return R.drawable.btle_white;
             case GSM:
             case LTE:
             case CDMA:

--- a/wiglewifiwardriving/src/main/res/drawable/bt_white.xml
+++ b/wiglewifiwardriving/src/main/res/drawable/bt_white.xml
@@ -1,0 +1,4 @@
+<vector android:height="20dp" android:viewportHeight="512"
+    android:viewportWidth="512" android:width="20dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FFF" android:pathData="M394.13,163.1 L270.2,38.4L248.52,38.4L248.52,204.15L148.48,104.11l-30.6,30.6 121.64,121.64 -121.64,121.72 30.6,30.6 100.04,-100.04L248.52,473.6l21.68,0L394.13,349.67 300.8,256.34ZM291.87,122.04 L332.93,163.1 291.87,204.15ZM332.93,349.67 L291.87,390.72l0,-82.11z"/>
+</vector>

--- a/wiglewifiwardriving/src/main/res/drawable/btle_white.xml
+++ b/wiglewifiwardriving/src/main/res/drawable/btle_white.xml
@@ -1,0 +1,6 @@
+<vector android:height="20dp" android:viewportHeight="512"
+    android:viewportWidth="512" android:width="20dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FFF"
+        android:pathData="m447.68,421.55h37.1v16.7h-37.1zM447.68,476.25h45.7v19.02h-45.7zM443.12,383.15h51.51v16.25h-51.51zM376.61,478.71h51.56v16.56h-51.56zM438.15,383.15h19.19v112.13h-19.19zM372.47,383.57h19.19L391.65,495.41L372.47,495.41ZM394.13,163.1 L270.2,38.4L248.52,38.4v165.75l-100.04,-100.04 -30.6,30.6 121.64,121.64 -121.64,121.72 30.6,30.6L248.52,308.61L248.52,473.6h21.67l123.93,-123.93 -93.33,-93.33zM291.87,122.04 L332.92,163.1 291.87,204.15ZM332.92,349.67 L291.87,390.73v-82.11z"
+        android:strokeLineCap="round" android:strokeLineJoin="round" android:strokeWidth="9.36914"/>
+</vector>

--- a/wiglewifiwardriving/src/main/res/values/dimens.xml
+++ b/wiglewifiwardriving/src/main/res/values/dimens.xml
@@ -2,4 +2,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <dimen name="design_navigation_separator_vertical_padding" tools:override="true">2dp</dimen>
     <dimen name="menu_item_icon_size">24dp</dimen>
+    <dimen name="map_label_image_padding">8dp</dimen>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values/dimens.xml
+++ b/wiglewifiwardriving/src/main/res/values/dimens.xml
@@ -2,5 +2,5 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <dimen name="design_navigation_separator_vertical_padding" tools:override="true">2dp</dimen>
     <dimen name="menu_item_icon_size">24dp</dimen>
-    <dimen name="map_label_image_padding">8dp</dimen>
+    <dimen name="map_label_image_padding">6dp</dimen>
 </resources>


### PR DESCRIPTION
The network rendering behavior has been confusing for a long time.
This is one of a series of improvements to make network type, encryption status, and description more clear during clustering.
This adds:
- Pins colored according to network type
- Text Bubbles colored according to network type
- Icons indicating BT/BLE, 5G vs. other cell, and WiFi encryption status
- defaults to BSSID in the event of empty/null SSID in label.
- increase in labelled-nets from 1/15th to 1/10th of total net cache.

Very open to further refinement, this is just a first step.