### PR TITLE
flatten nav groups, stops uploads from disappearing for a second

### DIFF
--- a/wiglewifiwardriving/src/main/res/menu/leftmenu.xml
+++ b/wiglewifiwardriving/src/main/res/menu/leftmenu.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-    <group>
+    <group
+        android:id="@+id/first_group"
+        android:checkableBehavior="single">
         <item
             android:id="@+id/nav_list"
             android:icon="@android:drawable/ic_menu_sort_by_size"
@@ -43,28 +45,33 @@
             android:icon="@android:drawable/ic_menu_today"
             android:title="@string/tab_stats"
             android:contentDescription="@string/tab_stats"/>
-        <group
-            android:id="@+id/stats_group">
-            <item
-                android:id="@+id/nav_user_stats"
-                android:icon="@drawable/user_star"
-                android:title="@string/user_stats_app_name"
-                android:contentDescription="@string/user_stats_app_name"
-                />
-            <item
-                android:id="@+id/nav_rank"
-                android:icon="@drawable/rankings"
-                android:title="@string/tab_rank"
-                android:contentDescription="@string/tab_rank"
-                />
-            <item
-                android:id="@+id/nav_site_stats"
-                android:icon="@drawable/w_logo"
-                app:tint="?attr/colorControlNormal"
-                android:title="@string/site_stats_app_name"
-                android:contentDescription="@string/site_stats_app_name"
-                />
-        </group>
+    </group>
+    <group
+        android:id="@+id/stats_group"
+        android:checkableBehavior="single">
+        <item
+            android:id="@+id/nav_user_stats"
+            android:icon="@drawable/user_star"
+            android:title="@string/user_stats_app_name"
+            android:contentDescription="@string/user_stats_app_name"
+            />
+        <item
+            android:id="@+id/nav_rank"
+            android:icon="@drawable/rankings"
+            android:title="@string/tab_rank"
+            android:contentDescription="@string/tab_rank"
+            />
+        <item
+            android:id="@+id/nav_site_stats"
+            android:icon="@drawable/w_logo"
+            app:tint="?attr/colorControlNormal"
+            android:title="@string/site_stats_app_name"
+            android:contentDescription="@string/site_stats_app_name"
+            />
+    </group>
+    <group
+        android:id="@+id/last_group"
+        android:checkableBehavior="single">
         <item
             android:id="@+id/nav_uploads"
             android:icon="@android:drawable/ic_menu_upload"
@@ -77,13 +84,13 @@
             android:title="@string/menu_settings"
             android:contentDescription="@string/menu_settings"
             />
+        <item
+            android:clipToPadding="false"
+            android:id="@+id/nav_exit"
+            app:showAsAction="always|withText"
+            android:title="@null"
+            android:icon="@null"
+            app:actionLayout="@layout/wigle_exit_item"
+            />
     </group>
-    <item
-        android:clipToPadding="false"
-        android:id="@+id/nav_exit"
-        app:showAsAction="always|withText"
-        android:title="@null"
-        android:icon="@null"
-        app:actionLayout="@layout/wigle_exit_item"
-        />
 </menu>


### PR DESCRIPTION
This stops the "Uploads" nav item from disappearing for a second when the`Statistics` are clicked on. I don't know if this would help with the out of bounds exception we're seeing, but at least it gets rid of that flicker regardless. Instead of nested groups, has everything in one of 3 top level groups that have IDs and the `android:checkableBehavior="single"` that seems to be recommended.