### PR TITLE
[FIX] for GPX and M8B export thread queue and cache paths

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/GpxManagementActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/GpxManagementActivity.java
@@ -177,8 +177,8 @@ public class GpxManagementActivity extends ScreenChildActivity implements PolyRo
             case EXPORT_GPX_DIALOG: {
                 if (!exportRouteGpxFile(exportRouteId)) {
                     Logging.warn("Failed to export gpx.");
-                    WiGLEToast.showOverFragment(this, R.string.error_general,
-                            getString(R.string.gpx_failed));
+                    //WiGLEToast.showOverFragment(this, R.string.error_general,
+                    //        getString(R.string.gpx_failed));
                 }
                 break;
             }
@@ -192,7 +192,13 @@ public class GpxManagementActivity extends ScreenChildActivity implements PolyRo
         if (totalRoutePoints > 1) {
             ExecutorService es = ListFragment.lameStatic.executorService;
             if (null != es) {
-                es.submit(new GpxExportRunnable(this, true, totalRoutePoints, runId));
+                try {
+                    es.submit(new GpxExportRunnable(this, true, totalRoutePoints, runId));
+                } catch (IllegalArgumentException e) {
+                    Logging.error("failed to submit job: ", e);
+                    WiGLEToast.showOverFragment(this, R.string.export_gpx, getString(R.string.duplicate_job));
+                    return false;
+                }
             } else {
                 Logging.error("null LameStatic ExecutorService - unable to submit route export");
             }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ProgressPanelRunnable.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ProgressPanelRunnable.java
@@ -113,13 +113,11 @@ public abstract class ProgressPanelRunnable implements AlertSettable {
     }
 
     protected void reactivateProgressBar(final int id) {
-        activity.runOnUiThread(new Runnable() {
-            @Override
-            public void run() {
-                pp.show();
-                setProgressStatus(id);
-                pp.setIndeterminate();
-            }});
+        activity.runOnUiThread(() -> {
+            pp.show();
+            setProgressStatus(id);
+            pp.setIndeterminate();
+        });
     }
 
     protected void setProgressIndeterminate() {
@@ -136,5 +134,4 @@ public abstract class ProgressPanelRunnable implements AlertSettable {
         msg.setData(bundle);
         handler.sendMessage(msg);
     }
-
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/UniqueTaskExecutorService.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/UniqueTaskExecutorService.java
@@ -4,10 +4,14 @@ import net.wigle.wigleandroid.util.Logging;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class UniqueTaskExecutorService extends ThreadPoolExecutor {
     private final Set<Class> jobClasses;
@@ -21,25 +25,89 @@ public class UniqueTaskExecutorService extends ThreadPoolExecutor {
 
     @Override
     public Future<?> submit(Runnable task) throws IllegalArgumentException {
-        if (jobClasses.contains(task.getClass())) {
+        if (!jobClasses.add(task.getClass())) {
             throw new IllegalArgumentException("instance of "+task.getClass()+" already in queue");
         }
         Logging.debug("===>SUBMITTED: "+task.getClass());
-        jobClasses.add(task.getClass());
+        // superclass will wrap by calling newTaskFor
         return super.submit(task);
     }
 
     @Override
     protected void beforeExecute(Thread t, Runnable r) {
-        Logging.debug("===>EXECUTING: "+r.getClass());
-        current = r;
+        if (r instanceof WrappedTask) {
+            WrappedTask wt = (WrappedTask)r;
+            Logging.debug("===>EXECUTING: " + wt.getWrappedClass());
+            current = r;
+        }
     }
 
     @Override
     protected void afterExecute(Runnable r, Throwable t) {
-        jobClasses.remove(r.getClass());
-        current = null;
-        Logging.debug("<===EXECUTED: "+r.getClass());
+        if (r instanceof  WrappedTask) {
+            WrappedTask wt = (WrappedTask)r;
+            jobClasses.remove(wt.getWrappedClass());
+            current = null;
+            Logging.debug("<===EXECUTED: " + wt.getWrappedClass());
+        }
         super.afterExecute(r, t);
+    }
+
+    @Override
+    protected <T> RunnableFuture<T> newTaskFor(Runnable runnable, T value){
+        return new WrappedTask(runnable,value, this);
+    }
+
+    final class WrappedTask<T> implements RunnableFuture<T> {
+        /* where we're forwarding to */
+        private final RunnableFuture<T> task;
+        /* the type of the runnable we're wrapping */
+        private final Class runnableType;
+
+        /* the service we're running in, so we can tell it if we're canceled. */
+        private final UniqueTaskExecutorService holder;
+        public WrappedTask(Runnable runnable, T value, UniqueTaskExecutorService holder){
+            this.runnableType = runnable.getClass();
+            this.task = new FutureTask<>(runnable,value);
+            this.holder = holder;
+        }
+
+        /**
+         * get the type of the inner runnable
+         */
+        public Class getWrappedClass(){
+            return runnableType;
+        }
+
+        @Override
+        public void run() {
+            task.run();
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            holder.jobClasses.remove(runnableType);
+            return task.cancel(mayInterruptIfRunning);
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return task.isCancelled();
+        }
+
+        @Override
+        public boolean isDone() {
+            return task.isDone();
+        }
+
+        @Override
+        public T get() throws ExecutionException, InterruptedException {
+            return task.get();
+        }
+
+        @Override
+        public T get(long timeout, TimeUnit unit) throws ExecutionException, InterruptedException, TimeoutException {
+            return task.get(timeout,unit);
+        }
     }
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/UniqueTaskExecutorService.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/UniqueTaskExecutorService.java
@@ -39,6 +39,8 @@ public class UniqueTaskExecutorService extends ThreadPoolExecutor {
             WrappedTask wt = (WrappedTask)r;
             Logging.debug("===>EXECUTING: " + wt.getWrappedClass());
             current = r;
+        } else {
+            Logging.error("beforeExecute received non-WrappedTask runnable - cannot execute.");
         }
     }
 
@@ -49,6 +51,8 @@ public class UniqueTaskExecutorService extends ThreadPoolExecutor {
             jobClasses.remove(wt.getWrappedClass());
             current = null;
             Logging.debug("<===EXECUTED: " + wt.getWrappedClass());
+        } else {
+            Logging.error("afterExecute received non-WrappedTask runnable - cannot execute. (impossible case)");
         }
         super.afterExecute(r, t);
     }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/FileUtility.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/FileUtility.java
@@ -156,8 +156,10 @@ public class FileUtility {
                                                        final String dir) throws IOException {
         File path = new File(context.getFilesDir(), dir);
         if (!path.exists()) {
-            //noinspection ResultOfMethodCallIgnored
-            path.mkdir();
+            final boolean createdDirs = path.mkdir();
+            if (! createdDirs) {
+                Logging.error("Failed to created directories for: "+dir+" - "+filename);
+            }
         }
         if (path.exists() && path.isDirectory()) {
             //DEBUG: MainActivity.info("... file output directory found");
@@ -185,9 +187,14 @@ public class FileUtility {
      */
     public static String getM8bPath(final Context context) {
         if ( hasSD() ) {
-            return safeFilePath(Environment.getExternalStorageDirectory()) + M8B_DIR;
+            final String externalPath = safeFilePath(Environment.getExternalStorageDirectory()) + M8B_DIR;
+            Logging.debug("Using m8b (external) "+ externalPath);
+            return externalPath;
         } else if (context != null) {
-            return safeFilePath(context.getCacheDir());
+            final String internalPath = safeFilePath(context.getCacheDir())+"/";
+            //= safeFilePath(context.getFilesDir()) + M8B_DIR; // if we need to return to files-path for future sharing perms (1/2)
+            Logging.debug("Using m8b (internal)"+ internalPath);
+            return internalPath;
         }
         return null;
     }
@@ -198,9 +205,14 @@ public class FileUtility {
      */
     public static String getGpxPath(final Context context) {
         if ( hasSD() ) {
-            return safeFilePath(Environment.getExternalStorageDirectory()) + GPX_DIR;
+            final String externalPath = safeFilePath(Environment.getExternalStorageDirectory()) + GPX_DIR;
+            Logging.debug("Using gpx (external) "+ externalPath);
+            return externalPath;
         } else if (context != null) {
-            return safeFilePath(context.getCacheDir());
+            final String internalPath = safeFilePath(context.getCacheDir())+"/";
+            //= safeFilePath(context.getFilesDir()) + GPX_DIR; // if we need to return to files-path for future sharing perms (2/2)
+            Logging.debug("Using gpx (internal)"+ internalPath);
+            return internalPath;
         }
         return null;
     }
@@ -208,6 +220,7 @@ public class FileUtility {
     /**
      * just get the KML location for internal purposes; should be compatible with the results of
      * getKmlDownloadFile
+     * TODO: switch to use cache dir in case of no-external
      * @param context the context of the application
      * @return the string path suitable for intent construction
      */

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/FileUtility.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/FileUtility.java
@@ -158,7 +158,7 @@ public class FileUtility {
         if (!path.exists()) {
             final boolean createdDirs = path.mkdir();
             if (! createdDirs) {
-                Logging.error("Failed to created directories for: "+dir+" - "+filename);
+                Logging.error("Failed to create directories for: "+dir+" - "+filename);
             }
         }
         if (path.exists() && path.isDirectory()) {


### PR DESCRIPTION
- at-most-one Thread queue was failing to respect job classes
- cache paths were missing a "/"
- added cancel-ability (not yet wired)