### PR TITLE
[ENH] Icon settings

### DIFF
--- a/wiglewifiwardriving/src/main/res/drawable/map_layer.xml
+++ b/wiglewifiwardriving/src/main/res/drawable/map_layer.xml
@@ -1,15 +1,15 @@
-<vector android:height="24dp" android:viewportHeight="24"
-    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+<vector android:height="100dp" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="100dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#00000000"
         android:pathData="M4,8L12,4L20,8L12,12L4,8Z"
-        android:strokeColor="#000000" android:strokeLineCap="round"
+        android:strokeColor="?attr/colorControlNormal" android:strokeLineCap="round"
         android:strokeLineJoin="round" android:strokeWidth="2"/>
     <path android:fillColor="#00000000"
         android:pathData="M4,12L12,16L20,12"
-        android:strokeColor="#000000" android:strokeLineCap="round"
+        android:strokeColor="?attr/colorControlNormal" android:strokeLineCap="round"
         android:strokeLineJoin="round" android:strokeWidth="2"/>
     <path android:fillColor="#00000000"
         android:pathData="M4,16L12,20L20,16"
-        android:strokeColor="#000000" android:strokeLineCap="round"
+        android:strokeColor="?attr/colorControlNormal" android:strokeLineCap="round"
         android:strokeLineJoin="round" android:strokeWidth="2"/>
 </vector>

--- a/wiglewifiwardriving/src/main/res/drawable/search.xml
+++ b/wiglewifiwardriving/src/main/res/drawable/search.xml
@@ -3,6 +3,6 @@
     android:width="100dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#00000000"
         android:pathData="M15.795,15.811L21,21M18,10.5C18,14.642 14.642,18 10.5,18C6.358,18 3,14.642 3,10.5C3,6.358 6.358,3 10.5,3C14.642,3 18,6.358 18,10.5Z"
-        android:strokeColor="#000000" android:strokeLineCap="round"
+        android:strokeColor="?attr/colorControlNormal" android:strokeLineCap="round"
         android:strokeLineJoin="round" android:strokeWidth="2"/>
 </vector>

--- a/wiglewifiwardriving/src/main/res/menu/leftmenu.xml
+++ b/wiglewifiwardriving/src/main/res/menu/leftmenu.xml
@@ -28,7 +28,7 @@
             />
         <item
             android:id="@+id/nav_search"
-            android:icon="@android:drawable/ic_menu_search"
+            android:icon="@drawable/search"
             android:title="@string/tab_search"
             android:contentDescription="@string/tab_search"
             />
@@ -73,7 +73,7 @@
             />
         <item
             android:id="@+id/nav_settings"
-            android:icon="@android:drawable/ic_menu_preferences"
+            android:icon="@drawable/wrench"
             android:title="@string/menu_settings"
             android:contentDescription="@string/menu_settings"
             />


### PR DESCRIPTION
continuing the move to vector icons in the left menu.
improving rendering for the new layers icon and the sorta-new search icon.
we should continue to eliminate the remaining `ic_menu...` items as possible.