### PR TITLE
[FIX] stop fragment manager select from wiping out highlight

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -780,6 +780,10 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             return;
         }
 
+        final NavigationView navigationView = findViewById(R.id.left_drawer);
+        if (null != navigationView) {
+            applyExitBackground(navigationView);
+        }
         final Map<Integer, String> fragmentTitles = new HashMap<>();
         fragmentTitles.put(R.id.nav_list, getString(R.string.mapping_app_name));
         fragmentTitles.put(R.id.nav_dash, getString(R.string.dashboard_app_name));


### PR DESCRIPTION
not enough to do it on select- any place the fragment manager can update, the highlight can get depopulated.