### PR TITLE
[FIX] background-thread for play console-reported ANR.

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -2684,10 +2684,16 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         //ALIBI: we'll piggyback off the current route, if we're logging it
         if (!logRoutes) {
             if (state != null && state.dbHelper != null) {
-                try {
-                    state.dbHelper.clearDefaultRoute();
-                } catch (DBException dbe) {
-                    Logging.warn("unable to clear default route on start-viz: ", dbe);
+                final DatabaseHelper dbHelper = state.dbHelper;
+                try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
+                    executor.execute(() -> {
+                        try {
+                            dbHelper.clearDefaultRoute();
+                        } catch (DBException dbe) {
+                            Logging.warn("unable to clear default route on startRouteMapping: ", dbe);
+                        }
+                    });
+                    executor.shutdown();
                 }
             }
         }


### PR DESCRIPTION
Play console detected an ANR when clearing previous route on start-up in "show current" and "don't log routes" case.
Moves clear operation to a background thread.