### PR TITLE
[FIX] Padding for Settings, Search, and Data Fragments (required by edge-to-edge migration)

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/DataFragment.java
@@ -11,6 +11,7 @@ import net.wigle.wigleandroid.background.ObservationUploader;
 import net.wigle.wigleandroid.background.KmlWriter;
 import net.wigle.wigleandroid.db.DBException;
 import net.wigle.wigleandroid.model.NetworkFilterType;
+import net.wigle.wigleandroid.ui.LayoutUtil;
 import net.wigle.wigleandroid.ui.NetworkTypeArrayAdapter;
 import net.wigle.wigleandroid.ui.WiFiSecurityTypeArrayAdapter;
 import net.wigle.wigleandroid.ui.WiGLEConfirmationDialog;
@@ -24,7 +25,15 @@ import android.app.Activity;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.media.AudioManager;
+import android.os.Build;
 import android.os.Bundle;
+import android.view.WindowInsets;
+
+import androidx.annotation.NonNull;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
@@ -39,7 +48,6 @@ import android.widget.Spinner;
 import android.widget.TextView;
 
 import static net.wigle.wigleandroid.MainActivity.ACTION_GPX_MGMT;
-import static net.wigle.wigleandroid.MainActivity.getMainActivity;
 import static net.wigle.wigleandroid.background.GpxExportRunnable.EXPORT_GPX_DIALOG;
 
 import com.google.android.material.textfield.TextInputLayout;
@@ -79,6 +87,7 @@ public final class DataFragment extends Fragment implements DialogListener {
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         final View view = inflater.inflate(R.layout.data, container, false);
+
         setupQueryInputs( view );
         setupQueryButtons( view );
         setupCsvButtons( view );
@@ -89,6 +98,26 @@ public final class DataFragment extends Fragment implements DialogListener {
         setupM8bExport(view);
         setupGpxExport(view);
         return view;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+        ViewCompat.setOnApplyWindowInsetsListener(view, (v, insets) -> {
+            final Insets navBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars());
+            v.setPadding(0, 0, 0, navBars.bottom);
+            return insets;
+        });
+        //hack manual padding
+        view.post(() -> {
+            int navBarHeight = LayoutUtil.getNavigationBarHeight(getActivity(), getResources());
+            if (navBarHeight > 0 && view.getPaddingBottom() == 0) {
+                view.setPadding(0, 0, 0, navBarHeight);
+            }
+            if (view.isAttachedToWindow()) {
+                ViewCompat.requestApplyInsets(view);
+            }
+        });
     }
 
     private void setupQueryInputs( final View view ) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -316,6 +316,8 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
                         }
                     }
             );
+            // propagate insets to fragments
+            mainWrapper.post(() -> ViewCompat.requestApplyInsets(mainWrapper));
         }
 
         DrawerLayout dl = findViewById(R.id.drawer_layout);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SearchFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SearchFragment.java
@@ -44,6 +44,7 @@ import com.google.android.gms.maps.model.LatLngBounds;
 
 import net.wigle.wigleandroid.model.NetworkFilterType;
 import net.wigle.wigleandroid.model.QueryArgs;
+import net.wigle.wigleandroid.ui.LayoutUtil;
 import net.wigle.wigleandroid.ui.NetworkTypeArrayAdapter;
 import net.wigle.wigleandroid.ui.ThemeUtil;
 import net.wigle.wigleandroid.ui.WiFiSecurityTypeArrayAdapter;
@@ -121,29 +122,20 @@ public class SearchFragment extends Fragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        View bottomToolsLayout = view.findViewById(R.id.network_search_buttons);
-        view.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
-            @Override
-            public void onViewAttachedToWindow(View v) {
-                v.requestApplyInsets();
-                v.removeOnAttachStateChangeListener(this);
-            }
-
-            @Override
-            public void onViewDetachedFromWindow(View v) {
-            }
-        });
-
-        // Set the insets listener on the view.
         ViewCompat.setOnApplyWindowInsetsListener(view, (v, insets) -> {
-            if (null != bottomToolsLayout) {
-                final Insets innerPadding = insets.getInsets(
-                        WindowInsetsCompat.Type.navigationBars() /*TODO:  | cutouts?*/);
-                v.setPadding(
-                        innerPadding.left, innerPadding.top, innerPadding.right, innerPadding.bottom
-                );
+            final Insets navBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars());
+            v.setPadding(0, 0, 0, navBars.bottom);
+            return insets;
+        });
+        //hack manual padding
+        view.post(() -> {
+            int navBarHeight = LayoutUtil.getNavigationBarHeight(getActivity(), getResources());
+            if (navBarHeight > 0 && view.getPaddingBottom() == 0) {
+                view.setPadding(0, 0, 0, navBarHeight);
             }
-            return insets; // Pass the insets down to the children
+            if (view.isAttachedToWindow()) {
+                ViewCompat.requestApplyInsets(view);
+            }
         });
     }
     @Override

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/SettingsFragment.java
@@ -20,6 +20,10 @@ import android.os.Bundle;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatDelegate;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
@@ -45,6 +49,7 @@ import android.widget.TextView;
 import net.wigle.wigleandroid.listener.GNSSListener;
 import net.wigle.wigleandroid.model.api.ApiTokenResponse;
 import net.wigle.wigleandroid.net.RequestCompletedListener;
+import net.wigle.wigleandroid.ui.LayoutUtil;
 import net.wigle.wigleandroid.ui.PrefsBackedCheckbox;
 import net.wigle.wigleandroid.ui.WiGLEConfirmationDialog;
 import net.wigle.wigleandroid.util.FileUtility;
@@ -104,10 +109,34 @@ public final class SettingsFragment extends Fragment implements DialogListener {
             a.setVolumeControlStream(AudioManager.STREAM_MUSIC);
         }
 
-        // don't let the textbox have focus to start with, so we don't see a keyboard right away
         final LinearLayout linearLayout = view.findViewById(R.id.settingslayout);
-        linearLayout.setFocusableInTouchMode(true);
-        linearLayout.requestFocus();
+        if (null != linearLayout) {
+            ViewCompat.setOnApplyWindowInsetsListener(linearLayout, new OnApplyWindowInsetsListener() {
+                        @Override
+                        public @org.jspecify.annotations.NonNull WindowInsetsCompat onApplyWindowInsets(@org.jspecify.annotations.NonNull View v, @org.jspecify.annotations.NonNull WindowInsetsCompat insets) {
+                            final Insets innerPadding = insets.getInsets(
+                                    WindowInsetsCompat.Type.navigationBars());
+                            v.setPadding(0, 0, 0, innerPadding.bottom);
+                            return insets;
+                        }
+                    }
+            );
+            linearLayout.setFocusableInTouchMode(true);
+            linearLayout.requestFocus();
+            // don't let the textbox have focus to start with, so we don't see a keyboard right away
+        }
+
+        //hack manual padding - apply to root ScrollView
+        view.post(() -> {
+            int navBarHeight = LayoutUtil.getNavigationBarHeight(getActivity(), getResources());
+            if (navBarHeight > 0 && view.getPaddingBottom() == 0) {
+                view.setPadding(0, 0, 0, navBarHeight);
+            }
+            if (view.isAttachedToWindow()) {
+                ViewCompat.requestApplyInsets(view);
+            }
+        });
+
         updateView(view);
         return view;
     }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/LayoutUtil.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/LayoutUtil.java
@@ -1,0 +1,25 @@
+package net.wigle.wigleandroid.ui;
+
+import android.app.Activity;
+import android.content.res.Resources;
+import android.os.Build;
+import android.view.WindowInsets;
+
+/**
+ * Absolutely awful hack to compensate for edge-to-edge insets propagation problems in Fragments.
+ */
+public class LayoutUtil {
+    public static int getNavigationBarHeight(Activity activity, Resources resources) {
+        if (activity == null) return 0;
+
+        WindowInsets insets = activity.getWindow().getDecorView().getRootWindowInsets();
+        if (insets != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                return insets.getInsets(WindowInsets.Type.navigationBars()).bottom;
+            }
+        }
+        //this is sketchy, and shouldn't happen
+        int resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
+        return resourceId > 0 ? resources.getDimensionPixelSize(resourceId) : 0;
+    }
+}

--- a/wiglewifiwardriving/src/main/res/layout/data.xml
+++ b/wiglewifiwardriving/src/main/res/layout/data.xml
@@ -2,7 +2,8 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
-    android:layout_height="fill_parent">
+    android:layout_height="fill_parent"
+    android:clipToPadding="false">
 <LinearLayout
     android:id="@+id/data_tools_layout"
     android:orientation="vertical"

--- a/wiglewifiwardriving/src/main/res/layout/settings.xml
+++ b/wiglewifiwardriving/src/main/res/layout/settings.xml
@@ -3,7 +3,8 @@
             xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:background="#00FFFFFF">
+    android:background="#00FFFFFF"
+    android:clipToPadding="false">
     <!-- ALIBI:  background in to prevent arrow/scroll regressions on oldroid -->
 <LinearLayout
 	android:id="@+id/settingslayout"


### PR DESCRIPTION
resolving layout problems described in issue #787
 - adding an ugly hack to manually pad windows to compensate for navigation bar.