### PR TITLE
[ENH] making missing start/end padding explicit

### DIFF
--- a/wiglewifiwardriving/src/main/res/layout-v29/row.xml
+++ b/wiglewifiwardriving/src/main/res/layout-v29/row.xml
@@ -45,6 +45,7 @@
 				android:layout_width="0dp"
 				android:layout_height="wrap_content"
 				android:paddingEnd="3dp"
+				android:paddingStart="0dp"
 				android:scrollHorizontally="true"
 				android:ellipsize="end"
 				android:maxLines="1"
@@ -74,6 +75,7 @@
 			tools:text="-69"
 			android:minWidth="24dp"
 			android:paddingEnd="0dp"
+			android:paddingStart="0dp"
 			android:textSize="12sp" />
 		<TextView
 			android:id="@+id/mac_string"

--- a/wiglewifiwardriving/src/main/res/layout/address_filter_list_item.xml
+++ b/wiglewifiwardriving/src/main/res/layout/address_filter_list_item.xml
@@ -10,6 +10,7 @@
         android:layout_centerVertical="true"
         android:layout_alignParentStart="true"
         android:paddingStart="8dp"
+        android:paddingEnd="0dp"
         android:textSize="18sp"
         android:textStyle="bold"
         android:layout_alignStart="@+id/delete_btn"

--- a/wiglewifiwardriving/src/main/res/layout/checkbox.xml
+++ b/wiglewifiwardriving/src/main/res/layout/checkbox.xml
@@ -1,7 +1,8 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:paddingStart="10dp">
+    android:paddingStart="10dp"
+    android:paddingEnd="0dp">
     <CheckBox
         android:id="@+id/checkbox"
         style="?android:attr/textAppearanceMedium"

--- a/wiglewifiwardriving/src/main/res/layout/dash.xml
+++ b/wiglewifiwardriving/src/main/res/layout/dash.xml
@@ -4,5 +4,6 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:keepScreenOn="true"
-    android:paddingStart="3dp">
+    android:paddingStart="3dp"
+    android:paddingEnd="0dp">
 </ScrollView>

--- a/wiglewifiwardriving/src/main/res/layout/dashlandscape.xml
+++ b/wiglewifiwardriving/src/main/res/layout/dashlandscape.xml
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:weightSum="2"
-    android:baselineAligned="false">
+    android:baselineAligned="false"
+    tools:orientation="horizontal">
     <LinearLayout
         android:orientation="horizontal"
         android:layout_weight="1"
         android:layout_height="match_parent"
         android:layout_width="0dp"
-        android:paddingEnd="10dp">
+        android:paddingEnd="10dp"
+        android:paddingStart="0dp">
         <include layout="@layout/dashtop"/>
     </LinearLayout>
     <LinearLayout

--- a/wiglewifiwardriving/src/main/res/layout/list.xml
+++ b/wiglewifiwardriving/src/main/res/layout/list.xml
@@ -291,6 +291,7 @@
 			android:layout_weight="4"
             android:layout_gravity="start"
             android:paddingStart="4dp"
+            android:paddingEnd="4dp"
             tools:text="8,888,888 km"
             />
         <TextView

--- a/wiglewifiwardriving/src/main/res/layout/row.xml
+++ b/wiglewifiwardriving/src/main/res/layout/row.xml
@@ -45,6 +45,7 @@
 				android:layout_width="0dp"
 				android:layout_height="wrap_content"
 				android:paddingEnd="3dp"
+				android:paddingStart="0dp"
 				android:scrollHorizontally="true"
 				android:ellipsize="end"
 				android:maxLines="1"
@@ -74,6 +75,7 @@
 			tools:text="-69"
 			android:minWidth="24dp"
 			android:paddingEnd="0dp"
+			android:paddingStart="0dp"
 			android:textSize="12sp" />
 		<TextView
 			android:id="@+id/mac_string"

--- a/wiglewifiwardriving/src/main/res/layout/search_nets.xml
+++ b/wiglewifiwardriving/src/main/res/layout/search_nets.xml
@@ -43,6 +43,7 @@
             <RadioButton android:id="@+id/radio_search_local"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:paddingStart="0dp"
                 android:paddingEnd="6dp"
                 android:text="@string/search_local"
                 />

--- a/wiglewifiwardriving/src/main/res/layout/sitestatslandscape.xml
+++ b/wiglewifiwardriving/src/main/res/layout/sitestatslandscape.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="horizontal"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:weightSum="5"
-    android:baselineAligned="false">
+    android:baselineAligned="false"
+    tools:orientation="horizontal">
     <LinearLayout
         android:orientation="horizontal"
         android:layout_weight="3"
         android:layout_height="match_parent"
         android:layout_width="0dp"
+        android:paddingStart="0dp"
         android:paddingEnd="10dp">
         <include layout="@layout/sitestatstop"/>
     </LinearLayout>

--- a/wiglewifiwardriving/src/main/res/layout/wigle_detail_toast.xml
+++ b/wiglewifiwardriving/src/main/res/layout/wigle_detail_toast.xml
@@ -16,6 +16,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginEnd="8dp"
+            android:contentDescription="@string/wigle_service"
             />
         <TextView
             android:id="@+id/toast_title_text"


### PR DESCRIPTION
just lint.

- largely making 0dp corresponding Start/Ends explicit.
0 useing the WiGLE service name for the icon in the toast, because I guess that's correct.