### PR TITLE
fix: textual fallback for indeterminate progress when system animatio…

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ProgressPanel.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ProgressPanel.java
@@ -1,5 +1,9 @@
 package net.wigle.wigleandroid;
 
+import android.animation.ValueAnimator;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.Parcelable;
 import android.view.View;
 import android.widget.LinearLayout;
@@ -19,6 +23,15 @@ public class ProgressPanel {
     private final ProgressBar progressBar;
     private final TextView queueLabel;
 
+    /** Base message text without any animated dot suffix. */
+    private String baseMessage = "";
+    /** Lazily created; only used when system animations are disabled. */
+    private Handler dotAnimationHandler;
+    private Runnable dotAnimationRunnable;
+    private int dotCount;
+
+    private static final long DOT_ANIMATION_INTERVAL_MS = 400L;
+
     public ProgressPanel(LinearLayout layout, TextView progressLabel, ProgressBar progressBar, TextView queueLabel) {
         this.container = layout;
         this.progressLabel = progressLabel;
@@ -31,16 +44,26 @@ public class ProgressPanel {
     }
 
     public void hide() {
+        stopDotAnimation();
         setProgress(0);
         progressBar.setIndeterminate(true);
         container.setVisibility(View.GONE);
     }
 
     public void setMessage(final String text) {
-        if (null != progressLabel) progressLabel.setText(text);
+        baseMessage = (text == null) ? "" : text;
+        if (null != progressLabel) {
+            progressLabel.setText(buildLabelText());
+        }
     }
 
     public void setProgress(final int progress) {
+        // Determinate progress works fine even when system animations are off;
+        // tear down any textual fallback and ensure the bar is visible.
+        stopDotAnimation();
+        if (null != progressBar) {
+            progressBar.setVisibility(View.VISIBLE);
+        }
         progressBar.setIndeterminate(false);
         progressBar.setProgress(progress);
     }
@@ -48,6 +71,17 @@ public class ProgressPanel {
     public void setIndeterminate() {
         if (null != progressBar) {
             progressBar.setIndeterminate(true);
+        }
+        // ProgressBar.setIndeterminate(true) renders nothing on API 21-27 when
+        // Battery Saver / Reduced Animations is on (animator scale = 0). Hide
+        // the bar and animate the existing label as a textual fallback so the
+        // user still sees that work is in progress. See WiGLE issue #699.
+        if (animatorsDisabled()) {
+            if (null != progressBar) progressBar.setVisibility(View.GONE);
+            startDotAnimation();
+        } else {
+            if (null != progressBar) progressBar.setVisibility(View.VISIBLE);
+            stopDotAnimation();
         }
     }
 
@@ -58,6 +92,53 @@ public class ProgressPanel {
     public void setQueue(final CharSequence text) {
         queueLabel.setVisibility(View.VISIBLE);
         queueLabel.setText(text);
+    }
+
+    private boolean animatorsDisabled() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            return !ValueAnimator.areAnimatorsEnabled();
+        }
+        // API 24/25: no public way to detect animator scale = 0, and the
+        // ProgressBar bug is rare on those versions. Preserve original behavior.
+        return false;
+    }
+
+    private void startDotAnimation() {
+        if (null == progressLabel) return;
+        if (null == dotAnimationHandler) {
+            dotAnimationHandler = new Handler(Looper.getMainLooper());
+        }
+        if (null != dotAnimationRunnable) return; // already running
+        dotAnimationRunnable = new Runnable() {
+            @Override public void run() {
+                dotCount = (dotCount + 1) % 4;
+                progressLabel.setText(buildLabelText());
+                if (null != dotAnimationHandler && null != dotAnimationRunnable) {
+                    dotAnimationHandler.postDelayed(this, DOT_ANIMATION_INTERVAL_MS);
+                }
+            }
+        };
+        dotAnimationHandler.post(dotAnimationRunnable);
+    }
+
+    private void stopDotAnimation() {
+        if (null == dotAnimationRunnable) return;
+        if (null != dotAnimationHandler) {
+            dotAnimationHandler.removeCallbacks(dotAnimationRunnable);
+        }
+        dotAnimationRunnable = null;
+        dotCount = 0;
+        if (null != progressLabel) {
+            progressLabel.setText(buildLabelText());
+        }
+    }
+
+    private String buildLabelText() {
+        if (dotCount <= 0) return baseMessage;
+        StringBuilder sb = new StringBuilder(baseMessage.length() + dotCount);
+        sb.append(baseMessage);
+        for (int i = 0; i < dotCount; i++) sb.append('.');
+        return sb.toString();
     }
 
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractBackgroundTask.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/AbstractBackgroundTask.java
@@ -169,9 +169,6 @@ public abstract class AbstractBackgroundTask extends Thread implements AlertSett
                 clearProgressDialog();
                 updateTransferringState(false, uploadButton, importObservedButton);
             });
-            //ALIBI: this will get replaced as soon as the progress is set for the first time
-            progressBar.setIndeterminate(true);
-
             //ALIBI: prevent multiple simultaneous large transfers by disabling visible buttons,
             // setting global state to make sure they get set on show
             updateTransferringState(true, uploadButton, importObservedButton);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ProgressPanelRunnable.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ProgressPanelRunnable.java
@@ -47,9 +47,6 @@ public abstract class ProgressPanelRunnable implements AlertSettable {
                 //taskCancelButton.setOnClickListener(v -> {
                 // TODO: make these subclasses cancellable, link to cancel button
                 //  });
-                //ALIBI: this will get replaced as soon as the progress is set for the first time
-                progressBar.setIndeterminate(true);
-
                 //ALIBI: prevent multiple simultaneous large transfers by disabling visible buttons,
                 // setting global state to make sure they get set on show
                 //updateTransferringState(true, uploadButton, importObservedButton);


### PR DESCRIPTION
Closes #699.

On API 21-27 with `animator_duration_scale = 0` (Battery Saver, Reduced Animations), `ProgressBar.setIndeterminate(true)` renders nothing. The reporter's diagnosis in #699 matches the current code in `ProgressPanel` and `AbstractBackgroundTask`.

Detect via `ValueAnimator.areAnimatorsEnabled()` (API 26+). When animators are off, hide the bar and cycle trailing dots on the status label (`Working`, `Working.`, `Working..`, `Working...`) with a `Handler.postDelayed` loop. `setProgress(int)` and `hide()` tear it down. Centralized in `ProgressPanel` so both `AbstractBackgroundTask` and `ProgressPanelRunnable` get it. Same patch removes two redundant direct `progressBar.setIndeterminate(true)` calls in those callers; they duplicated the `pp.setIndeterminate()` immediately following.

Why a `Handler` not another `ValueAnimator`: `areAnimatorsEnabled()` is the detection signal, and the system has disabled `ValueAnimator`, which is what the fallback would otherwise rely on. `Handler.postDelayed` is the standard escape hatch.

API 24/25 keep the original behavior. The underlying bug is rare there and there's no public way to detect animator scale = 0 without reflection. Easy to extend if reports come in.

FOSS portability: `ProgressPanel` has no `Foss*` sibling (shared between `main` and `foss-main`). All three changed files use only `android.*` APIs. Mechanical port.

Manual test plan:
1. Animations off. Developer Options, set "Animator duration scale" to "Animation off". Trigger a background task. Expect bar hidden, label cycling dots ~every 0.4s.
2. Animations on. Scale to "1x". Expect normal animated bar, static label.
3. Determinate progress. Long upload. Expect bar visible and progressing, no dots.
4. Battery Saver. Enable in Settings on a device that flips animator scale. Same as #1.

Files: `ProgressPanel.java` (fallback), `AbstractBackgroundTask.java` and `ProgressPanelRunnable.java` (redundant call removed). No XML, strings, or manifest changes.
