### PR TITLE
chore: fix StartWigleAtBootReciever class name typo and "wierd" log

### DIFF
--- a/wiglewifiwardriving/src/main/AndroidManifest.xml
+++ b/wiglewifiwardriving/src/main/AndroidManifest.xml
@@ -357,7 +357,7 @@
             </intent-filter>
         </receiver>
         <receiver
-            android:name=".listener.StartWigleAtBootReciever"
+            android:name=".listener.StartWigleAtBootReceiver"
             android:label="StartWigleAtBootReceiver"
             android:exported="true"
             android:permission="android.permission.RECEIVE_BOOT_COMPLETED">

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
@@ -799,7 +799,7 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
             }
         } catch ( IncompatibleClassChangeError ex ) {
             // yeah, saw this in the wild, who knows.
-            Logging.error( "wierd ex: " + ex, ex);
+            Logging.error( "weird ex: " + ex, ex);
         }
     }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/StartWigleAtBootReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/StartWigleAtBootReceiver.java
@@ -8,7 +8,7 @@ import android.content.SharedPreferences;
 import net.wigle.wigleandroid.MainActivity;
 import net.wigle.wigleandroid.util.PreferenceKeys;
 
-public class StartWigleAtBootReciever extends BroadcastReceiver {
+public class StartWigleAtBootReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(Context context, Intent intent) {


### PR DESCRIPTION
Two small internal cleanups in one commit. No behavior change, no UI strings, no public API.

Class rename: `StartWigleAtBootReciever` to `StartWigleAtBootReceiver`. The `BroadcastReceiver` subclass in `net.wigle.wigleandroid.listener` has had a transposed `ie`/`ei` since inception. The `<receiver android:label="...">` attribute on `AndroidManifest.xml` line 361 is already spelled correctly, so the typo was caught in the user-facing label but missed on the class, its `.java` file, and the `android:name=".listener.StartWigleAtBootReciever"` reference. This PR brings them into agreement and matches Android's standard `*Receiver` convention.

Changes:
- `StartWigleAtBootReciever.java` to `StartWigleAtBootReceiver.java` (file rename via `git mv`, 93% history similarity).
- Class declaration updated inside the file.
- `AndroidManifest.xml` line 360: `android:name` updated.

No imports reference this class by name (only the manifest invokes it via the framework), so the rename is fully contained.

Log message: `"wierd ex:"` to `"weird ex:"` in `ListFragment.java` line 802, inside the `IncompatibleClassChangeError` catch handler. The comment on the line above ("yeah, saw this in the wild, who knows.") suggests this was a debug-session leftover. Logcat-only, never user-facing, but easy to fix while we're here.
