### PR TITLE
[FIX] filtering non-safe ASCII header characters from user agent, centralizing

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractApiRequest.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractApiRequest.java
@@ -11,6 +11,7 @@ import net.wigle.wigleandroid.ListFragment;
 import net.wigle.wigleandroid.db.DatabaseHelper;
 import net.wigle.wigleandroid.TokenAccess;
 import net.wigle.wigleandroid.WiGLEAuthException;
+import net.wigle.wigleandroid.net.WiGLEApiManager;
 import net.wigle.wigleandroid.util.FileAccess;
 import net.wigle.wigleandroid.util.FileUtility;
 import net.wigle.wigleandroid.util.Logging;
@@ -93,27 +94,12 @@ public abstract class AbstractApiRequest extends AbstractBackgroundTask {
         return createConnection(connectURL, setBoundary, preConnectConfigurator, connectionMethod);
     }
 
-    public static String getUserAgentString() {
-        String javaVersion = "unknown";
-        try {
-            javaVersion =  System.getProperty("java.vendor") + " " +
-                    System.getProperty("java.version") + ", jvm: " +
-                    System.getProperty("java.vm.vendor") + " " +
-                    System.getProperty("java.vm.name") + " " +
-                    System.getProperty("java.vm.version") + " on " +
-                    System.getProperty("os.name") + " " +
-                    System.getProperty("os.version") +
-                    " [" + System.getProperty("os.arch") + "]";
-        } catch (RuntimeException ignored) { }
-        return "WigleWifi ("+javaVersion+")";
-    }
-
     private static HttpURLConnection createConnection(final URL connectURL, final boolean setBoundary,
                                                       final PreConnectConfigurator preConnectConfigurator,
                                                       final String connectionMethod)
             throws IOException {
 
-        final String userAgent = AbstractApiRequest.getUserAgentString();
+        final String userAgent = WiGLEApiManager.USER_AGENT;
 
         // Open a HTTP connection to the URL
         HttpURLConnection conn = (HttpURLConnection) connectURL.openConnection();

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/net/WiGLEApiManager.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/net/WiGLEApiManager.java
@@ -88,6 +88,7 @@ public class WiGLEApiManager {
                     System.getProperty("os.name") + " " +
                     System.getProperty("os.version") +
                     " [" + System.getProperty("os.arch") + "]";
+            javaVersion = javaVersion.replaceAll("[^\\x00-\\x7F]", "");
         } catch (RuntimeException e) {
             Logging.error("Unable to get Java version for user agent string: ",e);
         }


### PR DESCRIPTION
fix for https://github.com/wiglenet/wigle-wifi-wardriving/issues/703

filters non-ascii header chars if present in the elements we use to construct the user agent header and DRYs UserAgent generation into the WiGLEApiManager class.