### PR TITLE
fix: partitioning uploads to remedy #783.

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/ObservationUploader.java
@@ -11,7 +11,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.os.Bundle;
-import android.preference.PreferenceManager;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 
@@ -48,9 +47,9 @@ import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.channels.ClosedByInterruptException;
-import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 import java.text.DecimalFormat;
 import java.text.FieldPosition;
 import java.text.NumberFormat;
@@ -66,7 +65,7 @@ import java.util.stream.Collectors;
 import javax.net.ssl.SSLException;
 
 /**
- * replacement file upload task
+ * Output files as WiGLE.net CSV v1.6 ( <a href="https://api.wigle.net/csvFormat-1_6.html">specified on the site</a> ) with progress state
  * Created by arkasha on 2/6/17.
  */
 
@@ -74,24 +73,26 @@ public class ObservationUploader extends AbstractProgressApiRequest {
 
     private static final String COMMA = ",";
     private static final String NEWLINE = "\n";
-
-    private static final String ENCODING = "UTF-8";
-
     private static final CSVFormat CSV_FORMAT;
 
-    private final boolean justWriteFile;
-    private final boolean writeEntireDb;
-    private final boolean writeRun;
+    private final boolean justWriteFile; // flag indicating that this is export to FS-only
+    private final boolean writeEntireDb; // flag indicating output of the entire DB
+    private final boolean writeRun; // flag indicating output of the current run only
+    private final boolean limitFileForUpload; // if this is for upload, respect server upload cap
 
     Status status;
 
+    // WiGLE CSV format 1.6 rows header
     public final static String CSV_COLUMN_HEADERS = "MAC,SSID,AuthMode,FirstSeen,Channel,Frequency,RSSI,CurrentLatitude,CurrentLongitude,AltitudeMeters,AccuracyMeters,RCOIs,MfgrId,Type";
 
+    // state object for upload progress
     private static class CountStats {
         int byteCount;
         int lineCount;
+        boolean rowsCapped;
     }
 
+    // CSV output configuration
     static {
         // Use the default (RFC4180) settings, except no carriage return on line end
         final CSVFormat.Builder builder = CSVFormat.Builder.create();
@@ -115,6 +116,7 @@ public class ObservationUploader extends AbstractProgressApiRequest {
         }
         this.writeEntireDb = writeEntireDb;
         this.writeRun = writeRun;
+        this.limitFileForUpload = !justWriteFile && !writeEntireDb;
     }
 
     @Override
@@ -159,7 +161,7 @@ public class ObservationUploader extends AbstractProgressApiRequest {
     }
 
     /**
-     * override base startDownload - but instead perform an upload
+     * override base startDownload from {@link AbstractProgressApiRequest} - (but instead we perform an upload)
      * TODO: a misnomer, really
      * @param fragment the fragment from which the upload was started
      */
@@ -177,7 +179,7 @@ public class ObservationUploader extends AbstractProgressApiRequest {
                 Logging.error("Failed to get activity for non-null fragment - prefs access failed on upload.");
             }
         } else {
-            prefs = PreferenceManager.getDefaultSharedPreferences(MainActivity.getMainActivity().getApplicationContext());
+            prefs = context.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
         }
         if (prefs != null) {
             final boolean hasApiToken = TokenAccess.hasApiToken(prefs);
@@ -266,7 +268,9 @@ public class ObservationUploader extends AbstractProgressApiRequest {
                             status = Status.SUCCESS;
                             final SharedPreferences.Editor editor = prefs.edit();
                             editor.putLong( PreferenceKeys.PREF_DB_MARKER, maxId );
-                            editor.putLong( PreferenceKeys.PREF_MAX_DB, maxId );
+                            if (!countStats.rowsCapped) {
+                                editor.putLong( PreferenceKeys.PREF_MAX_DB, maxId );
+                            }
                             editor.putLong( PreferenceKeys.PREF_NETS_UPLOADED, dbHelper.getNetworkCount() );
                             editor.apply();
                             final UploadReseponse.UploadResultsResponse uploadResults = response.getResults();
@@ -312,8 +316,10 @@ public class ObservationUploader extends AbstractProgressApiRequest {
                                         : "Uploads: Too many within timeframe";
                                 bundle.putString( BackgroundGuiHandler.ERROR, translated);
                             } else {
-                                final String translated = context != null? context.getString(R.string.no_wigle_conn): "Unable to connect.";
-                                bundle.putString( BackgroundGuiHandler.ERROR, translated+" (data: "+WiGLEApiManager.hasDataConnection(context)+")");
+                                final String translated = context != null ? context.getString(R.string.no_wigle_conn): "Unable to connect.";
+                                bundle.putString( BackgroundGuiHandler.ERROR, translated+" (data: " +
+                                        (context != null ? WiGLEApiManager.hasDataConnection(context):"unknown")
+                                        + ")");
                             }
                         } catch (JSONException e) {
                             throw new RuntimeException(e);
@@ -322,27 +328,23 @@ public class ObservationUploader extends AbstractProgressApiRequest {
                         context.sendBroadcast(intent);
                     }
                 });
-            };
+            }
         } catch ( final InterruptedException ex ) {
             Logging.info("ObservationUploader interrupted");
             throw ex;
         } catch (final ClosedByInterruptException | UnknownHostException | ConnectException | FileNotFoundException ex) {
             Logging.error( "Upload connection problem: " + ex, ex );
-            ex.printStackTrace();
             status = Status.EXCEPTION;
             bundle.putString( BackgroundGuiHandler.ERROR, context.getString(R.string.no_wigle_conn) );
         } catch (final SSLException ex) {
             Logging.error( "Upload security problem: " + ex, ex );
-            ex.printStackTrace();
             status = Status.EXCEPTION;
             bundle.putString( BackgroundGuiHandler.ERROR, context.getString(R.string.no_secure_wigle_conn) );
         } catch ( final IOException ex ) {
-            ex.printStackTrace();
             Logging.error( "Upload io problem: " + ex, ex );
             status = Status.EXCEPTION;
             bundle.putString( BackgroundGuiHandler.ERROR, "io problem: " + ex );
         } catch ( final Exception ex ) {
-            ex.printStackTrace();
             Logging.error( "Upload problem: " + ex, ex );
             MainActivity.writeError( this, ex, context, "Has data connection: " + WiGLEApiManager.hasDataConnection(context) );
             status = Status.EXCEPTION;
@@ -372,14 +374,12 @@ public class ObservationUploader extends AbstractProgressApiRequest {
             Logging.info("justWriteFile interrupted: " + ex);
         }
         catch ( IOException ex ) {
-            ex.printStackTrace();
             Logging.error( "io problem: " + ex, ex );
             MainActivity.writeError( this, ex, context );
             status = Status.EXCEPTION;
             bundle.putString( BackgroundGuiHandler.ERROR, "io problem: " + ex );
         }
         catch ( final Exception ex ) {
-            ex.printStackTrace();
             Logging.error( "ex problem: " + ex, ex );
             MainActivity.writeError( this, ex, context );
             status = Status.EXCEPTION;
@@ -420,7 +420,8 @@ public class ObservationUploader extends AbstractProgressApiRequest {
     }
 
     /**
-     * (lifted directly from FileUploaderTask)
+     * Write a WiGLE CSV-formatted output file. Row count is capped at the server batch limit only for
+     * incremental uploads; filesystem and whole-database exports write all matching rows.
      */
     private long writeFileWithCursor(final Context context, final OutputStream fos, final Bundle bundle,
                                      final ObservationUploader.CountStats countStats,
@@ -432,7 +433,10 @@ public class ObservationUploader extends AbstractProgressApiRequest {
         final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
         dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         countStats.lineCount = 0;
-        final int total = cursor.getCount();
+        countStats.rowsCapped = false;
+        final long rowCap = limitFileForUpload ? FileUtility.maxRowsPerUpload() : Long.MAX_VALUE;
+        final int cursorCount = cursor.getCount();
+        final int total = (!limitFileForUpload || cursorCount <= rowCap) ? cursorCount : (int) rowCap;
         long fileWriteMillis = 0;
         long netMillis = 0;
 
@@ -459,7 +463,7 @@ public class ObservationUploader extends AbstractProgressApiRequest {
                 "subBody=0"
         );
         headerBuffer.append(CSV_COLUMN_HEADERS).append(NEWLINE);
-        final byte[] headerBytes = headerBuffer.toString().getBytes(ENCODING);
+        final byte[] headerBytes = headerBuffer.toString().getBytes(StandardCharsets.UTF_8);
         fos.write( headerBytes );
         countStats.byteCount = headerBytes.length;
         // Logging.debug("headerBuffer: " + headerBuffer);
@@ -471,7 +475,7 @@ public class ObservationUploader extends AbstractProgressApiRequest {
             //noinspection resource
             final CSVPrinter printer = new CSVPrinter(charBuffer, CSV_FORMAT);
 
-            final CharsetEncoder encoder = Charset.forName( ENCODING ).newEncoder();
+            final CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
             // don't stop when a goofy character is found
             encoder.onUnmappableCharacter( CodingErrorAction.REPLACE );
             final NumberFormat numberFormat = NumberFormat.getNumberInstance( Locale.US );
@@ -489,6 +493,12 @@ public class ObservationUploader extends AbstractProgressApiRequest {
             for ( cursor.moveToFirst(); ! cursor.isAfterLast(); cursor.moveToNext() ) {
                 if ( wasInterrupted() ) {
                     throw new InterruptedException( "we were interrupted" );
+                }
+                if ( limitFileForUpload && countStats.lineCount >= rowCap ) {
+                    countStats.rowsCapped = true;
+                    Logging.info("upload row cap (" + rowCap + ") reached; truncating batch. "
+                            + "Total cursor rows: " + cursorCount + ", lastId written: " + maxId);
+                    break;
                 }
                 // _id,bssid,level,lat,lon,time
                 final long id = cursor.getLong(0);
@@ -600,7 +610,7 @@ public class ObservationUploader extends AbstractProgressApiRequest {
                 // debug logging
                 // byte[] dst = new byte[end];
                 // System.arraycopy(byteBuffer.array(), offset, dst, 0, end);
-                // final String out = new String(dst, ENCODING);
+                // final String out = new String(dst, StandardCharsets.UTF_8);
                 // Logging.debug("bytes! " + out);
 
                 // update UI

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/FileUtility.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/util/FileUtility.java
@@ -6,7 +6,6 @@ import android.os.StatFs;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,7 +15,7 @@ import java.util.List;
  */
 public class FileUtility {
 
-    //directory locations - centrally managed here, but must be in sync with fileprovider defs
+    //directory locations - centrally managed here, but must be in sync with fileProvider definitions
     private  final static String APP_DIR = "wiglewifi";
     private final static String APP_SUB_DIR = "/"+APP_DIR+"/";
     private static final String GPX_DIR = APP_SUB_DIR+"gpx/";
@@ -350,7 +349,7 @@ public class FileUtility {
     }
 
     /**
-     * file inspection debugging method - probably should get moved into a utility class eventually
+     * file inspection debugging method
      * @param directory the directory to enumerate
      */
     public static void printDirContents(final File directory) {
@@ -362,7 +361,7 @@ public class FileUtility {
                 Logging.info("\t\t" + file.getName() + "\t" + file.getAbsoluteFile());
             }
         } else {
-            Logging.error("Null file listing for "+directory.toString());
+            Logging.error("Null file listing for "+directory);
         }
     }
 
@@ -373,12 +372,7 @@ public class FileUtility {
         if (null != location) {
             final File directory = new File(location);
             if (directory.exists()) {
-                File[] files = directory.listFiles(new FilenameFilter() {
-                    @Override
-                    public boolean accept(File dir, String name) {
-                        return name.endsWith(CSV_GZ_EXT);
-                    }
-                });
+                File[] files = directory.listFiles((dir, name) -> name.endsWith(CSV_GZ_EXT));
                 if (null != files) {
                     for (File file : files) {
                         if (file.getName().endsWith(CSV_GZ_EXT)) {
@@ -394,19 +388,23 @@ public class FileUtility {
     }
 
     /**
-     * Evaluate the number of un-uploaded networks to determine whether the upload file is likely to require segmentation for upload. largely a placeholder
+     * Estimate whether the # of un-uploaded networks indicates whether upload file is likely too big for a single upload upload.
      * @param outstanding the number of un-uploaded networks
-     * @return true if the upload file should be partitioned to avoid disqualification, otherwise false
+     * @return true if the upload file should likely be partitioned, otherwise false
      */
     public static boolean checkUploadOversize(final long outstanding) {
-        if (outstanding * MIN_BYTES_PER_CSV_ROW_EST > WIGLE_MAX_UPLOAD_BYTES) {
-            return true;
-        }
-        if  ((long)(outstanding * MAX_BYTES_PER_CSV_ROW_EST * LARGE_RECORD_PROBABILITY) > WIGLE_MAX_UPLOAD_BYTES) {
-            //TODO: there's a lot of nuance we can add here.
-            return true;
-        }
+        return outstanding > maxRowsPerUpload();
+    }
 
-        return false;
+    /**
+     * Estimate the maximum number of rows that can be included in a single upload
+     * @return the maximum estimated number of rows
+     */
+    public static long maxRowsPerUpload() {
+        // both bounds in checkUploadOversize must hold; use the more conservative cap.
+        final long minBoundCap = WIGLE_MAX_UPLOAD_BYTES / MIN_BYTES_PER_CSV_ROW_EST;
+        final long maxBoundCap = (long) (WIGLE_MAX_UPLOAD_BYTES
+                / (MAX_BYTES_PER_CSV_ROW_EST * LARGE_RECORD_PROBABILITY));
+        return Math.min(minBoundCap, maxBoundCap);
     }
 }

--- a/wiglewifiwardriving/src/main/res/values-ar/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ar/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">تصدير البيانات</string>
     <string name="backup_restore">النسخ الاحتياطي والاستعادة</string>
     <string name="flag_whole_database">تعيين قاعدة البيانات بالكامل للتحميل</string>
-    <string name="file_size_warning">من المحتمل أن يتجاوز حجم الملف الحد الأقصى.</string>
+    <string name="file_size_warning">ستكون عمليات رفع متعددة ضرورية.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-cs-rCZ/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-cs-rCZ/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">Export dat</string>
     <string name="backup_restore">Zálohování a obnovení</string>
     <string name="flag_whole_database">Označit celou databázi k nahrání</string>
-    <string name="file_size_warning">Velikost souboru pravděpodobně překročí maximum.</string>
+    <string name="file_size_warning">Bude nutné provést několik nahrání.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-da/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-da/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">Dataeksport</string>
     <string name="backup_restore">Sikkerhedskopi og gendannelse</string>
     <string name="flag_whole_database">Angiv hele databasen til upload</string>
-    <string name="file_size_warning">Filstørrelsen vil sandsynligvis overstige maksimum.</string>
+    <string name="file_size_warning">Flere uploads vil være nødvendige.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-de/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-de/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">Datenexport</string>
     <string name="backup_restore">Sichern und Wiederherstellen</string>
     <string name="flag_whole_database">Gesamte Datenbank zum Upload markieren</string>
-    <string name="file_size_warning">Dateigröße überschreitet vermutlich das Maximum.</string>
+    <string name="file_size_warning">Mehrere Uploads sind erforderlich.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-es-rES/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-es-rES/strings.xml
@@ -495,5 +495,5 @@
     <string name="export">Exportar datos</string>
     <string name="backup_restore">Copia de seguridad y restauración</string>
     <string name="flag_whole_database">Marcar toda la base de datos para subir</string>
-    <string name="file_size_warning">El tamaño del archivo probablemente superará el máximo.</string>
+    <string name="file_size_warning">Serán necesarias varias subidas.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fi/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fi/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">Tietojen vienti</string>
     <string name="backup_restore">Varmuuskopiointi ja palautus</string>
     <string name="flag_whole_database">Merkitse koko tietokanta lähetettäväksi</string>
-    <string name="file_size_warning">Tiedoston koko ylittää todennäköisesti enimmäisrajan.</string>
+    <string name="file_size_warning">Useita lähetyksiä tarvitaan.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fr/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fr/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">Exportation des données</string>
     <string name="backup_restore">Sauvegarde et restauration</string>
     <string name="flag_whole_database">Marquer toute la base pour l’envoi</string>
-    <string name="file_size_warning">La taille du fichier dépassera probablement le maximum.</string>
+    <string name="file_size_warning">Plusieurs envois seront nécessaires.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-fy/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-fy/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">Data eksportearje</string>
     <string name="backup_restore">Backup en weromsette</string>
     <string name="flag_whole_database">Hiele database foar upload setten</string>
-    <string name="file_size_warning">Bestânsgrutte sil neifoardacht it maksimum oerstige.</string>
+    <string name="file_size_warning">Meardere uploads binne nedich.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hi-rIN/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hi-rIN/strings.xml
@@ -495,5 +495,5 @@
     <string name="export">डेटा निर्यात</string>
     <string name="backup_restore">बैकअप और पुनर्स्थापना</string>
     <string name="flag_whole_database">अपलोड के लिए पूरा डेटाबेस सेट करें</string>
-    <string name="file_size_warning">फ़ाइल आकार अधिकतम से अधिक होने की संभावना है।</string>
+    <string name="file_size_warning">एकाधिक अपलोड आवश्यक होंगे।</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-hu-rHU/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-hu-rHU/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">Adatexport</string>
     <string name="backup_restore">Biztonsági mentés és visszaállítás</string>
     <string name="flag_whole_database">A teljes adatbázis jelölése feltöltésre</string>
-    <string name="file_size_warning">A fájlméret valószínűleg meghaladja a maximumot.</string>
+    <string name="file_size_warning">Több feltöltésre lesz szükség.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-it-rIT/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-it-rIT/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">Esportazione dati</string>
     <string name="backup_restore">Backup e ripristino</string>
     <string name="flag_whole_database">Imposta l’intero database per il caricamento</string>
-    <string name="file_size_warning">La dimensione del file probabilmente supererà il massimo.</string>
+    <string name="file_size_warning">Saranno necessari più caricamenti.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-iw/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-iw/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">ייצוא נתונים</string>
     <string name="backup_restore">גיבוי ושחזור</string>
     <string name="flag_whole_database">סמן את כל מסד הנתונים להעלאה</string>
-    <string name="file_size_warning">גודל הקובץ ככל הנראה יחרוג מהמקסימום.</string>
+    <string name="file_size_warning">נדרשות העלאות מרובות.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ja-rJP/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ja-rJP/strings.xml
@@ -499,5 +499,5 @@ KMLにエクスポート</string>
     <string name="export">データのエクスポート</string>
     <string name="backup_restore">バックアップと復元</string>
     <string name="flag_whole_database">アップロード用にデータベース全体を設定</string>
-    <string name="file_size_warning">ファイルサイズが上限を超える可能性があります。</string>
+    <string name="file_size_warning">複数回のアップロードが必要になります。</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ko/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ko/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">데이터 내보내기</string>
     <string name="backup_restore">백업 및 복원</string>
     <string name="flag_whole_database">업로드용 전체 데이터베이스로 설정</string>
-    <string name="file_size_warning">파일 크기가 최대치를 초과할 가능성이 있습니다.</string>
+    <string name="file_size_warning">여러 차례 업로드가 필요합니다.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-nl/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nl/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">Gegevens exporteren</string>
     <string name="backup_restore">Back-up en herstel</string>
     <string name="flag_whole_database">Gehele database markeren voor upload</string>
-    <string name="file_size_warning">Bestandsgrootte overschrijdt waarschijnlijk het maximum.</string>
+    <string name="file_size_warning">Er zijn meerdere uploads nodig.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-nn/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-nn/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">Dataeksport</string>
     <string name="backup_restore">Tryggingskopi og gjenoppretting</string>
     <string name="flag_whole_database">Set heile databasen for opplasting</string>
-    <string name="file_size_warning">Filstorleiken vil truleg overskride maksimum.</string>
+    <string name="file_size_warning">Fleire opplastingar vil vera naudsynt.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-no/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-no/strings.xml
@@ -497,5 +497,5 @@
     <string name="export">Dataeksport</string>
     <string name="backup_restore">Sikkerhetskopi og gjenoppretting</string>
     <string name="flag_whole_database">Angi hele databasen for opplasting</string>
-    <string name="file_size_warning">Filstørrelsen vil sannsynligvis overstige maksimum.</string>
+    <string name="file_size_warning">Flere opplastinger vil være nødvendige.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pl-rPL/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pl-rPL/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">Eksport danych</string>
     <string name="backup_restore">Kopia zapasowa i przywracanie</string>
     <string name="flag_whole_database">Oznacz całą bazę do przesłania</string>
-    <string name="file_size_warning">Rozmiar pliku prawdopodobnie przekroczy maksimum.</string>
+    <string name="file_size_warning">Konieczne będzie kilka przesłań.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rBR/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">Exportar dados</string>
     <string name="backup_restore">Backup e restauração</string>
     <string name="flag_whole_database">Definir banco de dados inteiro para envio</string>
-    <string name="file_size_warning">O tamanho do arquivo provavelmente excederá o máximo.</string>
+    <string name="file_size_warning">Serão necessários vários uploads.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-pt-rPT/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-pt-rPT/strings.xml
@@ -495,5 +495,5 @@
     <string name="export">Exportar dados</string>
     <string name="backup_restore">Cópia de segurança e restauro</string>
     <string name="flag_whole_database">Marcar toda a base de dados para envio</string>
-    <string name="file_size_warning">O tamanho do ficheiro provavelmente excederá o máximo.</string>
+    <string name="file_size_warning">Serão necessários vários envios.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ro-rRO/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ro-rRO/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">Export de date</string>
     <string name="backup_restore">Backup și restaurare</string>
     <string name="flag_whole_database">Marchează întreaga bază pentru încărcare</string>
-    <string name="file_size_warning">Dimensiunea fișierului va depăși probabil maximul.</string>
+    <string name="file_size_warning">Vor fi necesare mai multe încărcări.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-ru/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-ru/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">Экспорт данных</string>
     <string name="backup_restore">Резервное копирование и восстановление</string>
     <string name="flag_whole_database">Пометить всю базу для выгрузки</string>
-    <string name="file_size_warning">Размер файла, вероятно, превысит максимум.</string>
+    <string name="file_size_warning">Потребуется несколько загрузок.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-sv-rSE/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-sv-rSE/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">Dataexport</string>
     <string name="backup_restore">Säkerhetskopiering och återställning</string>
     <string name="flag_whole_database">Ange hela databasen för uppladdning</string>
-    <string name="file_size_warning">Filstorleken kommer sannolikt att överskrida maximum.</string>
+    <string name="file_size_warning">Flera uppladdningar kommer att krävas.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-sw/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-sw/strings.xml
@@ -495,5 +495,5 @@
     <string name="export">Hamisha data</string>
     <string name="backup_restore">Hifadhi rudufu na kurejesha</string>
     <string name="flag_whole_database">Weka hifadhidata nzima kwa upakiaji</string>
-    <string name="file_size_warning">Ukubwa wa faili utazidi upeo kwa uwezekano mkubwa.</string>
+    <string name="file_size_warning">Itahitajika kupakia mara kwa mara.</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-tr-rTR/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-tr-rTR/strings.xml
@@ -496,6 +496,6 @@
     <string name="export">Veri dışa aktarma</string>
     <string name="backup_restore">Yedekleme ve geri yükleme</string>
     <string name="flag_whole_database">Yükleme için tüm veritabanını işaretle</string>
-    <string name="file_size_warning">Dosya boyutu büyük olasılıkla üst sınırı aşacaktır.</string>
+    <string name="file_size_warning">Birden fazla yükleme gerekecek.</string>
 </resources>
 

--- a/wiglewifiwardriving/src/main/res/values-zh-rCN/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rCN/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">数据导出</string>
     <string name="backup_restore">备份与恢复</string>
     <string name="flag_whole_database">将整个数据库标记为上传</string>
-    <string name="file_size_warning">文件大小可能会超过上限。</string>
+    <string name="file_size_warning">需要多次上传。</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rHK/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rHK/strings.xml
@@ -495,5 +495,5 @@
     <string name="export">數據匯出</string>
     <string name="backup_restore">備份與還原</string>
     <string name="flag_whole_database">將整個數據庫設為上傳</string>
-    <string name="file_size_warning">檔案大小可能會超過上限。</string>
+    <string name="file_size_warning">需要多次上傳。</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh-rTW/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh-rTW/strings.xml
@@ -495,5 +495,5 @@
     <string name="export">資料匯出</string>
     <string name="backup_restore">備份與還原</string>
     <string name="flag_whole_database">將整個資料庫設為上傳</string>
-    <string name="file_size_warning">檔案大小可能會超過上限。</string>
+    <string name="file_size_warning">需要多次上傳。</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values-zh/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values-zh/strings.xml
@@ -496,5 +496,5 @@
     <string name="export">数据导出</string>
     <string name="backup_restore">备份与恢复</string>
     <string name="flag_whole_database">将整个数据库标记为上传</string>
-    <string name="file_size_warning">文件大小可能会超过上限。</string>
+    <string name="file_size_warning">需要多次上传。</string>
 </resources>

--- a/wiglewifiwardriving/src/main/res/values/strings.xml
+++ b/wiglewifiwardriving/src/main/res/values/strings.xml
@@ -500,5 +500,5 @@
     <string name="export">Data export</string>
     <string name="backup_restore">Backup and restore</string>
     <string name="flag_whole_database">Set entire database for upload</string>
-    <string name="file_size_warning">File size will likely exceed maximum.</string>
+    <string name="file_size_warning">Multiple uploads will be necessary.</string>
 </resources>


### PR DESCRIPTION
Breaks too-large uploads into multiple upload chunks. Also revises warning text in DB activity to warn about chunking instead of failure.

- Uses our previously-established max-file-size estimation values 
- actual upload sizes in practical testing with cell/bt/wifi all enabled: 170,721,334 - 154,603,855 bytes

There's a case to be made for some follow-on features: 
- changing new/un-uploaded number on the main screen (and in the DB) when we reset DB marker to zero (deemed outside the scope of this PR, but it's how I tested it)
- warning people who reset their DB marker because ew.
- refining upload size estimates
- CLEAN-UP: when you reset your DB marker and make N near-maximum size uploads to test this, it's WASTEFUL w/ local disk space.
- somehow I was credited by the server with 7 new bluetooth + location from re-uploading 10,125,009 wifi+cell+bt nets; suggests an upload race condition on BT CSV gen.
- do we ever need to check compressed artifact size (back of the envelope we're always safe, but could we hypothetically create a high-entropy enough file that GZ can't save us?