### PR TITLE
[FIX] fix for null parent

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/AddressFilterAdapter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/AddressFilterAdapter.java
@@ -64,7 +64,7 @@ public class AddressFilterAdapter extends BaseAdapter implements ListAdapter {
         View view = convertView;
         if (view == null) {
             LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-            view = inflater.inflate(R.layout.address_filter_list_item, null);
+            view = inflater.inflate(R.layout.address_filter_list_item, parent, false);
         }
 
         TextView listItemText = view.findViewById(R.id.list_item_string);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MacFilterActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MacFilterActivity.java
@@ -58,7 +58,6 @@ public class MacFilterActivity extends ScreenChildActivity {
         ListView lv = findViewById(R.id.addr_filter_list_view);
 
         filtersAdapter = new AddressFilterAdapter(listItems, this, prefs, filterKey);
-
         lv.setAdapter(filtersAdapter);
     }
 


### PR DESCRIPTION
working through the "correctness" issues with old code.

**Problem:**
"Layout Inflation without a Parent" in compilation report. We're building the row template for the MAC addr filter so that we can re-use it as-needed for each displayed filter row, but failing to pass a parent ViewGroup means that when we translate the XML to ViewGroups/etc, we're not using any device-adapted params. Null "works" but it means we're dynamically resizing at runtime which 1. has a performance cost and 2. may result in display bugs.

[understanding-androids-layoutinflater-inflate](https://bignerdranch.com/blog/understanding-androids-layoutinflater-inflate/)

**Solution:**
[addviewview-layoutparams-is-not-supported](https://stackoverflow.com/questions/4576219/logcat-error-addviewview-layoutparams-is-not-supported-in-adapterview-in-a)
contains the discussion, but (at the time of writing), the "pass null" solution" has outscored the "pass the parent but include a third param to indicate not to add the view to it" solution. The latter seems to be correct.