### PR TITLE
chore: cross-language strings cleanup (per #825 review)

### DIFF
--- a/wiglewifiwardriving/src/main/res/values-cs-rCZ/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-cs-rCZ/strings.xml
@@ -447,8 +447,8 @@
     <string name="registration_html_prompt">&lt;a href=\'net.wigle.wigleandroid.register://register\'>Zaregistrujte se na&lt;/a&gt; @WiGLE.net nebo &lt;a href=\'net.wigle.wigleandroid://activate\'&gt;aktivujte nyní pomocí QR kódu&lt;/a&gt;</string>
     <string name="ble_services">BLE UUID:</string>
     <string name="ble_vendor">ID dodavatele BLE:</string>
-    <string name="speech_new_bt">Nové bluetooth do DB</string>
-    <string name="tts_new_bt">Nové bluetooth</string>
+    <string name="speech_new_bt">Nové Bluetooth do DB</string>
+    <string name="tts_new_bt">Nové Bluetooth</string>
     <string name="gnss_full">Použít úplné sledování GNSS (velká spotřeba baterie)</string>
     <string name="search_area">Oblast hledání:</string>
     <string name="queued_jobs">(%1$d úkolů ve frontě)</string>

--- a/wiglewifiwardriving/src/main/res/values-da/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-da/strings.xml
@@ -267,7 +267,7 @@
     <string name="map_toast_satellite">Korttype: Satellit</string>
     <string name="map_toast_hybrid">Korttype: Hybrid</string>
     <string name="map_toast_terrain">Korttype: Terræn</string>
-    <string name="map_needs_playservice">Kort kræver Google Play Service</string>
+    <string name="map_needs_playservice">Kort kræver Google Play Services</string>
     <string name="drawer_open">Skuffe åben</string>
     <string name="drawer_close">Skuffe tæt</string>
     <string name="site_stats_app_name">WiGLE.net Statistik</string>
@@ -447,8 +447,8 @@
     <string name="registration_html_prompt">&lt;a href=\'net.wigle.wigleandroid.register://register\'>Tilmeld&lt;/a&gt; @WiGLE.net eller &lt;a href=\'net.wigle.wigleandroid://activate\'&gt;aktiver nu med QR-kode&lt;/a&gt;</string>
     <string name="ble_services">BLE UUIDs:</string>
     <string name="ble_vendor">BLE Leverandør ID:</string>
-    <string name="speech_new_bt">Ny bluetooth til DB</string>
-    <string name="tts_new_bt">Ny bluetooth</string>
+    <string name="speech_new_bt">Ny Bluetooth til DB</string>
+    <string name="tts_new_bt">Ny Bluetooth</string>
     <string name="gnss_full">Brug GNSS fuld sporing (stort batteriforbrug)</string>
     <string name="search_area">Søgeområde:</string>
     <string name="queued_jobs">(%1$d opgaver i kø)</string>

--- a/wiglewifiwardriving/src/main/res/values-de/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-de/strings.xml
@@ -267,7 +267,7 @@
     <string name="map_toast_satellite">Kartentyp: Satellit</string>
     <string name="map_toast_hybrid">Kartentyp: Hybrid</string>
     <string name="map_toast_terrain">Kartentyp: Terrain</string>
-    <string name="map_needs_playservice">Karte benötigt Google Play Service</string>
+    <string name="map_needs_playservice">Karte benötigt Google Play Services</string>
     <string name="drawer_open">Drawer öffnen</string>
     <string name="drawer_close">Drawer schließen</string>
     <string name="site_stats_app_name">WiGLE.net Statistiken</string>

--- a/wiglewifiwardriving/src/main/res/values-es-rES/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-es-rES/strings.xml
@@ -446,8 +446,8 @@
     <string name="registration_html_prompt">&lt;a href=\'net.wigle.wigleandroid.register://register\'>Registrarse&lt;/a&gt; @WiGLE.net or &lt;a href=\'net.wigle.wigleandroid://activate\'&gt;activar ahora con código QR&lt;/a&gt;</string>
     <string name="ble_services">UUID BLE:</string>
     <string name="ble_vendor">ID de proveedor BLE:</string>
-    <string name="speech_new_bt">Nueva bluetooth a DB</string>
-    <string name="tts_new_bt">Nueva bluetooth</string>
+    <string name="speech_new_bt">Nueva Bluetooth a DB</string>
+    <string name="tts_new_bt">Nueva Bluetooth</string>
     <string name="gnss_full">Utilice seguimiento completo GNSS (gran consumo de batería)</string>
     <string name="search_area">Área de búsqueda:</string>
     <string name="queued_jobs">(%1$d tareas en cola)</string>

--- a/wiglewifiwardriving/src/main/res/values-fi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fi/strings.xml
@@ -447,8 +447,8 @@
     <string name="registration_html_prompt">&lt;a href=\'net.wigle.wigleandroid.register://register\'>Rekisteröidy&lt;/a&gt; @WiGLE.net tai &lt;a href=\'net.wigle.wigleandroid://activate\'&gt;aktivoi nyt QR-koodilla&lt;/a&gt;</string>
     <string name="ble_services">BLE UUID:</string>
     <string name="ble_vendor">BLE-toimittajan tunnus:</string>
-    <string name="speech_new_bt">Uusi bluetooth DB:lle</string>
-    <string name="tts_new_bt">Uusi bluetooth</string>
+    <string name="speech_new_bt">Uusi Bluetooth DB:lle</string>
+    <string name="tts_new_bt">Uusi Bluetooth</string>
     <string name="gnss_full">Käytä täydellistä GNSS-seurantaa (suuri akun tyhjennys)</string>
     <string name="search_area">Hakualue:</string>
     <string name="queued_jobs">(%1$d jonossa olevaa tehtävää)</string>

--- a/wiglewifiwardriving/src/main/res/values-fr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fr/strings.xml
@@ -267,7 +267,7 @@
     <string name="map_toast_satellite">Type de carte : Satellite</string>
     <string name="map_toast_hybrid">Type de carte : Hybride</string>
     <string name="map_toast_terrain">Type de carte : Terrain</string>
-    <string name="map_needs_playservice">La carte nécessite Google Play Service</string>
+    <string name="map_needs_playservice">La carte nécessite Google Play Services</string>
     <string name="drawer_open">Tiroir ouvert</string>
     <string name="drawer_close">Tiroir fermé</string>
     <string name="site_stats_app_name">Statistiques WiGLE.net</string>

--- a/wiglewifiwardriving/src/main/res/values-fy/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fy/strings.xml
@@ -267,7 +267,7 @@
     <string name="map_toast_satellite">Kaarttype: Satelliet</string>
     <string name="map_toast_hybrid">Kaarttype: hybride</string>
     <string name="map_toast_terrain">Kaarttype: Terrein</string>
-    <string name="map_needs_playservice">Map vereist Google Play Service</string>
+    <string name="map_needs_playservice">Map vereist Google Play Services</string>
     <string name="drawer_open">Lade open</string>
     <string name="drawer_close">Lade gesloten</string>
     <string name="site_stats_app_name">WiGLE.net Statistieken</string>
@@ -447,8 +447,8 @@
     <string name="registration_html_prompt">&lt;a href=\'net.wigle.wigleandroid.register://register\'>Registreer&lt;/a&gt; @WiGLE.net of &lt;a href=\'net.wigle.wigleandroid://activate\'&gt;activeer nu met QR-code&lt;/a&gt;</string>
     <string name="ble_services">BLE UUID\'s:</string>
     <string name="ble_vendor">BLE-leveranciers-ID:</string>
-    <string name="speech_new_bt">Nije bluetooth nei DB</string>
-    <string name="tts_new_bt">Nije bluetooth</string>
+    <string name="speech_new_bt">Nije Bluetooth nei DB</string>
+    <string name="tts_new_bt">Nije Bluetooth</string>
     <string name="gnss_full">Brûk GNSS folsleine tracking (grutte batterij drain)</string>
     <string name="search_area">Zoekgebied:</string>
     <string name="queued_jobs">(%1$d taken in de wachtrij)</string>

--- a/wiglewifiwardriving/src/main/res/values-hu-rHU/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hu-rHU/strings.xml
@@ -447,8 +447,8 @@
     <string name="registration_html_prompt">&lt;a href=\'net.wigle.wigleandroid.register://register\'>Regisztráció&lt;/a&gt; @WiGLE.net vagy &lt;a href=\'net.wigle.wigleandroid://activate\'&gt;aktiválás most QR-kóddal&lt;/a&gt;</string>
     <string name="ble_services">BLE UUID-ok:</string>
     <string name="ble_vendor">BLE szállítói azonosító:</string>
-    <string name="speech_new_bt">Új bluetooth a DB-hez</string>
-    <string name="tts_new_bt">Új bluetooth</string>
+    <string name="speech_new_bt">Új Bluetooth a DB-hez</string>
+    <string name="tts_new_bt">Új Bluetooth</string>
     <string name="gnss_full">Használja a GNSS teljes követést (nagy akkumulátorlemerülés)</string>
     <string name="search_area">Keresési terület:</string>
     <string name="queued_jobs">(%1$d sorban álló feladat)</string>

--- a/wiglewifiwardriving/src/main/res/values-it-rIT/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-it-rIT/strings.xml
@@ -267,7 +267,7 @@
     <string name="map_toast_satellite">Tipo di Mappa: Satellite</string>
     <string name="map_toast_hybrid">Tipo di Mappa: Ibrida</string>
     <string name="map_toast_terrain">Tipo di Mappa: Terreno</string>
-    <string name="map_needs_playservice">La Mappa necessità di Google Play Service</string>
+    <string name="map_needs_playservice">La Mappa necessità di Google Play Services</string>
     <string name="drawer_open">Cassetto Aperto</string>
     <string name="drawer_close">Cassetto Chiuso</string>
     <string name="site_stats_app_name">Generali</string>

--- a/wiglewifiwardriving/src/main/res/values-nl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nl/strings.xml
@@ -267,7 +267,7 @@
     <string name="map_toast_satellite">Kaarttype: Satelliet</string>
     <string name="map_toast_hybrid">Kaarttype: hybride</string>
     <string name="map_toast_terrain">Kaarttype: Terrein</string>
-    <string name="map_needs_playservice">Map vereist Google Play Service</string>
+    <string name="map_needs_playservice">Map vereist Google Play Services</string>
     <string name="drawer_open">Lade open</string>
     <string name="drawer_close">Lade gesloten</string>
     <string name="site_stats_app_name">WiGLE.net Statistieken</string>

--- a/wiglewifiwardriving/src/main/res/values-nn/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nn/strings.xml
@@ -157,7 +157,7 @@
     <string name="signal">Signal</string>
     <string name="ssid">SSID</string>
     <string name="bssid">BSSID</string>
-    <string name="best_results">For best results, unset "Network notification" in "Wireless &amp; networks"-&gt;"WiFi settings"</string>
+    <string name="best_results">For best results, disable Android\'s "available networks" notifications in your Wi-Fi settings.</string>
     <string name="turn_on_wifi">Please turn on WiFi</string>
     <string name="no_gps_device">No GPS detected in device!</string>
     <string name="turn_on_gps">Please turn on GPS</string>
@@ -267,7 +267,7 @@
     <string name="map_toast_satellite">Map Type: Satellite</string>
     <string name="map_toast_hybrid">Map Type: Hybrid</string>
     <string name="map_toast_terrain">Map Type: Terrain</string>
-    <string name="map_needs_playservice">Map requires Google Play Service</string>
+    <string name="map_needs_playservice">Map requires Google Play Services</string>
     <string name="drawer_open">Drawer Open</string>
     <string name="drawer_close">Drawer Close</string>
     <string name="site_stats_app_name">WiGLE.net Statistics</string>
@@ -447,8 +447,8 @@
     <string name="registration_html_prompt">&lt;a href=\'net.wigle.wigleandroid.register://register\'>Registrer&lt;/a&gt; @WiGLE.net eller &lt;a href=\'net.wigle.wigleandroid://activate\'&gt;aktiver nå med QR-kode&lt;/a&gt;</string>
     <string name="ble_services">BLE UUIDer:</string>
     <string name="ble_vendor">BLE-leverandør-ID:</string>
-    <string name="speech_new_bt">Ny bluetooth til DB</string>
-    <string name="tts_new_bt">Ny bluetooth</string>
+    <string name="speech_new_bt">Ny Bluetooth til DB</string>
+    <string name="tts_new_bt">Ny Bluetooth</string>
     <string name="gnss_full">Bruk GNSS full sporing (stort batteriforbruk)</string>
     <string name="search_area">Søkeområde:</string>
     <string name="queued_jobs">(%1$d oppgaver i kø)</string>

--- a/wiglewifiwardriving/src/main/res/values-no/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-no/strings.xml
@@ -448,8 +448,8 @@
     <string name="registration_html_prompt">&lt;a href=\'net.wigle.wigleandroid.register://register\'>Registrer&lt;/a&gt; @WiGLE.net eller &lt;a href=\'net.wigle.wigleandroid://activate\'&gt;aktiver nå med QR-kode&lt;/a&gt;</string>
     <string name="ble_services">BLE UUIDer:</string>
     <string name="ble_vendor">BLE-leverandør-ID:</string>
-    <string name="speech_new_bt">Ny bluetooth til DB</string>
-    <string name="tts_new_bt">Ny bluetooth</string>
+    <string name="speech_new_bt">Ny Bluetooth til DB</string>
+    <string name="tts_new_bt">Ny Bluetooth</string>
     <string name="gnss_full">Bruk GNSS full sporing (stort batteriforbruk)</string>
     <string name="search_area">Søkeområde:</string>
     <string name="queued_jobs">(%1$d oppgaver i kø)</string>

--- a/wiglewifiwardriving/src/main/res/values-pl-rPL/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pl-rPL/strings.xml
@@ -447,8 +447,8 @@
     <string name="registration_html_prompt">&lt;a href=\'net.wigle.wigleandroid.register://register\'>Zarejestruj&lt;/a&gt; @WiGLE.net lub &lt;a href=\'net.wigle.wigleandroid://activate\'&gt;aktywuj teraz za pomocą kodu QR&lt;/a&gt;</string>
     <string name="ble_services">Identyfikatory UUID BLE:</string>
     <string name="ble_vendor">Identyfikator dostawcy BLE:</string>
-    <string name="speech_new_bt">Nowy bluetooth do DB</string>
-    <string name="tts_new_bt">Nowy bluetooth</string>
+    <string name="speech_new_bt">Nowy Bluetooth do DB</string>
+    <string name="tts_new_bt">Nowy Bluetooth</string>
     <string name="gnss_full">Użyj pełnego śledzenia GNSS (duże zużycie baterii)</string>
     <string name="search_area">Obszar wyszukiwania:</string>
     <string name="queued_jobs">(%1$d zadania w kolejce)</string>

--- a/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
@@ -447,8 +447,8 @@
     <string name="registration_html_prompt">&lt;a href=\'net.wigle.wigleandroid.register://register\'>Registre-se em&lt;/a&gt; @WiGLE.net ou &lt;a href=\'net.wigle.wigleandroid://activate\'&gt;ative agora com o código QR&lt;/a&gt;</string>
     <string name="ble_services">UUIDs BLE:</string>
     <string name="ble_vendor">ID do fornecedor BLE:</string>
-    <string name="speech_new_bt">Novo bluetooth para banco de dados</string>
-    <string name="tts_new_bt">Novo bluetooth</string>
+    <string name="speech_new_bt">Novo Bluetooth para banco de dados</string>
+    <string name="tts_new_bt">Novo Bluetooth</string>
     <string name="gnss_full">Use rastreamento completo GNSS (grande consumo de bateria)</string>
     <string name="search_area">Área de pesquisa:</string>
     <string name="queued_jobs">(%1$d tarefas em fila)</string>

--- a/wiglewifiwardriving/src/main/res/values-pt-rPT/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rPT/strings.xml
@@ -446,8 +446,8 @@
     <string name="registration_html_prompt">&lt;a href=\'net.wigle.wigleandroid.register://register\'>Registre-se em&lt;/a&gt; @WiGLE.net ou &lt;a href=\'net.wigle.wigleandroid://activate\'&gt;ative agora com o código QR&lt;/a&gt;</string>
     <string name="ble_services">UUIDs BLE:</string>
     <string name="ble_vendor">ID do fornecedor BLE:</string>
-    <string name="speech_new_bt">Novo bluetooth para banco de dados</string>
-    <string name="tts_new_bt">Novo bluetooth</string>
+    <string name="speech_new_bt">Novo Bluetooth para banco de dados</string>
+    <string name="tts_new_bt">Novo Bluetooth</string>
     <string name="gnss_full">Use rastreamento completo GNSS (grande consumo de bateria)</string>
     <string name="search_area">Área de pesquisa:</string>
     <string name="queued_jobs">(%1$d tarefas em fila)</string>

--- a/wiglewifiwardriving/src/main/res/values-sv-rSE/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-sv-rSE/strings.xml
@@ -447,8 +447,8 @@
     <string name="registration_html_prompt">&lt;a href=\'net.wigle.wigleandroid.register://register\'>Registrera&lt;/a&gt; @WiGLE.net eller &lt;a href=\'net.wigle.wigleandroid://activate\'&gt;aktivera nu med QR-kod&lt;/a&gt;</string>
     <string name="ble_services">BLE UUID:</string>
     <string name="ble_vendor">BLE leverantörs-ID:</string>
-    <string name="speech_new_bt">Ny bluetooth till DB</string>
-    <string name="tts_new_bt">Ny bluetooth</string>
+    <string name="speech_new_bt">Ny Bluetooth till DB</string>
+    <string name="tts_new_bt">Ny Bluetooth</string>
     <string name="gnss_full">Använd GNSS full tracking (stort batteriförbrukning)</string>
     <string name="search_area">Sökområde:</string>
     <string name="queued_jobs">(%1$d köade uppgifter)</string>

--- a/wiglewifiwardriving/src/main/res/values-tr-rTR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-tr-rTR/strings.xml
@@ -157,7 +157,7 @@
     <string name="signal">Sinyal</string>
     <string name="ssid">SSID</string>
     <string name="bssid">BSSID</string>
-    <string name="best_results">For best results, unset "Network notification" in "Wireless &amp; networks"-&gt;"WiFi settings"</string>
+    <string name="best_results">For best results, disable Android\'s "available networks" notifications in your Wi-Fi settings.</string>
     <string name="turn_on_wifi">WiFi aktif ediliyor</string>
     <string name="no_gps_device">Cihazınızda GPS bulunamadı!</string>
     <string name="turn_on_gps">Lütfen GPS\'i aktifleştirin</string>
@@ -448,7 +448,7 @@
     <string name="ble_services">BLE UUID\'leri:</string>
     <string name="ble_vendor">BLE Satıcı Kimliği:</string>
     <string name="speech_new_bt">DB\'ye yeni Bluetooth</string>
-    <string name="tts_new_bt">Yeni bluetooth</string>
+    <string name="tts_new_bt">Yeni Bluetooth</string>
     <string name="gnss_full">GNSS tam takibini kullanın (çok fazla pil tüketimi)</string>
     <string name="search_area">Arama Alanı:</string>
     <string name="queued_jobs">(%1$d sıraya alınmış görev)</string>

--- a/wiglewifiwardriving/src/main/res/values/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values/strings.xml
@@ -158,7 +158,7 @@
     <string name="signal">Signal</string>
     <string name="ssid">SSID</string>
     <string name="bssid">BSSID</string>
-    <string name="best_results">For best results, unset "Network notification" in "Wireless &amp; networks"-&gt;"WiFi settings"</string>
+    <string name="best_results">For best results, disable Android\'s "available networks" notifications in your Wi-Fi settings.</string>
     <string name="turn_on_wifi">Please turn on WiFi</string>
     <string name="no_gps_device">No GPS detected in device!</string>
     <string name="turn_on_gps">Please turn on GPS</string>
@@ -268,7 +268,7 @@
     <string name="map_toast_satellite">Map Type: Satellite</string>
     <string name="map_toast_hybrid">Map Type: Hybrid</string>
     <string name="map_toast_terrain">Map Type: Terrain</string>
-    <string name="map_needs_playservice">Map requires Google Play Service</string>
+    <string name="map_needs_playservice">Map requires Google Play Services</string>
     <string name="drawer_open">Drawer Open</string>
     <string name="drawer_close">Drawer Close</string>
     <string name="site_stats_app_name">WiGLE.net Statistics</string>
@@ -399,7 +399,7 @@
     <string name="pie_bad">Android Pie (9.0) throttles WiFi scans to 2 per minute. Upgrade Android if possible.</string>
     <string name="q_bad">Android 10 throttles WiFi scans unless disabled in Developer Settings.</string>
     <string name="enable_developer">To enable developer options: Settings -> About Phone -> Tap Build Number 7 times.</string>
-    <string name="disable_throttle">To disable WiFi scan throttling: System -> Advanced -> Developer options -> WiFi scan throttling to off.</string>
+    <string name="disable_throttle">To disable WiFi scan throttling: open Developer options and turn "WiFi scan throttling" off.</string>
     <string name="no_internal_space_title">No Space Available</string>
     <string name="no_internal_space_message">There isn\'t enough internal application storage on your device.</string>
     <string name="no_external_space_title">No Space Available</string>
@@ -439,7 +439,7 @@
     <string name="filter_show_btle">Show Bluetooth LE</string>
     <string name="settings_gps_head">GPS Settings</string>
     <string name="enable_kalman">Filter GPS noise</string>
-    <string name="gps_old_message">This device is no longer supported via the app store due to Google\'s policies. Please back-up your data and side-load the WiGLE v. 2.67 .apk (or lower) from https://github.com/wiglenet/wigle-wifi-wardriving/ . Sorry for the inconvenience!</string>
+    <string name="gps_old_message">This device is no longer supported via the app store due to Google\'s policies. Please back up your data and side-load the WiGLE v. 2.67 .apk (or lower) from https://github.com/wiglenet/wigle-wifi-wardriving/ . Sorry for the inconvenience!</string>
     <string name="gps_old_title">Unable to initialize GPS</string>
     <string name="enable_map_bearing">Follow my bearing/heading</string>
     <string name="login_title">Login required</string>
@@ -448,8 +448,8 @@
     <string name="registration_html_prompt">&lt;a href=\'net.wigle.wigleandroid.register://register\'>Register&lt;/a&gt; @WiGLE.net or &lt;a href=\'net.wigle.wigleandroid://activate\'&gt;activate now with QR code&lt;/a&gt;</string>
     <string name="ble_services">BLE UUIDs:</string>
     <string name="ble_vendor">BLE Vendor ID:</string>
-    <string name="speech_new_bt">New bluetooth to DB</string>
-    <string name="tts_new_bt">New bluetooth</string>
+    <string name="speech_new_bt">New Bluetooth to DB</string>
+    <string name="tts_new_bt">New Bluetooth</string>
     <string name="gnss_full">Use GNSS full tracking (large battery drain)</string>
     <string name="search_area">Search area:</string>
     <string name="queued_jobs">(%1$d queued tasks)</string>


### PR DESCRIPTION
Per @rksh's request on #825, splitting the English `strings.xml` changes into this PR with cross-language audit. Same fix propagated across every `values-*` file where the English text appears verbatim alongside the otherwise-translated string.

Mechanical fixes:

- `map_needs_playservice` "Google Play Service" -> "Google Play Services": 8 files (English + da, de, fr, fy, it-rIT, nl, nn). Languages with "service" translated to local script untouched.
- `speech_new_bt` and `tts_new_bt` "bluetooth" -> "Bluetooth" (proper noun): 13 non-English files had lowercase "bluetooth" in at least one of the two keys (cs-rCZ, da, es-rES, fi, fy, hu-rHU, nn, no, pl-rPL, pt-rBR, pt-rPT, sv-rSE, and tr-rTR which only had it in `tts_new_bt`). Languages already capitalizing it untouched.
- `best_results` English fallback: 3 files (English + nn, tr-rTR) were carrying the original English source verbatim; updated to the new English text.

English-source rewrites (translator follow-up needed):

- `best_results`: full rephrase. The 27 other language versions reference the legacy "Wireless & networks -> WiFi settings" UI path that disappeared after Android 4.x.
- `disable_throttle`: full rephrase. The "System -> Advanced" path varies by Android version; localized translations follow that older pattern.

Happy to coordinate a translator pass for both as a follow-up.

English-only fix:

- `gps_old_message` "back-up your data" -> "back up your data" (verb form). Other languages either don't have the hyphen or use "back-up" as a grammatically-correct Dutch noun ("Maak een back-up").

Out of scope, flagging only:

- `values-nn/strings.xml` and `values-no/strings.xml` carry the wrong text on the `disable_throttle` key (it's the `no_internal_space_message` text instead). Looks like a copy-paste mishap. Separate PR if desired.

Diff: 18 `strings.xml` files modified, 40 insertions, 40 deletions. All files parse and the debug APK assembles clean.
