### PR TITLE
chore: fix "lattitude"/"lattidude" typos in KalmanLatLong javadoc

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/KalmanLatLong.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/KalmanLatLong.java
@@ -26,9 +26,9 @@ public class KalmanLatLong {
     }
 
     /// <summary>
-    /// Kalman filter processing for lattitude and longitude
+    /// Kalman filter processing for latitude and longitude
     /// </summary>
-    /// <param name="lat_measurement_degrees">new measurement of lattidude</param>
+    /// <param name="lat_measurement_degrees">new measurement of latitude</param>
     /// <param name="lng_measurement">new measurement of longitude</param>
     /// <param name="accuracy">measurement of 1 standard deviation error in metres</param>
     /// <param name="TimeStamp_milliseconds">time of measurement</param>


### PR DESCRIPTION
## Summary
Fixes two spelling errors in the javadoc for `KalmanLatLong.process(...)`:
- `lattitude` -> `latitude` (summary line, L29)
- `lattidude` -> `latitude` (param description for `lat_measurement_degrees`, L31)

Comment-only change; no functional impact.

## Test plan
- [x] `./gradlew assembleDebug` succeeds locally (debug APK builds, JDK 17, Android SDK 36)

## AI / LLM disclosure
Per CONTRIBUTING.md: I used Claude Code (Anthropic's Claude Opus 4.7) to help locate this typo and draft the PR. The change is a trivial 2-line comment fix that I reviewed and understand fully.