### PR TITLE
[FIX] fixing on-fold exits

### DIFF
--- a/wiglewifiwardriving/src/main/AndroidManifest.xml
+++ b/wiglewifiwardriving/src/main/AndroidManifest.xml
@@ -5,9 +5,8 @@
     android:versionCode="296"
     android:versionName="2.96">
 
-    <attribution android:tag="wigle"
+    <attribution android:tag="@string/empty"
         android:label="@string/app_name" />
-
     <supports-screens
         android:anyDensity="true"
         android:largeScreens="true"
@@ -78,10 +77,12 @@
         android:label="@string/app_name"
         android:resizeableActivity="true"
         android:theme="@style/Theme.AppCompat.DayNight"
-        android:supportsRtl="true">
+        android:enableOnBackInvokedCallback="true"
+        android:supportsRtl="true"
+        tools:targetApi="tiramisu">
         <activity
             android:name=".MainActivity"
-            android:configChanges="keyboard|keyboardHidden|orientation|locale|screenSize|uiMode"
+            android:configChanges="keyboard|keyboardHidden|orientation|locale|screenSize|smallestScreenSize|screenLayout|uiMode"
             android:label="@string/list_app_name"
             android:exported="true"
             android:launchMode="singleTask">

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/BluetoothReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/BluetoothReceiver.java
@@ -614,6 +614,7 @@ public final class BluetoothReceiver extends BroadcastReceiver implements LeScan
                         m.bluetoothScan();
                     } catch (Exception ex) {
                         Logging.warn("exception starting bt scan: " + ex, ex);
+                        return false;
                     }
                 }
 

--- a/wiglewifiwardriving/src/main/res/values/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
+    <string name="empty"></string>
     <string name="stats">Starting</string>
     <string name="app_name">WiGLE WiFi Wardriving</string>
     <string name="list_app_name">WiGLE WiFi</string>


### PR DESCRIPTION
lack of handling was resulting in (clean but unintentional) exits on fold/unfold of phone.
https://github.com/wiglenet/wigle-wifi-wardriving/issues/747 was caused by this.

additional "empty string" addition+manifest attr is just to handle massive number of log errors due to:
https://stackoverflow.com/questions/79721071/log-file-filled-with-attributiontag-not-declared-in-manifest

don't think we need to add empty string to EVERY language strings.xml, since they all inherit from default `strings.xml`
