### PR TITLE
chore: google is breaking 3p CERTTRANS libraries in favor of their own

### DIFF
--- a/wiglewifiwardriving/build.gradle
+++ b/wiglewifiwardriving/build.gradle
@@ -108,7 +108,6 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'com.github.edwardstock:edittext-mask:1.0.7'
     implementation 'com.goebl:simplify:1.0.0'
-    implementation "com.appmattus.certificatetransparency:certificatetransparency-android:2.8.20"
     implementation 'com.google.maps.android:android-maps-utils:3.1.1'
     implementation 'org.apache.commons:commons-csv:1.10.0'
     implementation group: 'org.yaml', name: 'snakeyaml', version: '2.1'

--- a/wiglewifiwardriving/src/main/AndroidManifest.xml
+++ b/wiglewifiwardriving/src/main/AndroidManifest.xml
@@ -75,6 +75,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:resizeableActivity="true"
         android:theme="@style/Theme.AppCompat.DayNight"
         android:enableOnBackInvokedCallback="true"

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/net/WiGLEApiManager.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/net/WiGLEApiManager.java
@@ -1,6 +1,5 @@
 package net.wigle.wigleandroid.net;
 
-import static net.wigle.wigleandroid.util.UrlConfig.API_DOMAIN;
 import static net.wigle.wigleandroid.util.UrlConfig.FILE_POST_URL;
 
 import android.content.Context;
@@ -15,9 +14,6 @@ import android.os.Message;
 
 import androidx.annotation.NonNull;
 
-import com.appmattus.certificatetransparency.CTInterceptorBuilder;
-import com.appmattus.certificatetransparency.CTLogger;
-import com.appmattus.certificatetransparency.VerificationResult;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 
@@ -41,7 +37,6 @@ import net.wigle.wigleandroid.util.PreferenceKeys;
 import net.wigle.wigleandroid.util.UrlConfig;
 
 import org.jetbrains.annotations.NotNull;
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.io.BufferedReader;
@@ -102,19 +97,6 @@ public class WiGLEApiManager {
     private final OkHttpClient unauthedClient;
     private final Context context;
 
-    private static final CTInterceptorBuilder ctIB = new CTInterceptorBuilder();
-
-    private static final CTLogger ctLogger = new CTLogger() {
-        @Override
-        public void log(@NonNull String host, @NonNull VerificationResult result) {
-            Logging.info("[CERTTRANS] "+result);
-        }
-    };
-
-    // certificate transparency interceptor
-    private final static Interceptor certTransparencyInterceptor = ctIB.includeHost(API_DOMAIN)
-            .setLogger(ctLogger).build();
-
     /**
      * Build a WiGLEApiManager
      * @param prefs the preferences for the app to configure authentication
@@ -125,7 +107,6 @@ public class WiGLEApiManager {
         this.context = context;
         //authed connection to WiGLE
         this.authedClient = hasAuthed(prefs) ? new OkHttpClient.Builder()
-                .addNetworkInterceptor(certTransparencyInterceptor)
                 .addInterceptor(new BasicAuthInterceptor(prefs))
                 .addInterceptor(new Interceptor() {
                     @NotNull
@@ -143,7 +124,6 @@ public class WiGLEApiManager {
                 .readTimeout(READ_TIMEOUT_S, TimeUnit.SECONDS).build():null;
         //un-authed connection to WiGLE
         this.unauthedClient = new OkHttpClient.Builder()
-                .addNetworkInterceptor(certTransparencyInterceptor)
                 .addInterceptor(new Interceptor() {
                     @NotNull
                     @Override

--- a/wiglewifiwardriving/src/main/res/xml/network_security_config.xml
+++ b/wiglewifiwardriving/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+    <domain-config>
+        <domain includeSubdomains="true">wigle.net</domain>
+        <certificateTransparency enabled="true" />
+    </domain-config>
+</network-security-config>

--- a/wiglewifiwardriving/src/main/res/xml/network_security_config.xml
+++ b/wiglewifiwardriving/src/main/res/xml/network_security_config.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
     <base-config>
-        <trust-anchors>
-            <certificates src="system" />
-        </trust-anchors>
-    </base-config>
-    <domain-config>
-        <domain includeSubdomains="true">wigle.net</domain>
         <certificateTransparency enabled="true" />
-    </domain-config>
+    </base-config>
 </network-security-config>


### PR DESCRIPTION
maybe it's safer? maybe it's lock-in?
regardless, we can't release without removing the old library.