### PR TITLE
[FIX] NPE check

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
@@ -289,9 +289,11 @@ public final class DatabaseHelper extends Thread {
             }
 
             final MainActivity mainActivity = MainActivity.getMainActivity();
-            final Intent errorReportIntent = new Intent( mainActivity, ErrorReportActivity.class );
-            errorReportIntent.putExtra( ERROR_REPORT_DIALOG, error );
-            mainActivity.startActivity( errorReportIntent );
+            if (null != mainActivity) {
+                final Intent errorReportIntent = new Intent(mainActivity, ErrorReportActivity.class);
+                errorReportIntent.putExtra(ERROR_REPORT_DIALOG, error);
+                mainActivity.startActivity(errorReportIntent);
+            }
         }
     }
 


### PR DESCRIPTION
didn't know that was a risk here. (from play store report)
checks  NPE:
```
Exception java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.String android.content.Context.getPackageName()' on a null object reference
  at android.content.ComponentName.<init> (ComponentName.java:131)
  at android.content.Intent.<init> (Intent.java:6523)
  at net.wigle.wigleandroid.db.DatabaseHelper$DeathHandler.handleMessage (DatabaseHelper.java:292)
```