### PR TITLE
chore: fix "unitialised" and "Covarariance" typos in KalmanLatLong comments

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/KalmanLatLong.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/KalmanLatLong.java
@@ -36,7 +36,7 @@ public class KalmanLatLong {
     public void process(double latMeasurement, double lngMeasurement, float accuracy, long timeStampMillis) {
         if (accuracy < minAccuracy) accuracy = minAccuracy;
         if (variance < 0) {
-            // if variance < 0, object is unitialised, so initialise with current values
+            // if variance < 0, object is uninitialised, so initialise with current values
             this.TimeStamp_milliseconds = timeStampMillis;
             lat=latMeasurement; lng = lngMeasurement; variance = accuracy*accuracy;
         } else {
@@ -50,13 +50,13 @@ public class KalmanLatLong {
                 // TO DO: USE VELOCITY INFORMATION HERE TO GET A BETTER ESTIMATE OF CURRENT POSITION
             }
 
-            // Kalman gain matrix K = Covarariance * Inverse(Covariance + MeasurementVariance)
+            // Kalman gain matrix K = Covariance * Inverse(Covariance + MeasurementVariance)
             // NB: because K is dimensionless, it doesn't matter that variance has different units to lat and lng
             float K = variance / (variance + accuracy * accuracy);
             // apply K
             lat += K * (latMeasurement - lat);
             lng += K * (lngMeasurement - lng);
-            // new Covarariance  matrix is (IdentityMatrix - K) * Covarariance
+            // new Covariance  matrix is (IdentityMatrix - K) * Covariance
             variance = (1 - K) * variance;
         }
     }


### PR DESCRIPTION
## Summary
Follow-up to #829. Fixes the remaining typos in `KalmanLatLong.java` comments:
- L39: `unitialised` -> `uninitialised`
- L53: `Covarariance` -> `Covariance` (1 occurrence)
- L59: `Covarariance` -> `Covariance` (2 occurrences)

Comment-only changes; no functional impact. Branched from `main` so it does not depend on #829 - either PR can merge first.

Note: kept British `initialise` (L39) and the existing double-space in the L59 comment as-is to keep the change strictly to the misspellings.

## Test plan
- [x] `./gradlew assembleDebug` succeeds locally (debug APK builds, JDK 17, Android SDK 36)

## AI / LLM disclosure
Per CONTRIBUTING.md: I used Claude Code (Anthropic's Claude Opus 4.7) to help locate these typos and draft the PR. The change is a 3-line comment fix that I reviewed and understand fully.