### PR TITLE
[ENH] trying a way to get tile retry working

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MappingFragment.java
@@ -374,7 +374,7 @@ public final class MappingFragment extends Fragment {
                     @Override
                     public Tile getTile(int x, int y, int zoom) {
                         if (!checkTileExists(x, y, zoom)) {
-                            return null;
+                            return NO_TILE;
                         }
 
                         final Long since = prefs.getLong(PreferenceKeys.PREF_SHOW_DISCOVERED_SINCE, 2001);
@@ -402,7 +402,11 @@ public final class MappingFragment extends Fragment {
 
                         try {
                             final byte[] data = downloadData(new URL(s), userAgent, authToken);
-                            return new Tile(providerTileRes, providerTileRes, data);
+                            if (data.length > 0) {
+                                return new Tile(providerTileRes, providerTileRes, data);
+                            } else {
+                                return null;
+                            }
                         } catch (MalformedURLException e) {
                             throw new AssertionError(e);
                         }


### PR DESCRIPTION
per https://developers.google.com/maps/documentation/android-sdk/reference/com/google/android/libraries/maps/model/TileProvider#getTile(int,%20int,%20int):

> If you do not wish to provide a tile for this tile coordinate, return [NO_TILE](https://developers.google.com/maps/documentation/android-sdk/reference/com/google/android/libraries/maps/model/TileProvider#NO_TILE). If the tile could not be found at this point in time, return null and further requests might be made with an exponential backoff.