### PR TITLE
DB contention fixes and modernization

### DIFF
--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/AbstractGpxManagementActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/AbstractGpxManagementActivity.java
@@ -24,7 +24,6 @@ import net.wigle.wigleandroid.background.GpxExportRunnable;
 import net.wigle.wigleandroid.db.DBException;
 import net.wigle.wigleandroid.db.DatabaseHelper;
 import net.wigle.wigleandroid.model.RouteDescriptor;
-import net.wigle.wigleandroid.ui.ThemeUtil;
 import net.wigle.wigleandroid.ui.GpxRecyclerAdapter;
 import net.wigle.wigleandroid.ui.ScreenChildActivity;
 import net.wigle.wigleandroid.ui.WiGLEToast;
@@ -289,21 +288,8 @@ public abstract class AbstractGpxManagementActivity extends ScreenChildActivity 
         }
         int runIdCol = cursor.getColumnIndexOrThrow("run_id");
         long runId = cursor.getLong(runIdCol);
-        try (Cursor routeCursor = dbHelper.routeIterator(runId)) {
-            if (routeCursor == null) return;
-            final int mapMode = prefs.getInt(PreferenceKeys.PREF_MAP_TYPE, 1);
-            final boolean nightMode = ThemeUtil.shouldUseMapNightMode(this, prefs);
-            RouteDescriptor newRoute = new RouteDescriptor();
-            for (routeCursor.moveToFirst(); !routeCursor.isAfterLast(); routeCursor.moveToNext()) {
-                float lat = routeCursor.getFloat(0);
-                float lon = routeCursor.getFloat(1);
-                newRoute.addLatLng(lat, lon, mapMode, nightMode);
-            }
-            configureMapForRoute(newRoute);
-        } catch (Exception e) {
-            Logging.error("Unable to display route after delete: ", e);
-        }
         adapter.setSelectedPosition(0);
+        adapter.loadAndShowRoute(runId);
     }
 
     @Override
@@ -314,7 +300,9 @@ public abstract class AbstractGpxManagementActivity extends ScreenChildActivity 
             final RecyclerView.Adapter<?> adapter = recyclerView.getAdapter();
             if (adapter instanceof GpxRecyclerAdapter) {
                 // close the route-meta Cursor held by the adapter
-                ((GpxRecyclerAdapter) adapter).updateCursor(null);
+                final GpxRecyclerAdapter gpxAdapter = (GpxRecyclerAdapter) adapter;
+                gpxAdapter.shutdown();
+                gpxAdapter.updateCursor(null);
             }
             recyclerView.setAdapter(null);
         }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/FossNetworkActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/FossNetworkActivity.java
@@ -13,6 +13,7 @@ import android.graphics.Color;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.view.View;
 import android.widget.RelativeLayout;
 
@@ -153,8 +154,12 @@ public class FossNetworkActivity extends AbstractNetworkActivity {
                     mapLibreMap.setStyle(styleUrl, style -> {
                         if ((network != null) && (network.getLatLng() != null)) {
                             final org.maplibre.android.geometry.LatLng focusOn =
-                                    new org.maplibre.android.geometry.LatLng(
-                                            network.getLatLng().latitude, network.getLatLng().longitude);
+                                    toMapLibreLatLng(network.getLatLng());
+                            if (focusOn == null) {
+                                Logging.warn("Skipping FOSS network map focus; invalid coordinates: "
+                                        + network.getLatLng());
+                                return;
+                            }
                             final CameraPosition cameraPosition = new CameraPosition.Builder()
                                     .target(focusOn).zoom(DEFAULT_ZOOM).build();
                             mapLibreMap.moveCamera(CameraUpdateFactory.newCameraPosition(cameraPosition));
@@ -195,6 +200,9 @@ public class FossNetworkActivity extends AbstractNetworkActivity {
         // we could check and perform multi-cluster here
         // (get arithmetic mean, std-dev, try to do sigma-based partitioning)
         // but that seems less likely w/ one individual's observations
+        if (mapView == null) {
+            return;
+        }
         final net.wigle.wigleandroid.model.LatLng estCentroid = computeBasicLocation(obsMap);
         final int zoomLevel = computeZoom(obsMap, estCentroid);
         mapView.getMapAsync(mapLibre -> {
@@ -204,8 +212,11 @@ public class FossNetworkActivity extends AbstractNetworkActivity {
                 final int level = obs.getValue();
 
                 // default to initial position
-                final org.maplibre.android.geometry.LatLng targetLatLon =
-                        new org.maplibre.android.geometry.LatLng(latLon.latitude, latLon.longitude);
+                final org.maplibre.android.geometry.LatLng targetLatLon = toMapLibreLatLng(latLon);
+                if (targetLatLon == null) {
+                    Logging.warn("Skipping observation with invalid coordinates: " + latLon);
+                    continue;
+                }
                 if (count == 0 && network.getLatLng() == null) {
                     final CameraPosition cameraPosition = new CameraPosition.Builder()
                             .target(targetLatLon).zoom(DEFAULT_ZOOM).build();
@@ -220,10 +231,9 @@ public class FossNetworkActivity extends AbstractNetworkActivity {
                 count++;
             }
             // if we got a good centroid, display it and center on it
-            if (estCentroid.latitude != 0d && estCentroid.longitude != 0d) {
+            final org.maplibre.android.geometry.LatLng llCentroid = toMapLibreLatLng(estCentroid);
+            if (llCentroid != null && estCentroid.latitude != 0d && estCentroid.longitude != 0d) {
                 //TODO: improve zoom based on obs distances?
-                final org.maplibre.android.geometry.LatLng llCentroid =
-                        new org.maplibre.android.geometry.LatLng(estCentroid.latitude, estCentroid.longitude);
                 final CameraPosition cameraPosition = new CameraPosition.Builder()
                         .target(llCentroid).zoom(zoomLevel).build();
                 mapLibre.moveCamera(CameraUpdateFactory.newCameraPosition(cameraPosition));
@@ -239,9 +249,15 @@ public class FossNetworkActivity extends AbstractNetworkActivity {
 
     @Override
     protected void mapWifiSeen(Network network, int zoomLevel, net.wigle.wigleandroid.model.LatLng latest, int rssi) {
+        if (mapView == null) {
+            return;
+        }
+        final org.maplibre.android.geometry.LatLng latestObs = toMapLibreLatLng(latest);
+        if (latestObs == null) {
+            Logging.warn("Skipping survey observation with invalid coordinates: " + latest);
+            return;
+        }
         mapView.getMapAsync(mapLibre -> {
-            final org.maplibre.android.geometry.LatLng latestObs =
-                    new org.maplibre.android.geometry.LatLng(latest.latitude, latest.longitude);
             if (network.getLatLng() == null) {
                 final CameraPosition cameraPosition = new CameraPosition.Builder()
                         .target(latestObs).zoom(zoomLevel).build();
@@ -259,6 +275,27 @@ public class FossNetworkActivity extends AbstractNetworkActivity {
 
     @Override
     protected void clearMap() {
-        mapView.getMapAsync(MapLibreMap::clear);
+        if (mapView != null) {
+            mapView.getMapAsync(MapLibreMap::clear);
+        }
+    }
+
+    /**
+     * utility function that safely wraps MapLibre LatLng creation to prevent IllegalArgumentExceptions
+     * @param latLon WiGLE lat/lon
+     * @return a valid MapLibre LatLon if possible - otherwise null
+     */
+    @Nullable
+    private static org.maplibre.android.geometry.LatLng toMapLibreLatLng(
+            final net.wigle.wigleandroid.model.LatLng latLon) {
+        if (latLon == null) {
+            return null;
+        }
+        final double lat = latLon.latitude;
+        final double lon = latLon.longitude;
+        if (!Double.isFinite(lat) || !Double.isFinite(lon) || Math.abs(lat) > 90.0) {
+            return null;
+        }
+        return new org.maplibre.android.geometry.LatLng(lat, lon);
     }
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ListFragment.java
@@ -244,30 +244,36 @@ public final class ListFragment extends Fragment implements ApiListener, DialogL
         //ALIBI: the number of async requests to perform.
         final Handler handler = new Handler(Looper.getMainLooper());
         executor.execute(() -> {
-            final long count = state.dbHelper.getNewWifiCount();
-            handler.post(() -> {
-                TextView text = view.findViewById( R.id.stats_wifi );
-                text.setText( UINumberFormat.counterFormat(count) );
-            });
+            if (null != state.dbHelper) {
+                final long count = state.dbHelper.getNewWifiCount();
+                handler.post(() -> {
+                    TextView text = view.findViewById(R.id.stats_wifi);
+                    text.setText(UINumberFormat.counterFormat(count));
+                });
+            }
         });
         TextView tv = view.findViewById( R.id.stats_cell );
         tv.setText( UINumberFormat.counterFormat(lameStatic.newCells));
         executor.execute(() -> {
-            final long count = state.dbHelper.getNewBtCount();
-            handler.post(() -> {
-                TextView text = view.findViewById( R.id.stats_bt );
-                text.setText( UINumberFormat.counterFormat(count) );
-            });
+            if (null != state.dbHelper) {
+                final long count = state.dbHelper.getNewBtCount();
+                handler.post(() -> {
+                    TextView text = view.findViewById(R.id.stats_bt);
+                    text.setText(UINumberFormat.counterFormat(count));
+                });
+            }
         });
         final long unUploaded = StatsUtil.newNetsSinceUpload(prefs);
         tv = view.findViewById( R.id.stats_unuploaded );
         tv.setText( UINumberFormat.counterFormat(unUploaded));
         executor.execute(() -> {
-            final long count = state.dbHelper.getNetworkCount();
-            handler.post(() -> {
-                TextView text = view.findViewById( R.id.stats_dbnets );
-                text.setText(dbFormat.format(count)); //
-            });
+            if (null != state.dbHelper) {
+                final long count = state.dbHelper.getNetworkCount();
+                handler.post(() -> {
+                    TextView text = view.findViewById(R.id.stats_dbnets);
+                    text.setText(dbFormat.format(count)); //
+                });
+            }
         });
     }
     public void setDBStatusUI(final View view, final String status, final long queueDepth ) {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -3005,16 +3005,10 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
         //ALIBI: we'll piggyback off the current route, if we're logging it
         if (!logRoutes) {
             if (state != null && state.dbHelper != null) {
-                final DatabaseHelper dbHelper = state.dbHelper;
-                try (ExecutorService executor = Executors.newSingleThreadExecutor()) {
-                    executor.execute(() -> {
-                        try {
-                            dbHelper.clearDefaultRoute();
-                        } catch (DBException dbe) {
-                            Logging.warn("unable to clear default route on startRouteMapping: ", dbe);
-                        }
-                    });
-                    executor.shutdown();
+                try {
+                    state.dbHelper.clearDefaultRoute();
+                } catch (DBException dbe) {
+                    Logging.warn("unable to clear default route on startRouteMapping: ", dbe);
                 }
             }
         }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -1082,10 +1082,8 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
 
     private void setupDatabase(final SharedPreferences prefs) {
         // could be set by nonconfig retain
-        if (state.dbHelper == null) {
-            state.dbHelper = new DatabaseHelper(getApplicationContext(), prefs);
-            //state.dbHelper.checkDB();
-            state.dbHelper.start();
+        if (state.dbHelper == null || state.dbHelper.isFullyClosed()) {
+            state.dbHelper = DatabaseHelper.acquire(getApplicationContext(), prefs);
             ListFragment.lameStatic.dbHelper = state.dbHelper;
         }
         if (state.mxcDbHelper == null) {
@@ -2838,7 +2836,13 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             }
 
             // close the db. not in destroy, because it'll still write after that.
-            if (state.dbHelper != null) state.dbHelper.close();
+            if (state.dbHelper != null) {
+                state.dbHelper.close();
+                if (ListFragment.lameStatic.dbHelper == state.dbHelper) {
+                    ListFragment.lameStatic.dbHelper = null;
+                }
+                state.dbHelper = null;
+            }
             if (state.mxcDbHelper != null) state.mxcDbHelper.close();
 
             final LocationManager locationManager = (LocationManager) this.getApplicationContext().getSystemService(Context.LOCATION_SERVICE); //ALIBI: avoid activity context-based leaks

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/MainActivity.java
@@ -2838,10 +2838,6 @@ public final class MainActivity extends AppCompatActivity implements TextToSpeec
             // close the db. not in destroy, because it'll still write after that.
             if (state.dbHelper != null) {
                 state.dbHelper.close();
-                if (ListFragment.lameStatic.dbHelper == state.dbHelper) {
-                    ListFragment.lameStatic.dbHelper = null;
-                }
-                state.dbHelper = null;
             }
             if (state.mxcDbHelper != null) state.mxcDbHelper.close();
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/GpxExportRunnable.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/GpxExportRunnable.java
@@ -94,17 +94,14 @@ public class GpxExportRunnable extends ProgressPanelRunnable implements Runnable
             writer.append(GPX_HEADER_B);
             writer.append(nameStr);
 
-            Cursor cursor;
-            if (routeId == -1) {
-                cursor = ListFragment.lameStatic.dbHelper.currentRouteIterator();
-            } else {
-                cursor = ListFragment.lameStatic.dbHelper.routeIterator(routeId);
+            try (Cursor cursor = (routeId == -1)
+                    ? ListFragment.lameStatic.dbHelper.currentRouteIterator()
+                    : ListFragment.lameStatic.dbHelper.routeIterator(routeId)) {
+                long segmentCount = writeSegmentsWithCursor(writer, cursor, df, totalCount);
+                Logging.info("wrote " + segmentCount + " segments");
             }
-            long segmentCount = writeSegmentsWithCursor(writer, cursor, df, totalCount);
-            Logging.info("wrote " + segmentCount + " segments");
             writer.append(GPX_FOOTER);
             writer.flush();
-            cursor.close();
         } catch (IOException | DBException | InterruptedException e) {
             Logging.error("Error writing GPX", e);
         } finally {

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/PooledQueryExecutor.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/background/PooledQueryExecutor.java
@@ -1,7 +1,6 @@
 package net.wigle.wigleandroid.background;
 
 import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
 
 import net.wigle.wigleandroid.db.DBException;
 import net.wigle.wigleandroid.db.DatabaseHelper;
@@ -49,9 +48,8 @@ public class PooledQueryExecutor {
         public void run() {
             Cursor cursor = null;
             try {
-                final SQLiteDatabase db = dbHelper.getDB();
-                if ( db != null ) {
-                    cursor = db.rawQuery( sql, args );
+                if ( dbHelper != null ) {
+                    cursor = dbHelper.query( sql, args );
                     while ( cursor.moveToNext() ) {
                         if (!handler.handleRow( cursor )) {
                             break;

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
@@ -654,11 +654,11 @@ public final class DatabaseHelper extends Thread {
         if (db.enableWriteAheadLogging()) {
             Logging.info("WAL enabled");
             // WAL already fsyncs the log; FULL would fsync the main file on every drain too
-            db.execSQL("PRAGMA synchronous = NORMAL");
+            execPragma("PRAGMA synchronous = NORMAL");
         } else {
             Logging.warn("WAL not available; using rollback journal");
         }
-        db.execSQL("PRAGMA busy_timeout = " + BUSY_TIMEOUT_MS);
+        execPragma("PRAGMA busy_timeout = " + BUSY_TIMEOUT_MS);
 
         if ( ! tableExists( db, NETWORK_TABLE ) ) {
             Logging.info( "network table missing, will create" );
@@ -883,6 +883,13 @@ public final class DatabaseHelper extends Thread {
         final int remaining = openTrackedCursors.get();
         if (remaining > 0) {
             Logging.warn("still " + remaining + " DB readers after " + timeoutMs + " ms");
+        }
+    }
+
+    /** Assignment PRAGMAs still return a row; {@link SQLiteDatabase#execSQL} rejects that. */
+    private void execPragma(final String sql) {
+        try (Cursor cursor = db.rawQuery(sql, null)) {
+            cursor.moveToFirst();
         }
     }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
@@ -47,6 +47,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.database.Cursor;
+import android.database.CursorWrapper;
 import android.database.DatabaseUtils;
 import android.database.SQLException;
 import android.database.sqlite.SQLiteConstraintException;
@@ -192,6 +193,7 @@ public final class DatabaseHelper extends Thread {
     private final ArrayBlockingQueue<DBUpdate> queue = new ArrayBlockingQueue<>(MAX_QUEUE);
     private final ArrayBlockingQueue<DBPending> pending = new ArrayBlockingQueue<>(MAX_QUEUE); // how to size this better?
     private final AtomicBoolean done = new AtomicBoolean(false);
+    private final AtomicInteger openTrackedCursors = new AtomicInteger();
     /** Held for the whole close sequence so a second caller waits until the file is actually released. */
     private final Object closeLock = new Object();
     private boolean fullyClosed = false;
@@ -374,6 +376,44 @@ public final class DatabaseHelper extends Thread {
     public SQLiteDatabase getDB() throws DBException {
         checkDB();
         return db;
+    }
+
+    /**
+     * Tracked read used by {@link net.wigle.wigleandroid.background.PooledQueryExecutor} so a
+     * checkpoint can see live readers. Prefer this over {@link #getDB()} plus a raw query.
+     */
+    public Cursor query(final String sql, final String[] args) throws DBException {
+        checkDB();
+        return trackedQuery(sql, args);
+    }
+
+    /**
+     * Count is best-effort; a leaked cursor is still a leak. Close is idempotent so adapter
+     * swap/update paths that close twice do not drive the count negative.
+     */
+    private Cursor trackedQuery(final String sql, final String[] args) {
+        final Cursor inner = db.rawQuery(sql, args);
+        openTrackedCursors.incrementAndGet();
+        return new TrackedCursor(inner);
+    }
+
+    private final class TrackedCursor extends CursorWrapper {
+        private final AtomicBoolean closed = new AtomicBoolean(false);
+
+        TrackedCursor(final Cursor cursor) {
+            super(cursor);
+        }
+
+        @Override
+        public void close() {
+            if (closed.compareAndSet(false, true)) {
+                try {
+                    super.close();
+                } finally {
+                    openTrackedCursors.decrementAndGet();
+                }
+            }
+        }
     }
 
     private static class DeathHandler extends Handler {
@@ -769,15 +809,32 @@ public final class DatabaseHelper extends Thread {
 
     /**
      * Fold WAL frames into the main file. The cursor must be stepped or SQLite never
-     * runs the pragma. TRUNCATE also resets the WAL so a copy of the main file is complete;
-     * FULL is the fallback if a reader is still holding a snapshot.
+     * runs the pragma. TRUNCATE also resets the WAL so a copy of the main file is complete,
+     * but it cannot finish while a reader still holds a snapshot — use FULL in that case.
      */
     private void checkpointWal() {
         if (db == null || !db.isOpen() || !db.isWriteAheadLoggingEnabled()) {
             return;
         }
+        final int readers = openTrackedCursors.get();
+        if (readers > 0) {
+            Logging.info("WAL TRUNCATE skipped, " + readers + " readers open");
+            runWalCheckpoint("FULL");
+            return;
+        }
         if (!runWalCheckpoint("TRUNCATE")) {
             runWalCheckpoint("FULL");
+        }
+    }
+
+    private void waitForReaders(final long timeoutMs) {
+        final long deadline = System.currentTimeMillis() + timeoutMs;
+        while (openTrackedCursors.get() > 0 && System.currentTimeMillis() < deadline) {
+            MainActivity.sleep(50L);
+        }
+        final int remaining = openTrackedCursors.get();
+        if (remaining > 0) {
+            Logging.warn("still " + remaining + " DB readers after " + timeoutMs + " ms");
         }
     }
 
@@ -815,6 +872,7 @@ public final class DatabaseHelper extends Thread {
             if (Thread.currentThread() != this) {
                 waitForWorkerExit();
             }
+            waitForReaders(2000L);
             synchronized (this) {
                 checkpointWal();
                 closeCompiledStatements();
@@ -1192,7 +1250,7 @@ public final class DatabaseHelper extends Thread {
             // cache miss, get the last values from the db, if any
             long start = System.currentTimeMillis();
             // SELECT: can't precompile, as it has more than 1 result value
-            final Cursor cursor = db.rawQuery("SELECT lasttime,lastlat,lastlon,bestlevel,bestlat,bestlon,mfgrid FROM network WHERE bssid = ?", bssidArgs );
+            final Cursor cursor = trackedQuery("SELECT lasttime,lastlat,lastlon,bestlevel,bestlat,bestlon,mfgrid FROM network WHERE bssid = ?", bssidArgs );
             logTime( start, "db network queried " + bssid );
             if ( cursor.getCount() == 0 ) {
                 insertNetwork.bindString( 1, bssid );
@@ -1641,7 +1699,7 @@ public final class DatabaseHelper extends Thread {
     public long getRoutePointCount(long routeId) {
         try {
             checkDB();
-            try (Cursor cursor = db.rawQuery(ROUTE_COUNT_QUERY, new String[]{String.valueOf(routeId)})) {
+            try (Cursor cursor = trackedQuery(ROUTE_COUNT_QUERY, new String[]{String.valueOf(routeId)})) {
                 cursor.moveToFirst();
                 return cursor.getLong(0);
             }
@@ -1711,7 +1769,7 @@ public final class DatabaseHelper extends Thread {
 
     private long getMaxIdFromDB( final String table ) throws DBException {
         checkDB();
-        try (Cursor cursor = db.rawQuery("select MAX(_id) FROM " + table, null)) {
+        try (Cursor cursor = trackedQuery("select MAX(_id) FROM " + table, null)) {
             cursor.moveToFirst();
             final long count = cursor.getLong(0);
             return count;
@@ -1719,7 +1777,7 @@ public final class DatabaseHelper extends Thread {
     }
     public long getWiFiNetsWthLocCountFromDB() throws DBException {
         checkDB();
-        try (Cursor cursor = db.rawQuery(LOCATED_WIFI_COUNT_QUERY, null)) {
+        try (Cursor cursor = trackedQuery(LOCATED_WIFI_COUNT_QUERY, null)) {
             cursor.moveToFirst();
             return cursor.getLong(0);
         }
@@ -1730,7 +1788,7 @@ public final class DatabaseHelper extends Thread {
      */
     public NetworkCatTotals getNetworkTotalsByKindFromDB() throws DBException {
         checkDB();
-        try (Cursor cursor = db.rawQuery(NETWORK_TOTALS_BY_KIND_QUERY, null)) {
+        try (Cursor cursor = trackedQuery(NETWORK_TOTALS_BY_KIND_QUERY, null)) {
             cursor.moveToFirst();
             return new NetworkCatTotals(cursor.getLong(0), cursor.getLong(1), cursor.getLong(2));
         }
@@ -1745,7 +1803,7 @@ public final class DatabaseHelper extends Thread {
             try {
                 checkDB();
                 final String[] args = new String[]{ bssid };
-                cursor = db.rawQuery("select ssid,frequency,capabilities,type,lastlat,lastlon,bestlat,bestlon,rcois,mfgrid,service,bestlevel,lasttime FROM "
+                cursor = trackedQuery("select ssid,frequency,capabilities,type,lastlat,lastlon,bestlat,bestlon,rcois,mfgrid,service,bestlevel,lasttime FROM "
                         + NETWORK_TABLE
                         + " WHERE bssid = ?", args);
                 if ( cursor.getCount() > 0 ) {
@@ -1797,21 +1855,21 @@ public final class DatabaseHelper extends Thread {
         checkDB();
         Logging.info( "locationIterator fromId: " + fromId );
         final String[] args = new String[]{ Long.toString( fromId ) };
-        return db.rawQuery( "SELECT _id,bssid,level,lat,lon,altitude,accuracy,time,mfgrid FROM location WHERE _id > ? AND external = 0", args );
+        return trackedQuery( "SELECT _id,bssid,level,lat,lon,altitude,accuracy,time,mfgrid FROM location WHERE _id > ? AND external = 0", args );
     }
 
     public Cursor networkIterator(final NetworkFilter filter) throws DBException {
         checkDB();
         Logging.info( "networkIterator (filtered)" );
         final String[] args = new String[]{};
-        return db.rawQuery( "SELECT bssid,ssid,frequency,capabilities,lasttime,lastlat,lastlon,bestlevel,type,rcois,mfgrid,service FROM network WHERE "+filter.getFilter(), args );
+        return trackedQuery( "SELECT bssid,ssid,frequency,capabilities,lasttime,lastlat,lastlon,bestlevel,type,rcois,mfgrid,service FROM network WHERE "+filter.getFilter(), args );
     }
 
     public Cursor routeIterator(final long routeId) throws DBException {
         checkDB();
         Logging.info( "routeIterator" );
         final String[] args = new String[]{String.valueOf(routeId)};
-        return db.rawQuery( "SELECT lat,lon,altitude,time FROM route WHERE run_id = ?", args );
+        return trackedQuery( "SELECT lat,lon,altitude,time FROM route WHERE run_id = ?", args );
     }
 
     public Cursor routeMetaIterator() throws DBException {
@@ -1819,14 +1877,14 @@ public final class DatabaseHelper extends Thread {
         Logging.info( "routeMetaIterator" );
         final String[] args = new String[]{};
         //ALIBI: we'd love to parameterize min observations here, but SQLite rawQuery doesn't seem to respect ? parameterization in HAVING statements.
-        return db.rawQuery( "SELECT _id, run_id, MIN(time) AS starttime, MAX(time) AS endtime, count(_id) AS obs FROM route GROUP BY run_id HAVING obs >= 20 ORDER BY time DESC", args);
+        return trackedQuery( "SELECT _id, run_id, MIN(time) AS starttime, MAX(time) AS endtime, count(_id) AS obs FROM route GROUP BY run_id HAVING obs >= 20 ORDER BY time DESC", args);
     }
 
     public Cursor currentRouteIterator() throws DBException {
         checkDB();
         Logging.info( "routeIterator" );
         final String[] args = new String[]{};
-        return db.rawQuery( "SELECT lat,lon,altitude,time FROM route WHERE run_id = (SELECT MAX(run_id) FROM route)", args );
+        return trackedQuery( "SELECT lat,lon,altitude,time FROM route WHERE run_id = (SELECT MAX(run_id) FROM route)", args );
     }
 
     public void clearDefaultRoute() throws DBException {
@@ -1862,13 +1920,13 @@ public final class DatabaseHelper extends Thread {
             boolean logRoutes = prefs.getBoolean(PreferenceKeys.PREF_LOG_ROUTES, false);
             final long visibleRouteId = logRoutes ? prefs.getLong(PreferenceKeys.PREF_ROUTE_DB_RUN, 0L) : 0L;
             final String[] args = new String[]{String.valueOf(visibleRouteId)};
-            return db.rawQuery("SELECT lat,lon FROM route WHERE run_id = ?", args);
+            return trackedQuery("SELECT lat,lon FROM route WHERE run_id = ?", args);
     }
 
     public Cursor getSingleNetwork( final String bssid, final NetworkFilter filter ) throws DBException {
         checkDB();
         final String[] args = new String[]{bssid};
-        return db.rawQuery(
+        return trackedQuery(
                 "SELECT bssid,ssid,frequency,capabilities,lasttime,lastlat,lastlon,bestlevel,type,rcois,mfgrid,service FROM network WHERE bssid = ? AND "+ filter.getFilter(), args );
     }
 

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
@@ -24,10 +24,11 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 import net.wigle.wigleandroid.ErrorReportActivity;
 import net.wigle.wigleandroid.MainActivity;
@@ -147,6 +148,13 @@ public final class DatabaseHelper extends Thread {
     private static final String LOCATION_BSSID_ID_INDEX_CREATE =
             "CREATE INDEX IF NOT EXISTS idx_location_bssid__id ON " + LOCATION_TABLE + "(bssid, _id)";
 
+    /**
+     * {@code DELETE FROM route WHERE run_id = ?} is otherwise a full table scan, and run 0 is
+     * the visualization slot that can accumulate a long trail.
+     */
+    private static final String ROUTE_RUN_ID_INDEX_CREATE =
+            "CREATE INDEX IF NOT EXISTS idx_route_run_id ON " + ROUTE_TABLE + "(run_id)";
+
     private static final String LOCATED_NETS_QUERY_STEM = " FROM " + DatabaseHelper.NETWORK_TABLE
         + " WHERE bestlat != 0.0 AND bestlon != 0.0 AND instr(bssid, '_') <= 0";
 
@@ -242,6 +250,15 @@ public final class DatabaseHelper extends Thread {
 
     /** class for queueing updates to the database */
     final static class DBUpdate {
+        enum Op {
+            OBSERVATION,
+            ROUTE_POINT,
+            CLEAR_DEFAULT_ROUTE,
+            DELETE_ROUTE,
+            CLEAR_DATABASE
+        }
+
+        public final Op op;
         public final Network network;
         public final int level;
         public final Location location;
@@ -249,12 +266,20 @@ public final class DatabaseHelper extends Thread {
         public final boolean frequencyChanged;
         public final boolean typeMorphed;
         public final int external;
+        public final int wifiVisible;
+        public final int cellVisible;
+        public final int btVisible;
+        public final long runId;
+        public final CountDownLatch completion;
+        public final AtomicInteger result;
+        public final AtomicReference<Exception> error;
 
         public DBUpdate( final Network network, final int level, final Location location, final boolean newForRun, final boolean frequencyChanged, final boolean typeMorphed ) {
-            this(network, level, location, newForRun, false, false, 0);
+            this(network, level, location, newForRun, frequencyChanged, typeMorphed, 0);
         }
 
         public DBUpdate( final Network network, final int level, final Location location, final boolean newForRun, final boolean frequencyChanged, final boolean typeMorphed, final int external ) {
+            this.op = Op.OBSERVATION;
             this.network = network;
             this.level = level;
             this.location = location;
@@ -262,6 +287,58 @@ public final class DatabaseHelper extends Thread {
             this.frequencyChanged = frequencyChanged;
             this.typeMorphed = typeMorphed;
             this.external = external;
+            this.wifiVisible = 0;
+            this.cellVisible = 0;
+            this.btVisible = 0;
+            this.runId = 0L;
+            this.completion = null;
+            this.result = null;
+            this.error = null;
+        }
+
+        private DBUpdate(final Op op, final Location location, final int wifiVisible,
+                         final int cellVisible, final int btVisible, final long runId,
+                         final CountDownLatch completion, final AtomicInteger result,
+                         final AtomicReference<Exception> error) {
+            this.op = op;
+            this.network = null;
+            this.level = 0;
+            this.location = location;
+            this.newForRun = true;
+            this.frequencyChanged = false;
+            this.typeMorphed = false;
+            this.external = 0;
+            this.wifiVisible = wifiVisible;
+            this.cellVisible = cellVisible;
+            this.btVisible = btVisible;
+            this.runId = runId;
+            this.completion = completion;
+            this.result = result;
+            this.error = error;
+        }
+
+        static DBUpdate routePoint(final Location location, final int wifiVisible,
+                                   final int cellVisible, final int btVisible, final long runId) {
+            return new DBUpdate(Op.ROUTE_POINT, location, wifiVisible, cellVisible, btVisible,
+                    runId, null, null, null);
+        }
+
+        static DBUpdate clearDefaultRoute() {
+            return new DBUpdate(Op.CLEAR_DEFAULT_ROUTE, null, 0, 0, 0, 0L, null, null, null);
+        }
+
+        static DBUpdate deleteRoute(final long runId, final CountDownLatch completion,
+                                    final AtomicReference<Exception> error) {
+            return new DBUpdate(Op.DELETE_ROUTE, null, 0, 0, 0, runId, completion, null, error);
+        }
+
+        static DBUpdate clearDatabase(final CountDownLatch completion, final AtomicInteger result,
+                                      final AtomicReference<Exception> error) {
+            return new DBUpdate(Op.CLEAR_DATABASE, null, 0, 0, 0, 0L, completion, result, error);
+        }
+
+        boolean isObservation() {
+            return op == Op.OBSERVATION;
         }
     }
 
@@ -379,13 +456,7 @@ public final class DatabaseHelper extends Thread {
                         // doubt this will help the exclusive lock problems, but trying anyway
                         synchronized(TRANS_LOCK) {
                             try {
-                                // do a transaction for everything
-                                db.beginTransaction();
-                                for ( int i = 0; i < drainSize; i++ ) {
-                                    addObservation( drain.get( i ), drainSize );
-                                }
-                                db.setTransactionSuccessful();
-                                db.endTransaction();
+                                applyDrain(drain);
                                 countdown = 0;
                             }
                             catch ( SQLiteConstraintException ex ) {
@@ -396,6 +467,7 @@ public final class DatabaseHelper extends Thread {
                                 Logging.warn("DB run loop ex, countdown: " + countdown + " ex: " + ex );
                                 countdown--;
                                 if ( countdown <= 0 ) {
+                                    failWaiters(drain, ex);
                                     // give up
                                     throw ex;
                                 }
@@ -440,6 +512,7 @@ public final class DatabaseHelper extends Thread {
         }
 
         Logging.info("db worker thread shutting down");
+        failQueuedWaiters(new DBException("db worker shutting down", null));
     }
 
     public void deathDialog( String message, Exception ex ) {
@@ -619,7 +692,12 @@ public final class DatabaseHelper extends Thread {
         // drop index, was never publicly released
         db.execSQL("DROP INDEX IF EXISTS type");
 
-        // compile statements
+        createRouteRunIdIndex();
+        compileStatements();
+    }
+
+    private void compileStatements() {
+        closeCompiledStatements();
         insertNetwork = db.compileStatement( "INSERT INTO "+NETWORK_TABLE
                 + " (bssid,ssid,frequency,capabilities,lasttime,lastlat,lastlon,type,bestlevel,bestlat,bestlon,rcois,mfgrid,service) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)" );
 
@@ -639,12 +717,41 @@ public final class DatabaseHelper extends Thread {
                 + " (run_id,wifi_visible,cell_visible,bt_visible,lat,lon,altitude,accuracy,time) VALUES (?,?,?,?,?,?,?,?,?)" );
     }
 
+    private void closeCompiledStatements() {
+        insertNetwork = closeQuietly(insertNetwork);
+        insertLocationExternal = closeQuietly(insertLocationExternal);
+        updateNetwork = closeQuietly(updateNetwork);
+        updateNetworkMetadata = closeQuietly(updateNetworkMetadata);
+        insertRoute = closeQuietly(insertRoute);
+        updateNetworkType = closeQuietly(updateNetworkType);
+    }
+
+    private static SQLiteStatement closeQuietly(final SQLiteStatement statement) {
+        if (statement != null) {
+            try {
+                statement.close();
+            } catch (final Exception ex) {
+                Logging.info("statement close: " + ex);
+            }
+        }
+        return null;
+    }
+
     private void createFreshLocationObservationIndex() {
         try {
             db.execSQL( LOCATION_BSSID_ID_INDEX_CREATE );
         }
         catch ( final SQLiteException ex ) {
             Logging.warn( "fresh location observation index: " + ex );
+        }
+    }
+
+    private void createRouteRunIdIndex() {
+        try {
+            db.execSQL( ROUTE_RUN_ID_INDEX_CREATE );
+        }
+        catch ( final SQLiteException ex ) {
+            Logging.warn( "route run_id index: " + ex );
         }
     }
 
@@ -669,24 +776,7 @@ public final class DatabaseHelper extends Thread {
         while ( db != null && db.isOpen() && countdown > 0 ) {
             try {
                 synchronized ( this ) {
-                    if ( insertNetwork != null ) {
-                        insertNetwork.close();
-                    }
-                    if ( insertLocationExternal != null) {
-                        insertLocationExternal.close();
-                    }
-                    if ( updateNetwork != null ) {
-                        updateNetwork.close();
-                    }
-                    if ( updateNetworkMetadata != null ) {
-                        updateNetworkMetadata.close();
-                    }
-                    if ( insertRoute != null ) {
-                        insertRoute.close();
-                    }
-                    if ( updateNetworkType != null ) {
-                        updateNetworkType.close();
-                    }
+                    closeCompiledStatements();
                     if ( db.isOpen() ) {
                         db.close();
                     }
@@ -755,9 +845,10 @@ public final class DatabaseHelper extends Thread {
                 for ( Iterator<DBUpdate> it = queue.iterator(); it.hasNext(); ) {
                     final DBUpdate val = it.next();
 
-                    if ( ! val.newForRun && !val.typeMorphed && !val.frequencyChanged) {
-                        it.remove();
+                    if ( ! val.isObservation() || val.newForRun || val.typeMorphed || val.frequencyChanged) {
+                        continue;
                     }
+                    it.remove();
                 }
                 Logging.info("culled queue. size now: " + queue.size() );
                 added = queue.offer( update );
@@ -769,6 +860,221 @@ public final class DatabaseHelper extends Thread {
 
         }
         return added;
+    }
+
+    /**
+     * Run a drain batch as one transaction, then any CLEAR_DATABASE after that commit so DROP TABLE
+     * does not invalidate compiled statements mid-batch. Observation waiters are released as soon as
+     * their transaction commits so a later clear failure cannot cause a retry that would insert twice.
+     */
+    private void applyDrain(final List<DBUpdate> drain) throws DBException {
+        boolean clearDatabase = false;
+        db.beginTransaction();
+        try {
+            final int drainSize = drain.size();
+            for (int i = 0; i < drainSize; i++) {
+                final DBUpdate update = drain.get(i);
+                if (update.op == DBUpdate.Op.CLEAR_DATABASE) {
+                    clearDatabase = true;
+                    continue;
+                }
+                applyUpdate(update, drainSize);
+            }
+            db.setTransactionSuccessful();
+        } finally {
+            if (db.inTransaction()) {
+                db.endTransaction();
+            }
+        }
+        for (final DBUpdate update : drain) {
+            if (update.op != DBUpdate.Op.CLEAR_DATABASE) {
+                completeWaiter(update, 1, null);
+            }
+        }
+        if (clearDatabase) {
+            try {
+                final int cleared = applyClearDatabase();
+                for (final DBUpdate update : drain) {
+                    if (update.op == DBUpdate.Op.CLEAR_DATABASE) {
+                        completeWaiter(update, cleared, null);
+                    }
+                }
+            } catch (final Exception ex) {
+                for (final DBUpdate update : drain) {
+                    if (update.op == DBUpdate.Op.CLEAR_DATABASE) {
+                        completeWaiter(update, 0, ex);
+                    }
+                }
+                Logging.error("clear database after queued writes failed: " + ex, ex);
+            }
+        }
+    }
+
+    private void applyUpdate(final DBUpdate update, final int drainSize) throws DBException {
+        switch (update.op) {
+            case OBSERVATION:
+                addObservation(update, drainSize);
+                break;
+            case ROUTE_POINT:
+                applyRoutePoint(update);
+                break;
+            case CLEAR_DEFAULT_ROUTE:
+                applyClearDefaultRoute();
+                break;
+            case DELETE_ROUTE:
+                applyDeleteRoute(update.runId);
+                break;
+            case CLEAR_DATABASE:
+                // deferred until after the observation transaction commits
+                break;
+        }
+    }
+
+    private void applyRoutePoint(final DBUpdate update) {
+        if (done.get() || insertRoute == null || update.location == null) {
+            return;
+        }
+        final Location location = update.location;
+        if (location.getTime() == 0L) {
+            return;
+        }
+        final double accuracy = location.getAccuracy();
+        if (accuracy >= MIN_ROUTE_LOCATION_PRECISION_METERS || accuracy <= 0.0d) {
+            return;
+        }
+        if (lastLoggedLocation != null
+                && !(lastLoggedLocation.distanceTo(location) > MIN_ROUTE_LOCATION_DIFF_METERS
+                && (location.getTime() - lastLoggedLocation.getTime() > MIN_ROUTE_LOCATION_DIFF_TIME))) {
+            return;
+        }
+        insertRoute.bindLong(1, update.runId);
+        insertRoute.bindLong(2, update.wifiVisible);
+        insertRoute.bindLong(3, update.cellVisible);
+        insertRoute.bindLong(4, update.btVisible);
+        insertRoute.bindDouble(5, location.getLatitude());
+        insertRoute.bindDouble(6, location.getLongitude());
+        insertRoute.bindDouble(7, location.getAltitude());
+        insertRoute.bindDouble(8, location.getAccuracy());
+        insertRoute.bindLong(9, location.getTime());
+        final long start = System.currentTimeMillis();
+        try {
+            insertRoute.execute();
+            lastLoggedLocation = location;
+            currentRoutePointCount.incrementAndGet();
+            logTime(start, "db route point added");
+        } catch (IllegalStateException | SQLException ex) {
+            logTime(start, "db route point add failed: " + ex);
+        }
+    }
+
+    private void applyClearDefaultRoute() throws DBException {
+        checkDB();
+        if (null != db) {
+            db.execSQL(CLEAR_DEFAULT_ROUTE);
+        }
+    }
+
+    private void applyDeleteRoute(final long runId) throws DBException {
+        checkDB();
+        if (null != db) {
+            db.execSQL(DELETE_ROUTE_BY_ID, new Object[]{runId});
+            Logging.info("Deleted route run_id=" + runId);
+        }
+    }
+
+    private void completeWaiter(final DBUpdate update, final int result, final Exception error) {
+        if (update.completion == null) {
+            return;
+        }
+        if (error != null && update.error != null) {
+            update.error.set(error);
+        }
+        if (update.result != null) {
+            update.result.set(result);
+        }
+        update.completion.countDown();
+    }
+
+    private void failWaiters(final List<DBUpdate> drain, final Exception error) {
+        for (final DBUpdate update : drain) {
+            completeWaiter(update, 0, error);
+        }
+    }
+
+    private void failQueuedWaiters(final Exception error) {
+        DBUpdate update;
+        while ((update = queue.poll()) != null) {
+            completeWaiter(update, 0, error);
+        }
+    }
+
+    private void enqueue(final DBUpdate update) {
+        if (done.get()) {
+            Logging.warn("db closed, dropping " + update.op);
+            completeWaiter(update, 0, new DBException("db closed", null));
+            return;
+        }
+        if (!queue.offer(update)) {
+            Logging.warn("db queue full, dropping " + update.op);
+            completeWaiter(update, 0, new DBException("db queue full", null));
+        }
+    }
+
+    private void enqueueAndWait(final DBUpdate update) throws DBException {
+        if (done.get()) {
+            throw new DBException("db closed", null);
+        }
+        if (!isAlive() || Thread.currentThread() == this) {
+            applyNow(update);
+            final Exception error = update.error != null ? update.error.get() : null;
+            if (error instanceof DBException) {
+                throw (DBException) error;
+            }
+            if (error != null) {
+                throw new DBException("db write failed", error);
+            }
+            return;
+        }
+        try {
+            queue.put(update);
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new DBException("interrupted waiting to enqueue db write", ex);
+        }
+        try {
+            update.completion.await();
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new DBException("interrupted waiting for db write", ex);
+        }
+        final Exception error = update.error != null ? update.error.get() : null;
+        if (error instanceof DBException) {
+            throw (DBException) error;
+        }
+        if (error != null) {
+            throw new DBException("db write failed", error);
+        }
+    }
+
+    private void applyNow(final DBUpdate update) throws DBException {
+        synchronized (TRANS_LOCK) {
+            checkDB();
+            if (update.op == DBUpdate.Op.CLEAR_DATABASE) {
+                final int cleared = applyClearDatabase();
+                completeWaiter(update, cleared, null);
+                return;
+            }
+            db.beginTransaction();
+            try {
+                applyUpdate(update, 1);
+                db.setTransactionSuccessful();
+            } finally {
+                if (db.inTransaction()) {
+                    db.endTransaction();
+                }
+            }
+            completeWaiter(update, 1, null);
+        }
     }
 
     @SuppressWarnings("deprecation")
@@ -1205,53 +1511,25 @@ public final class DatabaseHelper extends Thread {
     }
 
     /**
-     * insert a new point for the specified route
-     * @param location location of current measurement
-     * @param wifiVisible # wifi nets visible
-     * @param cellVisible # cells visible
-     * @param btVisible # bt devices visible
-     * @param runId # the current, monotonic run ID
+     * Queue a new point for the specified route. The insert runs on the db worker so it
+     * shares the connection and transaction with observation writes.
      */
     public void logRouteLocation (final Location location, final int wifiVisible, final int cellVisible, final int btVisible, final long runId) {
         if (location == null) {
             Logging.error("Null location in logRouteLocation");
             return;
         }
-        ExecutorService executor = Executors.newSingleThreadExecutor();
-        executor.execute(() -> {
-            if (!done.get()) {
-                final double accuracy = location.getAccuracy();
-                if (insertRoute != null && location.getTime() != 0L &&
-                        accuracy < MIN_ROUTE_LOCATION_PRECISION_METERS &&
-                        accuracy > 0.0d && //ALIBI: should never happen?
-                        (lastLoggedLocation == null ||
-                                ((lastLoggedLocation.distanceTo(location) > MIN_ROUTE_LOCATION_DIFF_METERS &&
-                                        (location.getTime() - lastLoggedLocation.getTime() > MIN_ROUTE_LOCATION_DIFF_TIME)
-                                )) )) {
-                    insertRoute.bindLong(1, runId);
-                    insertRoute.bindLong(2, wifiVisible);
-                    insertRoute.bindLong(3, cellVisible);
-                    insertRoute.bindLong(4, btVisible);
-                    insertRoute.bindDouble(5, location.getLatitude());
-                    insertRoute.bindDouble(6, location.getLongitude());
-                    insertRoute.bindDouble(7, location.getAltitude());
-                    insertRoute.bindDouble(8, location.getAccuracy());
-                    insertRoute.bindLong(9, location.getTime());
-                    long start = System.currentTimeMillis();
-
-                    try {
-                        insertRoute.execute();
-                        lastLoggedLocation = location;
-                        currentRoutePointCount.incrementAndGet();
-                        logTime(start, "db route point added");
-                    } catch (IllegalStateException | SQLException ex) {
-                        logTime(start, "db route point add failed: " + ex);
-                    }
-                }
-            } else {
-                Logging.error("unable to log route point due to closing DB");
-            }
-        });
+        if (done.get()) {
+            Logging.error("unable to log route point due to closing DB");
+            return;
+        }
+        final double accuracy = location.getAccuracy();
+        if (location.getTime() == 0L
+                || accuracy >= MIN_ROUTE_LOCATION_PRECISION_METERS
+                || accuracy <= 0.0d) {
+            return;
+        }
+        enqueue(DBUpdate.routePoint(location, wifiVisible, cellVisible, btVisible, runId));
     }
 
     public boolean isFastMode() {
@@ -1478,23 +1756,27 @@ public final class DatabaseHelper extends Thread {
     }
 
     public void clearDefaultRoute() throws DBException {
-        checkDB();
-        if (null != db) {
-            db.execSQL(CLEAR_DEFAULT_ROUTE);
+        if (done.get()) {
+            throw new DBException("db closed", null);
+        }
+        try {
+            queue.put(DBUpdate.clearDefaultRoute());
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new DBException("interrupted waiting to enqueue default-route clear", ex);
         }
     }
 
     /**
-     * Delete a route and all its points by run_id.
+     * Delete a route and all its points by run_id. Blocks until the worker has applied the delete
+     * so callers can refresh UI against the new contents.
      * @param runId the run_id of the route to delete
      * @throws DBException if the database is unavailable
      */
     public void deleteRoute(long runId) throws DBException {
-        checkDB();
-        if (null != db) {
-            db.execSQL(DELETE_ROUTE_BY_ID, new Object[]{runId});
-            Logging.info("Deleted route run_id=" + runId);
-        }
+        final CountDownLatch completion = new CountDownLatch(1);
+        final AtomicReference<Exception> error = new AtomicReference<>();
+        enqueueAndWait(DBUpdate.deleteRoute(runId, completion, error));
     }
 
     public Cursor getCurrentVisibleRouteIterator(SharedPreferences prefs) throws DBException{
@@ -1550,7 +1832,23 @@ public final class DatabaseHelper extends Thread {
     }
 
     public int clearDatabase() {
+        final CountDownLatch completion = new CountDownLatch(1);
+        final AtomicInteger result = new AtomicInteger(0);
+        final AtomicReference<Exception> error = new AtomicReference<>();
         try {
+            enqueueAndWait(DBUpdate.clearDatabase(completion, result, error));
+        } catch (final DBException ex) {
+            Logging.error("queued clear database failed: " + ex, ex);
+            return 0;
+        }
+        return result.get();
+    }
+
+    private int applyClearDatabase() {
+        boolean ok = false;
+        try {
+            checkDB();
+            closeCompiledStatements();
             db.beginTransaction();
             Logging.info( "deleting location table" );
             db.execSQL(LOCATION_DELETE);
@@ -1575,17 +1873,28 @@ public final class DatabaseHelper extends Thread {
             db.execSQL(LOCATION_CREATE);
             createFreshLocationObservationIndex();
             db.execSQL(ROUTE_CREATE);
+            createRouteRunIdIndex();
             db.setTransactionSuccessful();
             networkCount.set( 0 );
             locationCount.set( 0 );
             currentRoutePointCount.set( 0 );
+            lastLoggedLocation = null;
+            previousWrittenLocationsCache.clear();
+            ok = true;
             //TODO: update list header count
-        } catch ( final SQLiteException ex ) {
+        } catch ( final SQLiteException | DBException ex ) {
             Logging.error( "sqlite exception: " + ex, ex );
-            return 0;
         } finally {
-            db.endTransaction();
+            if ( db != null && db.inTransaction() ) {
+                db.endTransaction();
+            }
         }
-        return 1;
+        try {
+            compileStatements();
+        } catch (final Exception compileEx) {
+            Logging.error("unable to recompile statements after clear: " + compileEx, compileEx);
+            return 0;
+        }
+        return ok ? 1 : 0;
     }
 }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
@@ -192,6 +192,9 @@ public final class DatabaseHelper extends Thread {
     private final ArrayBlockingQueue<DBUpdate> queue = new ArrayBlockingQueue<>(MAX_QUEUE);
     private final ArrayBlockingQueue<DBPending> pending = new ArrayBlockingQueue<>(MAX_QUEUE); // how to size this better?
     private final AtomicBoolean done = new AtomicBoolean(false);
+    /** Held for the whole close sequence so a second caller waits until the file is actually released. */
+    private final Object closeLock = new Object();
+    private boolean fullyClosed = false;
     private final AtomicLong networkCount = new AtomicLong();
     private final AtomicLong currentRoutePointCount = new AtomicLong();
     private final AtomicLong locationCount = new AtomicLong();
@@ -558,6 +561,17 @@ public final class DatabaseHelper extends Thread {
             db = context.openOrCreateDatabase( dbFilename, Context.MODE_PRIVATE, null );
         }
 
+        // Android's API also grows the connection pool so readers can proceed during a write.
+        // Returns false on filesystems that cannot host the WAL (old FAT/SD); we then keep
+        // the platform rollback journal rather than forcing PERSIST.
+        if (db.enableWriteAheadLogging()) {
+            Logging.info("WAL enabled");
+            // WAL already fsyncs the log; FULL would fsync the main file on every drain too
+            db.execSQL("PRAGMA synchronous = NORMAL");
+        } else {
+            Logging.warn("WAL not available; using rollback journal");
+        }
+
         if ( ! tableExists( db, NETWORK_TABLE ) ) {
             Logging.info( "network table missing, will create" );
             doCreateNetwork = true;
@@ -631,8 +645,6 @@ public final class DatabaseHelper extends Thread {
         db.execSQL( "PRAGMA count_changes = false" );
         // keep transactions in memory until committed
         db.execSQL( "PRAGMA temp_store = MEMORY" );
-        // keep around the journal file, don't create and delete a ton of times
-        db.rawQuery( "PRAGMA journal_mode = PERSIST", null).close();
 
         Logging.info( "database version: " + db.getVersion() );
         if ( db.getVersion() == 0 ) {
@@ -756,41 +768,100 @@ public final class DatabaseHelper extends Thread {
     }
 
     /**
-     * close db, shut down thread
+     * Fold WAL frames into the main file. The cursor must be stepped or SQLite never
+     * runs the pragma. TRUNCATE also resets the WAL so a copy of the main file is complete;
+     * FULL is the fallback if a reader is still holding a snapshot.
+     */
+    private void checkpointWal() {
+        if (db == null || !db.isOpen() || !db.isWriteAheadLoggingEnabled()) {
+            return;
+        }
+        if (!runWalCheckpoint("TRUNCATE")) {
+            runWalCheckpoint("FULL");
+        }
+    }
+
+    private boolean runWalCheckpoint(final String mode) {
+        try (Cursor cursor = db.rawQuery("PRAGMA wal_checkpoint(" + mode + ")", null)) {
+            if (!cursor.moveToFirst()) {
+                Logging.warn("WAL checkpoint " + mode + " returned no row");
+                return false;
+            }
+            final int busy = cursor.getInt(0);
+            Logging.info("WAL checkpoint " + mode
+                    + " busy=" + busy
+                    + " log=" + cursor.getInt(1)
+                    + " checkpointed=" + cursor.getInt(2));
+            return busy == 0;
+        } catch (final SQLiteException ex) {
+            Logging.warn("WAL checkpoint " + mode + " failed: " + ex);
+            return false;
+        }
+    }
+
+    /**
+     * Stop the worker, wait until it has exited, then close the SQLite connection and drop the
+     * reference. Returns only once the file is released (or this is the worker thread itself).
+     * A second call waits for the first to finish, then returns; {@link #checkDB()} will not
+     * reopen afterwards.
      */
     public void close() {
-        done.set( true );
-
-        // interrupt the take, if any
-        this.interrupt();
-        // give time for db to finish any writes
-        int countdown = 30;
-        while ( this.isAlive() && countdown > 0 ) {
-            Logging.info( "db still alive. countdown: " + countdown );
-            MainActivity.sleep( 100L );
-            countdown--;
-            this.interrupt();
-        }
-
-        countdown = 50;
-        while ( db != null && db.isOpen() && countdown > 0 ) {
-            try {
-                synchronized ( this ) {
-                    closeCompiledStatements();
-                    if ( db.isOpen() ) {
-                        db.close();
+        synchronized (closeLock) {
+            if (fullyClosed) {
+                return;
+            }
+            done.set(true);
+            interrupt();
+            if (Thread.currentThread() != this) {
+                waitForWorkerExit();
+            }
+            synchronized (this) {
+                checkpointWal();
+                closeCompiledStatements();
+                if (db != null) {
+                    try {
+                        if (db.isOpen()) {
+                            db.close();
+                        }
+                    } catch (final SQLiteException ex) {
+                        Logging.error("db close after worker exit: " + ex, ex);
                     }
+                    db = null;
                 }
             }
-            catch ( SQLiteException ex ) {
-                Logging.info( "db close exception, will try again. countdown: " + countdown + " ex: " + ex, ex );
-                MainActivity.sleep( 100L );
+            failQueuedWaiters(new DBException("db closed", null));
+            fullyClosed = true;
+        }
+    }
+
+    /**
+     * Interrupt {@code take()} until the worker leaves {@link #run()}. Does not hold
+     * {@code this}, so the worker can still finish a {@link #checkDB()} that needs that lock.
+     */
+    private void waitForWorkerExit() {
+        boolean closerInterrupted = false;
+        long waitedMs = 0L;
+        while (isAlive()) {
+            interrupt();
+            try {
+                join(250L);
+            } catch (final InterruptedException ex) {
+                closerInterrupted = true;
             }
-            countdown--;
+            waitedMs += 250L;
+            if (isAlive() && waitedMs % 5000L == 0L) {
+                Logging.warn("waiting for db worker to exit, waited " + waitedMs + " ms");
+            }
+        }
+        if (closerInterrupted) {
+            Thread.currentThread().interrupt();
         }
     }
 
     public synchronized void checkDB() throws DBException {
+        if (done.get()) {
+            throw new DBException("db closed", null);
+        }
         if ( db == null || ! db.isOpen() ) {
             Logging.info( "re-opening db in checkDB" );
             try {
@@ -805,6 +876,9 @@ public final class DatabaseHelper extends Thread {
     public void blockingAddExternalObservation(final Network network, final Location location, final boolean newForRun )
             throws InterruptedException {
 
+        if (done.get()) {
+            throw new InterruptedException("db closed");
+        }
         final DBUpdate update = new DBUpdate( network, network.getLevel(), location, newForRun, false, false, 1 );
         queue.put(update);
     }
@@ -1805,6 +1879,17 @@ public final class DatabaseHelper extends Thread {
 
         if (hasSD()) {
             file = new File(EXTERNAL_DATABASE_PATH, DATABASE_NAME);
+        }
+        // fold committed WAL frames into the main file before we copy only that file
+        synchronized (TRANS_LOCK) {
+            try {
+                if (!done.get()) {
+                    checkDB();
+                    checkpointWal();
+                }
+            } catch (final DBException ex) {
+                Logging.warn("WAL checkpoint before backup skipped: " + ex);
+            }
         }
         Pair<Boolean,String> result;
         try (InputStream input = new FileInputStream(file)){

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/db/DatabaseHelper.java
@@ -52,6 +52,7 @@ import android.database.DatabaseUtils;
 import android.database.SQLException;
 import android.database.sqlite.SQLiteConstraintException;
 import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteDatabaseLockedException;
 import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteStatement;
 import android.location.Location;
@@ -74,6 +75,10 @@ public final class DatabaseHelper extends Thread {
     private static final String DATABASE_NAME = "wiglewifi"+SQL_EXT;
     private static final String EXTERNAL_DATABASE_PATH = FileUtility.getSDPath();
     private static final int DB_PRIORITY = Process.THREAD_PRIORITY_BACKGROUND;
+    /** Native SQLITE_BUSY wait per statement (checkpoint, leaked connection, API≤29 SD). */
+    private static final int BUSY_TIMEOUT_MS = 5000;
+    /** Extra worker attempts after busy_timeout expires. */
+    private static final int BUSY_RETRIES = 3;
     private static final Object TRANS_LOCK = new Object();
 
     private static final long QUEUE_CULL_TIMEOUT = 10000L;
@@ -197,6 +202,12 @@ public final class DatabaseHelper extends Thread {
     /** Held for the whole close sequence so a second caller waits until the file is actually released. */
     private final Object closeLock = new Object();
     private boolean fullyClosed = false;
+    /**
+     * Process-wide owner of the on-disk file. WAL cannot have two writers; acquire() waits for
+     * the previous helper to finish closing before opening another.
+     */
+    private static final Object OWNER_LOCK = new Object();
+    private static DatabaseHelper owner;
     private final AtomicLong networkCount = new AtomicLong();
     private final AtomicLong currentRoutePointCount = new AtomicLong();
     private final AtomicLong locationCount = new AtomicLong();
@@ -366,7 +377,34 @@ public final class DatabaseHelper extends Thread {
         }
     }
 
-    public DatabaseHelper( final Context context, final SharedPreferences prefs ) {
+    /**
+     * Return a new live helper after the previous one (if any) has fully released the file.
+     * Never reuses a still-running helper: a finishing activity would close it under a new
+     * activity that had borrowed it.
+     * <p>
+     * Lock order: {@link #OWNER_LOCK} then {@code closeLock}. Never reverse.
+     */
+    public static DatabaseHelper acquire(final Context context, final SharedPreferences prefs) {
+        synchronized (OWNER_LOCK) {
+            if (owner != null) {
+                Logging.info("closing previous DatabaseHelper before opening another");
+                owner.closeExclusive();
+                owner = null;
+            }
+            final DatabaseHelper helper = new DatabaseHelper(context, prefs);
+            helper.start();
+            owner = helper;
+            return helper;
+        }
+    }
+
+    public boolean isFullyClosed() {
+        synchronized (closeLock) {
+            return fullyClosed;
+        }
+    }
+
+    private DatabaseHelper( final Context context, final SharedPreferences prefs ) {
         this.context = context.getApplicationContext();
         this.prefs = prefs;
         setName("dbworker-" + getName());
@@ -495,27 +533,36 @@ public final class DatabaseHelper extends Thread {
                     final int drainSize = drain.size();
 
                     int countdown = 10;
+                    int busyCountdown = BUSY_RETRIES;
                     while ( countdown > 0 && ! done.get() ) {
-                        // doubt this will help the exclusive lock problems, but trying anyway
-                        synchronized(TRANS_LOCK) {
-                            try {
+                        try {
+                            synchronized(TRANS_LOCK) {
                                 applyDrain(drain);
-                                countdown = 0;
                             }
-                            catch ( SQLiteConstraintException ex ) {
-                                Logging.warn("DB run loop constraint ex, countdown: " + countdown + " ex: " + ex );
-                                countdown--;
+                            countdown = 0;
+                        }
+                        catch ( SQLiteConstraintException ex ) {
+                            Logging.warn("DB run loop constraint ex, countdown: " + countdown + " ex: " + ex );
+                            countdown--;
+                        }
+                        catch ( SQLiteDatabaseLockedException ex ) {
+                            Logging.warn("DB run loop locked, retries left: " + busyCountdown + " ex: " + ex );
+                            busyCountdown--;
+                            if ( busyCountdown <= 0 ) {
+                                failWaiters(drain, ex);
+                                throw ex;
                             }
-                            catch ( Exception ex ) {
-                                Logging.warn("DB run loop ex, countdown: " + countdown + " ex: " + ex );
-                                countdown--;
-                                if ( countdown <= 0 ) {
-                                    failWaiters(drain, ex);
-                                    // give up
-                                    throw ex;
-                                }
-                                MainActivity.sleep(100L);
+                            MainActivity.sleep(100L);
+                        }
+                        catch ( Exception ex ) {
+                            Logging.warn("DB run loop ex, countdown: " + countdown + " ex: " + ex );
+                            countdown--;
+                            if ( countdown <= 0 ) {
+                                failWaiters(drain, ex);
+                                // give up
+                                throw ex;
                             }
+                            MainActivity.sleep(100L);
                         }
                     }
 
@@ -611,6 +658,7 @@ public final class DatabaseHelper extends Thread {
         } else {
             Logging.warn("WAL not available; using rollback journal");
         }
+        db.execSQL("PRAGMA busy_timeout = " + BUSY_TIMEOUT_MS);
 
         if ( ! tableExists( db, NETWORK_TABLE ) ) {
             Logging.info( "network table missing, will create" );
@@ -863,6 +911,15 @@ public final class DatabaseHelper extends Thread {
      * reopen afterwards.
      */
     public void close() {
+        synchronized (OWNER_LOCK) {
+            closeExclusive();
+            if (owner == this) {
+                owner = null;
+            }
+        }
+    }
+
+    private void closeExclusive() {
         synchronized (closeLock) {
             if (fullyClosed) {
                 return;
@@ -1189,24 +1246,36 @@ public final class DatabaseHelper extends Thread {
     }
 
     private void applyNow(final DBUpdate update) throws DBException {
-        synchronized (TRANS_LOCK) {
-            checkDB();
-            if (update.op == DBUpdate.Op.CLEAR_DATABASE) {
-                final int cleared = applyClearDatabase();
-                completeWaiter(update, cleared, null);
-                return;
-            }
-            db.beginTransaction();
+        SQLiteDatabaseLockedException lastLocked = null;
+        for (int attempt = 0; attempt < BUSY_RETRIES; attempt++) {
             try {
-                applyUpdate(update, 1);
-                db.setTransactionSuccessful();
-            } finally {
-                if (db.inTransaction()) {
-                    db.endTransaction();
+                synchronized (TRANS_LOCK) {
+                    checkDB();
+                    if (update.op == DBUpdate.Op.CLEAR_DATABASE) {
+                        final int cleared = applyClearDatabase();
+                        completeWaiter(update, cleared, null);
+                        return;
+                    }
+                    db.beginTransaction();
+                    try {
+                        applyUpdate(update, 1);
+                        db.setTransactionSuccessful();
+                    } finally {
+                        if (db.inTransaction()) {
+                            db.endTransaction();
+                        }
+                    }
+                    completeWaiter(update, 1, null);
+                    return;
                 }
+            } catch (final SQLiteDatabaseLockedException ex) {
+                lastLocked = ex;
+                Logging.warn("applyNow locked, attempt " + (attempt + 1) + "/" + BUSY_RETRIES + " ex: " + ex);
+                MainActivity.sleep(100L);
             }
-            completeWaiter(update, 1, null);
         }
+        completeWaiter(update, 0, lastLocked);
+        throw new DBException("db locked", lastLocked);
     }
 
     @SuppressWarnings("deprecation")

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/CellReceiver.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/listener/CellReceiver.java
@@ -1,6 +1,8 @@
 package net.wigle.wigleandroid.listener;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.location.Location;
 import android.os.Build;
 import android.os.Handler;
@@ -22,6 +24,8 @@ import android.telephony.CellSignalStrengthWcdma;
 import android.telephony.TelephonyManager;
 import android.telephony.cdma.CdmaCellLocation;
 import android.telephony.gsm.GsmCellLocation;
+
+import androidx.annotation.NonNull;
 
 import net.wigle.wigleandroid.FilterMatcher;
 import net.wigle.wigleandroid.ListFragment;
@@ -154,79 +158,124 @@ public class CellReceiver {
             return;
         }
         final GNSSListener gpsListener = mainActivity.getGPSListener();
-        final android.content.SharedPreferences prefs = mainActivity.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
+        final SharedPreferences prefs = mainActivity.getSharedPreferences(PreferenceKeys.SHARED_PREFS, 0);
         Location location = null;
         if (gpsListener != null) {
             location = gpsListener.checkGetLocation(prefs);
         }
         final Location loc = location;
         final Context ctx = mainActivity;
-        //ALIBI: moving into executor due to ANRs caused by the TelephonyManager binder calls in
-        // getRawCellData then posting processCellData back onto main
-        cellExecutor.execute(() -> {
-            final RawCellData raw = getRawCellData(ctx);
-            mainHandler.post(() -> {
-                if (mainActivity == null || mainActivity.isFinishing()) {
-                    return;
-                }
-                Map<String, Network> cellNetworks = processCellData(raw, loc);
-                if (cellNetworks == null) {
-                    cellNetworks = Collections.emptyMap();
-                }
-                final int newCellForRun = cellNetworks.size();
-                if (loc == null && newCellForRun > 0) {
-                    ListFragment.lameStatic.pendingCellCount = Math.min(25,
-                            ListFragment.lameStatic.pendingCellCount + newCellForRun);
-                } else if (loc != null) {
-                    ListFragment.lameStatic.pendingCellCount = 0;
-                }
-                ListFragment.lameStatic.runCells = runCells.size();
-                ListFragment.lameStatic.newCells = dbHelper.getNewCellCount();
-                ListFragment.lameStatic.currCells = cellNetworks.size();
-                ListFragment.lameStatic.currNets = ListFragment.lameStatic.currWifi + ListFragment.lameStatic.currCells;
-                final boolean showCurrent = prefs.getBoolean(PreferenceKeys.PREF_SHOW_CURRENT, true);
-                if (showCurrent && listAdapter != null) {
-                    final java.util.regex.Matcher ssidMatcher = FilterMatcher.getSsidFilterMatcher(prefs, PreferenceKeys.FILTER_PREF_PREFIX);
-                    final java.util.regex.Matcher bssidMatcher = mainActivity.getBssidFilterMatcher(PreferenceKeys.PREF_EXCLUDE_DISPLAY_ADDRS);
-                    for (Network cellNetwork : cellNetworks.values()) {
-                        if (cellNetwork != null && FilterMatcher.isOk(ssidMatcher, bssidMatcher, prefs, PreferenceKeys.FILTER_PREF_PREFIX, cellNetwork)) {
-                            listAdapter.addCell(cellNetwork);
-                        }
+        cellExecutor.execute(() -> collectRawCellData(ctx, raw -> mainHandler.post(() -> {
+            if (mainActivity == null || mainActivity.isFinishing()) {
+                return;
+            }
+            Map<String, Network> cellNetworks = processCellData(raw, loc);
+            if (cellNetworks == null) {
+                cellNetworks = Collections.emptyMap();
+            }
+            final int newCellForRun = cellNetworks.size();
+            if (loc == null && newCellForRun > 0) {
+                ListFragment.lameStatic.pendingCellCount = Math.min(25,
+                        ListFragment.lameStatic.pendingCellCount + newCellForRun);
+            } else if (loc != null) {
+                ListFragment.lameStatic.pendingCellCount = 0;
+            }
+            ListFragment.lameStatic.runCells = runCells.size();
+            ListFragment.lameStatic.newCells = dbHelper.getNewCellCount();
+            ListFragment.lameStatic.currCells = cellNetworks.size();
+            ListFragment.lameStatic.currNets = ListFragment.lameStatic.currWifi + ListFragment.lameStatic.currCells;
+            final boolean showCurrent = prefs.getBoolean(PreferenceKeys.PREF_SHOW_CURRENT, true);
+            if (showCurrent && listAdapter != null) {
+                final java.util.regex.Matcher ssidMatcher = FilterMatcher.getSsidFilterMatcher(prefs, PreferenceKeys.FILTER_PREF_PREFIX);
+                final java.util.regex.Matcher bssidMatcher = mainActivity.getBssidFilterMatcher(PreferenceKeys.PREF_EXCLUDE_DISPLAY_ADDRS);
+                for (Network cellNetwork : cellNetworks.values()) {
+                    if (cellNetwork != null && FilterMatcher.isOk(ssidMatcher, bssidMatcher, prefs, PreferenceKeys.FILTER_PREF_PREFIX, cellNetwork)) {
+                        listAdapter.addCell(cellNetwork);
                     }
                 }
-                NetworkListUtil.sort(prefs, listAdapter);
-                mainActivity.setNetCountUI();
-            });
-        });
+            }
+            NetworkListUtil.sort(prefs, listAdapter);
+            mainActivity.setNetCountUI();
+        })));
+    }
+
+    private interface RawCellCallback {
+        void onRaw(RawCellData raw);
     }
 
     /**
-     * binder-call - do not perform on main thread
-     * @param context the context of the request
-     * @return a RawCellData object with the current scan's cell and operator information
+     * Binder-call — do not perform on the main thread. On Q+ this requests a modem
+     * refresh; older APIs (and request failures) read the cached {@code getAllCellInfo}.
      */
-    private static RawCellData getRawCellData(final Context context) {
+    @SuppressLint("MissingPermission")
+    private void collectRawCellData(final Context context, final RawCellCallback callback) {
         if (context == null) {
-            return new RawCellData(null, null, null, null, -1, null);
+            callback.onRaw(emptyRaw());
+            return;
         }
-        TelephonyManager tele = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
+        final TelephonyManager tele = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
         if (tele == null) {
-            return new RawCellData(null, null, null, null, -1, null);
+            callback.onRaw(emptyRaw());
+            return;
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            try {
+                tele.requestCellInfoUpdate(cellExecutor, new TelephonyManager.CellInfoCallback() {
+                    @Override
+                    public void onCellInfo(@NonNull final List<CellInfo> cellInfo) {
+                        callback.onRaw(snapshotRaw(tele, cellInfo, null));
+                    }
+
+                    @Override
+                    public void onError(final int errorCode, final Throwable detail) {
+                        Logging.warn("requestCellInfoUpdate error " + errorCode
+                                + (detail != null ? ": " + detail : ""));
+                        callback.onRaw(readCachedCellData(tele));
+                    }
+                });
+                return;
+            } catch (final SecurityException sex) {
+                Logging.warn("unable to scan cells due to permission issue: ", sex);
+                callback.onRaw(emptyRaw());
+                return;
+            } catch (final Exception ex) {
+                Logging.warn("requestCellInfoUpdate failed, using cache: ", ex);
+            }
+        }
+        callback.onRaw(readCachedCellData(tele));
+    }
+
+    private static RawCellData emptyRaw() {
+        return new RawCellData(null, null, null, null, -1, null);
+    }
+
+    @SuppressLint("MissingPermission")
+    private static RawCellData readCachedCellData(final TelephonyManager tele) {
         try {
-            List<CellInfo> infos = tele.getAllCellInfo();
+            final List<CellInfo> infos = tele.getAllCellInfo();
             CellLocation cellLocation = null;
             if (infos == null && Build.VERSION.SDK_INT < 26) {
                 cellLocation = tele.getCellLocation();
             }
+            return snapshotRaw(tele, infos, cellLocation);
+        } catch (final SecurityException sex) {
+            Logging.warn("unable to scan cells due to permission issue: ", sex);
+            return emptyRaw();
+        } catch (final NullPointerException ex) {
+            Logging.warn("NPE on cell scan: ", ex);
+            return emptyRaw();
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    private static RawCellData snapshotRaw(final TelephonyManager tele, final List<CellInfo> infos,
+            final CellLocation cellLocation) {
+        try {
             return new RawCellData(infos, cellLocation, tele.getNetworkOperator(), tele.getNetworkOperatorName(),
                     tele.getNetworkType(), tele.getNetworkCountryIso());
-        } catch (SecurityException sex) {
-            Logging.warn("unable to scan cells due to permission issue: ", sex);
-            return new RawCellData(null, null, null, null, -1, null);
-        } catch (NullPointerException ex) {
-            Logging.warn("NPE on cell scan: ", ex);
-            return new RawCellData(null, null, null, null, -1, null);
+        } catch (final SecurityException sex) {
+            Logging.warn("unable to read operator for cell scan: ", sex);
+            return new RawCellData(infos, cellLocation, null, null, -1, null);
         }
     }
 
@@ -241,25 +290,28 @@ public class CellReceiver {
         if (mainActivity == null || raw == null) {
             return networks;
         }
-        try {
-            List<CellInfo> infos = raw.cellInfo;
-            if (infos != null) {
-                for (final CellInfo cell : infos) {
-                    Network network = handleSingleCellInfo(cell, raw.networkOperator, location);
+        final List<CellInfo> infos = raw.cellInfo;
+        if (infos != null) {
+            for (final CellInfo cell : infos) {
+                try {
+                    final Network network = handleSingleCellInfo(cell, raw.networkOperator, location);
                     if (network != null) {
                         networks.put(network.getBssid(), network);
                     }
+                } catch (final Exception ex) {
+                    Logging.warn("skipping cell: " + ex, ex);
                 }
-            } else if (raw.cellLocation != null) {
-                Network currentNetwork = handleSingleCellLocation(raw.cellLocation, raw.networkOperator, raw.networkOperatorName, raw.networkTypeId, raw.networkCountryIso, location);
+            }
+        } else if (raw.cellLocation != null) {
+            try {
+                final Network currentNetwork = handleSingleCellLocation(raw.cellLocation, raw.networkOperator,
+                        raw.networkOperatorName, raw.networkTypeId, raw.networkCountryIso, location);
                 if (currentNetwork != null) {
                     networks.put(currentNetwork.getBssid(), currentNetwork);
                 }
+            } catch (final Exception ex) {
+                Logging.warn("skipping cell location: " + ex, ex);
             }
-        } catch (SecurityException sex) {
-            Logging.warn("unable to scan cells due to permission issue: ", sex);
-        } catch (NullPointerException ex) {
-            Logging.warn("NPE on cell scan: ", ex);
         }
         return networks;
     }

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/GsmOperator.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/model/GsmOperator.java
@@ -253,7 +253,11 @@ public class GsmOperator {
                 return operator;
             }
 
-            MainActivity.State s = MainActivity.getMainActivity().getState();
+            final MainActivity activity = MainActivity.getMainActivity();
+            if (activity == null) {
+                return null;
+            }
+            MainActivity.State s = activity.getState();
             if (null != s && null != s.mxcDbHelper) {
                 operator = s.mxcDbHelper.networkNameForMccMnc(mcc,mnc);
                 mccMap.put(mnc, operator);
@@ -276,7 +280,11 @@ public class GsmOperator {
                 //DEBUG: MainActivity.info("matched operator L1: "+operator+" ("+mcc+":"+mnc+")");
                 return true;
             }
-            MainActivity.State s = MainActivity.getMainActivity().getState();
+            final MainActivity activity = MainActivity.getMainActivity();
+            if (activity == null) {
+                return false;
+            }
+            MainActivity.State s = activity.getState();
             if ((null != s) && (null != s.mxcDbHelper)) {
                 try {
                     operator = s.mxcDbHelper.networkNameForMccMnc(mcc, mnc);

--- a/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/GpxRecyclerAdapter.java
+++ b/wiglewifiwardriving/src/main/java/net/wigle/wigleandroid/ui/GpxRecyclerAdapter.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.database.DataSetObserver;
+import android.os.Handler;
+import android.os.Looper;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -27,6 +29,9 @@ import net.wigle.wigleandroid.util.RouteExportSelector;
 import net.wigle.wigleandroid.util.RouteDeleteSelector;
 
 import java.text.DateFormat;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class GpxRecyclerAdapter extends RecyclerView.Adapter<GpxRecyclerAdapter.ViewHolder>  {
     public static final int EXPORT_GPX_DIALOG = 130;
@@ -45,6 +50,9 @@ public class GpxRecyclerAdapter extends RecyclerView.Adapter<GpxRecyclerAdapter.
     private final DateFormat dateFormat;
     private final DateFormat timeFormat;
     private int selectedPos = RecyclerView.NO_POSITION;
+    private final ExecutorService routeLoadExecutor = Executors.newSingleThreadExecutor();
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private final AtomicInteger routeLoadGeneration = new AtomicInteger();
 
     public GpxRecyclerAdapter(Context context, FragmentActivity fragmentActivity, Cursor cursor, RouteConfigurable configurable, RouteExportSelector routeSelector,
                               RouteDeleteSelector routeDeleteSelector, SharedPreferences prefs, DateFormat dateFormat, DateFormat timeFormat) {
@@ -154,27 +162,7 @@ public class GpxRecyclerAdapter extends RecyclerView.Adapter<GpxRecyclerAdapter.
             notifyItemChanged(selectedPos);
             selectedPos = position; //.getLayoutPosition();
             notifyItemChanged(selectedPos);
-            //DEBUG: MainActivity.info("get route "+clickedId);
-            try (Cursor routeCursor = ListFragment.lameStatic.dbHelper.routeIterator(clickedId)) {
-                final int mapMode = prefs.getInt(PreferenceKeys.PREF_MAP_TYPE, GoogleMap.MAP_TYPE_NORMAL);
-                final boolean nightMode = ThemeUtil.shouldUseMapNightMode(context, prefs);
-                if (null == routeCursor) {
-                    Logging.info("null route cursor; not mapping");
-                } else {
-                    RouteDescriptor newRoute = new RouteDescriptor();
-                    for (routeCursor.moveToFirst(); !routeCursor.isAfterLast(); routeCursor.moveToNext()) {
-                        final float lat = routeCursor.getFloat(0);
-                        final float lon = routeCursor.getFloat(1);
-                        //final float ele = routeCursor.getFloat(2);
-                        //final long time = routeCursor.getLong(3);
-                        newRoute.addLatLng(lat, lon, mapMode, nightMode);
-                    }
-                    Logging.info("Loaded route with " + newRoute.getSegments() + " segments");
-                    configurable.configureMapForRoute(newRoute);
-                }
-            } catch (Exception e) {
-                Logging.error("Unable to add route: ",e);
-            }
+            loadAndShowRoute(clickedId);
         });
         holder.shareButton.setOnClickListener(v -> {
             Logging.info("share route "+clickedId);
@@ -218,6 +206,50 @@ public class GpxRecyclerAdapter extends RecyclerView.Adapter<GpxRecyclerAdapter.
             return cursor.getCount();
         }
         return 0;
+    }
+
+    /**
+     * Load a route's points off the UI thread, then configure the map. A newer request
+     * cancels drawing an older one so rapid taps cannot apply a stale polyline.
+     */
+    public void loadAndShowRoute(final long runId) {
+        if (routeLoadExecutor.isShutdown()) {
+            return;
+        }
+        final int generation = routeLoadGeneration.incrementAndGet();
+        final int mapMode = prefs.getInt(PreferenceKeys.PREF_MAP_TYPE, GoogleMap.MAP_TYPE_NORMAL);
+        final boolean nightMode = ThemeUtil.shouldUseMapNightMode(context, prefs);
+        routeLoadExecutor.execute(() -> {
+            final RouteDescriptor newRoute = new RouteDescriptor();
+            try (Cursor routeCursor = ListFragment.lameStatic.dbHelper.routeIterator(runId)) {
+                if (routeCursor == null) {
+                    Logging.info("null route cursor; not mapping");
+                    return;
+                }
+                for (routeCursor.moveToFirst(); !routeCursor.isAfterLast(); routeCursor.moveToNext()) {
+                    newRoute.addLatLng(routeCursor.getFloat(0), routeCursor.getFloat(1),
+                            mapMode, nightMode);
+                }
+            } catch (Exception e) {
+                Logging.error("Unable to add route: ", e);
+                return;
+            }
+            Logging.info("Loaded route with " + newRoute.getSegments() + " segments");
+            mainHandler.post(() -> {
+                if (generation != routeLoadGeneration.get()) {
+                    return;
+                }
+                if (fragmentActivity.isFinishing()) {
+                    return;
+                }
+                configurable.configureMapForRoute(newRoute);
+            });
+        });
+    }
+
+    public void shutdown() {
+        routeLoadGeneration.incrementAndGet();
+        routeLoadExecutor.shutdownNow();
     }
 
     /**


### PR DESCRIPTION
Submitting as a **_draft_** for now - this is going to need a ton of testing.
Short version: database contention is a common cause of play console crashes - revisiting old mode and locking assumptions from the early days and trying to modernize them.
- switching to WAL mode to make logging more reliable/efficient
- handling a bunch of cases with timeouts and contention explicitly
- avoiding multiple helpers/queues that could result in deadlocks/contention