### PR TITLE
handle null result, clean up lamestatic init

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
@@ -131,9 +131,23 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
         public Set<String> runNetworks;
         public Set<String> runBtNetworks;
         public QueryArgs queryArgs;
-        public ConcurrentLinkedHashMap<String,Network> networkCache;
+        public final ConcurrentLinkedHashMap<String,Network> networkCache;
         public OUI oui;
-        public UniqueTaskExecutorService executorService;
+        public final UniqueTaskExecutorService executorService;
+
+        LameStatic() {
+            final long maxMemory = Runtime.getRuntime().maxMemory();
+            int cacheSize = 128;
+            if (maxMemory > 400_000_000L) {
+                cacheSize = 4000; // cap at 4,000
+            }
+            else if (maxMemory > 50_000_000L) {
+                cacheSize = (int)(maxMemory / 100_000); // 100MiB == 1000 cache
+            }
+            Logging.info("Heap: maxMemory: " + maxMemory + " cacheSize: " + cacheSize);
+            networkCache = new ConcurrentLinkedHashMap<>(cacheSize);
+            executorService = new UniqueTaskExecutorService(1);
+        }
     }
     public static final LameStatic lameStatic = new LameStatic();
 
@@ -143,20 +157,6 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
     private AnimatedVectorDrawableCompat scanningAnimation = null;
 
     private SharedPreferences prefs;
-
-    static {
-        final long maxMemory = Runtime.getRuntime().maxMemory();
-        int cacheSize = 128;
-        if (maxMemory > 400_000_000L) {
-            cacheSize = 4000; // cap at 4,000
-        }
-        else if (maxMemory > 50_000_000L) {
-            cacheSize = (int)(maxMemory / 100_000); // 100MiB == 1000 cache
-        }
-        Logging.info("Heap: maxMemory: " + maxMemory + " cacheSize: " + cacheSize);
-        lameStatic.networkCache = new ConcurrentLinkedHashMap<>(cacheSize);
-        lameStatic.executorService = new UniqueTaskExecutorService(1);
-    }
 
     /**
      * for the doing of things

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/WifiReceiver.java
@@ -236,6 +236,8 @@ public class WifiReceiver extends BroadcastReceiver {
         if ( results != null ) {
             resultSize = results.size();
             for ( ScanResult result : results ) {
+                if (result == null) continue; // have seen in the wild
+
                 Network network = networkCache.get( result.BSSID );
                 if ( network == null ) {
                     network = new Network( result );


### PR DESCRIPTION
```
Exception java.lang.RuntimeException:
  at android.app.LoadedApk$ReceiverDispatcher$Args.lambda$getRunnable$1$android-app-LoadedApk$ReceiverDispatcher$Args (LoadedApk.java:1854)
  at android.app.LoadedApk$ReceiverDispatcher$Args$$ExternalSyntheticLambda0.run (Unknown Source:2)
  at android.os.Handler.handleCallback (Handler.java:942)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:235)
  at android.os.Looper.loop (Looper.java:350)
  at android.app.ActivityThread.main (ActivityThread.java:8798)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:703)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:911)
Caused by java.lang.NullPointerException:
  at net.wigle.wigleandroid.listener.WifiReceiver.onReceive (WifiReceiver.java:239)
  at android.app.LoadedApk$ReceiverDispatcher$Args.lambda$getRunnable$1$android-app-LoadedApk$ReceiverDispatcher$Args (LoadedApk.java:1844)
```