### PR TITLE
chore: fix typos in README, TODO, CHANGELOG, and English strings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -760,7 +760,7 @@ stop scanning when trying to upload
 * 1.11 (7/02/2010)
 map target easier to see
 change sounds from wav to ogg to avoid snap sound after playing
-seperate audio configs for new network in run vs. database
+separate audio configs for new network in run vs. database
 visible network count in dashboard
 add new for run vs. db option in map
 better upload failure info in UI

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Currently Android versions from Nougat (Android 7 / API 24) to Android 16 (API 3
 We receive various bug reports from forks/ports of Android to non-standard devices, but cannot address or test all possible variations. While we do our best to support the widest range of devices possible, the best way to get support for your device is to help us debug or to submit a pull request!
 
 ## Contributing
-You can submit fixes and changes for inclusion by forking this repository, working in a branch, and issuing a pull request. Langauge help and translations are VERY welcome.
+You can submit fixes and changes for inclusion by forking this repository, working in a branch, and issuing a pull request. Language help and translations are VERY welcome.
 
 We don't have a lot of contribution guidelines, but please:
 

--- a/TODO
+++ b/TODO
@@ -47,7 +47,7 @@ a widget
 * geofence for "don't record" and/or "do upload"
 
 
---- complete/obivated? ---
+--- complete/obviated? ---
 import files, instead of uploading to site and downloading to app
 rssi on kml export
 on networkactivity record more observations on that network (site survey)


### PR DESCRIPTION
Typo cleanup in `README.md`, `TODO`, and `CHANGELOG`. No code changes.

Three typo fixes:

1. `README.md`: "Langauge" to "Language" (Contributing section).
2. `TODO`: "obivated" to "obviated" (section header).
3. `CHANGELOG`: "seperate" to "separate" (2010 entry).

Per @rksh's request, the English `strings.xml` changes that were originally in this PR have moved to #827 with cross-language audit.
